### PR TITLE
Fix a couple games in RSP interpreter:  CFC2 sign-extends $vcr.

### DIFF
--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -501,12 +501,14 @@ void RSP_Cop2_MF (void) {
 }
 
 void RSP_Cop2_CF (void) {
-	switch ((RSPOpC.rd & 0x03)) {
-	case 0: RSP_GPR[RSPOpC.rt].W = RSP_Flags[0].UHW[0]; break;
-	case 1: RSP_GPR[RSPOpC.rt].W = RSP_Flags[1].UHW[0]; break;
-	case 2: RSP_GPR[RSPOpC.rt].W = RSP_Flags[2].UHW[0]; break;
-	case 3: RSP_GPR[RSPOpC.rt].W = RSP_Flags[2].UHW[0]; break;
-	}
+	unsigned int rt, rd;
+
+	rt = RSPOpC.rt;
+	rd = RSPOpC.rd & 3;
+	if (rd > 2) /* There is no fourth flags register. */
+		rd = 2; /* illegal instruction bypass behavior */
+
+	RSP_GPR[rt].W = RSP_Flags[rd].HW[0]; /* sign-extended to match h/w (cxd4) */
 }
 
 void RSP_Cop2_MT (void) {


### PR DESCRIPTION
Actual hardware behavior on the RSP interprets the vector control register (specified by MIPS.R.rd in the instruction decode phase) such that it ends up treating the vector flags register RSP_Flags[0], RSP_Flags[1], or RSP_Flags[2] as a 16-bit input and *sign-extending* it, not *zero-extending* it the way that Project64 has been doing.  This little overlooked detail has been causing bugs in LLE gfx for at least _Quake 64_, if not also:  https://github.com/project64/project64/issues/2 .

Example:
```
ori     $at, $0, 0x8000
ctc2    $at, $vco # RSP_Flags[0] <-- 0x8000
cfc2    $at, $vco
```

In Project64, the final result of $at is 0x00008000.
On real h/w, the correct result is $at = (0x00008000 | ~0x0000FFFF), or 0xFFFF8000.