### PR TITLE
Logic and start emulation fix

### DIFF
--- a/Source/Project64/N64 System/Mips/Eeprom.cpp
+++ b/Source/Project64/N64 System/Mips/Eeprom.cpp
@@ -63,7 +63,7 @@ void CEeprom::EepromCommand ( BYTE * Command) {
 		if (Command[1] != 8 && bHaveDebugger()) { g_Notify->DisplayError("What am I meant to do with this Eeprom Command"); }
 		ReadFrom(&Command[4],Command[3]);
 		break;
-	case 5:
+	case 5: //Write from Eeprom
 		if (Command[0] != 10 && bHaveDebugger()) { g_Notify->DisplayError("What am I meant to do with this Eeprom Command"); }
 		if (Command[1] != 1 && bHaveDebugger()) { g_Notify->DisplayError("What am I meant to do with this Eeprom Command"); }
 		WriteTo(&Command[4],Command[3]);
@@ -71,12 +71,12 @@ void CEeprom::EepromCommand ( BYTE * Command) {
 	case 6: //RTC Status query
 		Command[3] = 0x00;
 		Command[4] = 0x10;
-		Command[12] = 0x00;
+		Command[5] = 0x00;
 		break;
-	case 7: //Read RTC
+	case 7: //Read RTC block
 		switch(Command[3])
 		{
-			case 0:
+			case 0: //Block number
 				Command[4] = 0x00;
 				Command[5] = 0x02;
 				Command[12] = 0x00;

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -59,8 +59,15 @@ CN64System::CN64System ( CPlugins * Plugins, bool SavesReadOnly ) :
 		break;
 	}
 
-	//Set the limitors hertz based on ROM system type
-	m_Limitor.SetHertz((m_SystemType == SYSTEM_PAL) ? 50 : 60);
+	//By default first grab hertz from settings
+	DWORD gameHertz = g_Settings->LoadDword(Game_ScreenHertz);
+
+	//If set hertz is default 0, then set based on system type
+	if (gameHertz == 0)
+		gameHertz = (m_SystemType == SYSTEM_PAL) ? 50 : 60;
+
+	//Set limitor to hertz
+	m_Limitor.SetHertz(gameHertz);
 }
 
 CN64System::~CN64System ( void ) 

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -45,7 +45,6 @@ CN64System::CN64System ( CPlugins * Plugins, bool SavesReadOnly ) :
 	m_SyncCount(0)
 {
 	m_hPauseEvent = CreateEvent(NULL,true,false,NULL);
-	m_Limitor.SetHertz(g_Settings->LoadDword(Game_ScreenHertz));
 	m_Cheats.LoadCheats(!g_Settings->LoadDword(Setting_RememberCheats));
 
 	switch (g_Rom->GetCountry())
@@ -59,6 +58,9 @@ CN64System::CN64System ( CPlugins * Plugins, bool SavesReadOnly ) :
 		m_SystemType = SYSTEM_NTSC;
 		break;
 	}
+
+	//Set the limitors hertz based on ROM system type
+	m_Limitor.SetHertz((m_SystemType == SYSTEM_PAL) ? 50 : 60);
 }
 
 CN64System::~CN64System ( void ) 

--- a/Source/Project64/Plugins/Audio Plugin.cpp
+++ b/Source/Project64/Plugins/Audio Plugin.cpp
@@ -226,7 +226,7 @@ bool CAudioPlugin::Initiate ( CN64System * System, CMainGui * RenderWindow ) {
 	}
 	
 	if (g_Reg->AI_DACRATE_REG != 0) {
-		DacrateChanged(SYSTEM_NTSC);
+		DacrateChanged(g_BaseSystem->m_SystemType);
 	}
 	return m_Initilized;
 }

--- a/Source/Project64/Settings/Settings Class.cpp
+++ b/Source/Project64/Settings/Settings Class.cpp
@@ -142,7 +142,7 @@ void CSettings::AddHowToHandleSetting ()
 	AddHandler(Rdb_UseHleGfx,           new CSettingTypeRomDatabase("HLE GFX",Plugin_UseHleGfx));
 	AddHandler(Rdb_UseHleAudio,         new CSettingTypeRomDatabase("HLE Audio",Plugin_UseHleAudio));
 	AddHandler(Rdb_LoadRomToMemory,     new CSettingTypeRomDatabase("Rom In Memory",false));	
-	AddHandler(Rdb_ScreenHertz,         new CSettingTypeRomDatabase("ScreenHertz",60));	
+	AddHandler(Rdb_ScreenHertz,         new CSettingTypeRomDatabase("ScreenHertz", 0));	
 	AddHandler(Rdb_FuncLookupMode,      new CSettingTypeRomDatabase("FuncFind",FuncFind_PhysicalLookup));	
 	AddHandler(Rdb_RegCache,            new CSettingTypeRDBYesNo("Reg Cache",true));	
 	AddHandler(Rdb_BlockLinking,        new CSettingTypeRDBOnOff("Linking",true));	

--- a/Source/Project64/User Interface/Frame Per Second Class.cpp
+++ b/Source/Project64/User Interface/Frame Per Second Class.cpp
@@ -20,7 +20,8 @@ CFramePerSecond::CFramePerSecond (CNotification * Notification):
 	
 	if (m_ScreenHertz == 0)
 	{
-		m_ScreenHertz = 60;
+		//Set screen hertz based on rom system type
+		m_ScreenHertz = m_ScreenHertz = (g_System->m_SystemType == SYSTEM_PAL) ? 50 : 60;;
 	}
 	
 	LARGE_INTEGER Freq;

--- a/Source/Project64/User Interface/Main Menu Class.cpp
+++ b/Source/Project64/User Interface/Main Menu Class.cpp
@@ -75,8 +75,13 @@ bool CMainMenu::ProcessMessage(WND_HANDLE hWnd, DWORD /*FromAccelerator*/, DWORD
 			g_BaseSystem->DisplayRomInfo(hWnd);
 		}
 		break;
-	case ID_FILE_STARTEMULATION:
+	case ID_FILE_STARTEMULATION:	
 		_Gui->SaveWindowLoc();
+		//Before we go and create the new system, ensure the previous one has been closed
+		CN64System::CloseSystem();
+		//Ok now g_BaseSystem should definitely be clean for initialization 
+		g_BaseSystem = new CN64System(g_Plugins, false);
+		//Now we have created again, we can start up emulation
 		g_BaseSystem->StartEmulation(true);
 		break;
 	case ID_FILE_ENDEMULATION: 


### PR DESCRIPTION
Fix some behaviour with Project 64, first one is the setting of NTSC rather than making use of the actual system type.

Second is fixing the crash caused with the "Start Emulation" option that was cause by g_BaseSystem not being initialized 