### PR TITLE
Deprecate `Indx` functional LUT on loop count in RSP interpreter.

### DIFF
--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -536,7 +536,7 @@ void RSP_Vector_VMULF (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		if (RSP_Vect[RSPOpC.rd].UHW[el] != 0x8000 || RSP_Vect[RSPOpC.rt].UHW[del] != 0x8000) {
@@ -566,7 +566,7 @@ void RSP_Vector_VMULU (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 		RSP_ACCUM[el].DW = (__int64)(RSP_Vect[RSPOpC.rd].HW[el] * RSP_Vect[RSPOpC.rt].HW[del]) << 17;
 		RSP_ACCUM[el].DW += 0x80000000;
@@ -587,7 +587,7 @@ void RSP_Vector_VMUDL (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		temp.UW = (DWORD)RSP_Vect[RSPOpC.rd].UHW[el] * (DWORD)RSP_Vect[RSPOpC.rt].UHW[del];
@@ -604,7 +604,7 @@ void RSP_Vector_VMUDM (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		temp.UW = (DWORD)((long)RSP_Vect[RSPOpC.rd].HW[el]) * (DWORD)RSP_Vect[RSPOpC.rt].UHW[del];
@@ -626,7 +626,7 @@ void RSP_Vector_VMUDN (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		temp.UW = (DWORD)RSP_Vect[RSPOpC.rd].UHW[el] * (DWORD)(long)(RSP_Vect[RSPOpC.rt].HW[del]);
@@ -647,7 +647,7 @@ void RSP_Vector_VMUDH (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 		
 		RSP_ACCUM[el].W[1] = (long)RSP_Vect[RSPOpC.rd].HW[el] * (long)RSP_Vect[RSPOpC.rt].HW[del]; 
@@ -684,7 +684,7 @@ void RSP_Vector_VMACF (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		/*temp.W = (long)RSP_Vect[RSPOpC.rd].HW[el] * (long)(DWORD)RSP_Vect[RSPOpC.rt].HW[del];
@@ -728,7 +728,7 @@ void RSP_Vector_VMACU (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		temp.W = (long)RSP_Vect[RSPOpC.rd].HW[el] * (long)(DWORD)RSP_Vect[RSPOpC.rt].HW[del];
@@ -762,7 +762,7 @@ void RSP_Vector_VMACQ (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		if (RSP_ACCUM[el].W[1] > 0x20) {
@@ -806,7 +806,7 @@ void RSP_Vector_VMADL (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		temp.UW = (DWORD)RSP_Vect[RSPOpC.rd].UHW[el] * (DWORD)RSP_Vect[RSPOpC.rt].UHW[del];
@@ -846,7 +846,7 @@ void RSP_Vector_VMADM (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		temp.UW = (DWORD)((long)RSP_Vect[RSPOpC.rd].HW[el]) * (DWORD)RSP_Vect[RSPOpC.rt].UHW[del];
@@ -890,7 +890,7 @@ void RSP_Vector_VMADN (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		temp.UW = (DWORD)RSP_Vect[RSPOpC.rd].UHW[el] * (DWORD)((long)RSP_Vect[RSPOpC.rt].HW[del]);
@@ -932,7 +932,7 @@ void RSP_Vector_VMADH (void) {
 	VECTOR result;
 
 	for (count = 0; count < 8; count ++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 		
 		RSP_ACCUM[el].W[1] += (long)RSP_Vect[RSPOpC.rd].HW[el] * (long)RSP_Vect[RSPOpC.rt].HW[del]; 
@@ -967,7 +967,7 @@ void RSP_Vector_VADD (void) {
 	VECTOR result;
 	
 	for ( count = 0; count < 8; count++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
         
 		temp.W = (int)RSP_Vect[RSPOpC.rd].HW[el] + (int)RSP_Vect[RSPOpC.rt].HW[del] +
@@ -997,7 +997,7 @@ void RSP_Vector_VSUB (void) {
 	VECTOR result;
 	
 	for ( count = 0; count < 8; count++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
         
 		temp.W = (int)RSP_Vect[RSPOpC.rd].HW[el] - (int)RSP_Vect[RSPOpC.rt].HW[del] -
@@ -1026,7 +1026,7 @@ void RSP_Vector_VABS (void) {
 	VECTOR result;
 
 	for ( count = 0; count < 8; count++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		if (RSP_Vect[RSPOpC.rd].HW[el] > 0) {
@@ -1052,7 +1052,7 @@ void RSP_Vector_VADDC (void) {
 	
 	RSP_Flags[0].UW = 0;
 	for ( count = 0; count < 8; count++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
         
 		temp.UW = (int)RSP_Vect[RSPOpC.rd].UHW[el] + (int)RSP_Vect[RSPOpC.rt].UHW[del];
@@ -1072,7 +1072,7 @@ void RSP_Vector_VSUBC (void) {
 	
 	RSP_Flags[0].UW = 0x0;
 	for ( count = 0; count < 8; count++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
         
 		temp.UW = (int)RSP_Vect[RSPOpC.rd].UHW[el] - (int)RSP_Vect[RSPOpC.rt].UHW[del];
@@ -1135,7 +1135,7 @@ void RSP_Vector_VLT (void) {
 	
 	RSP_Flags[1].UW = 0;
 	for ( count = 0; count < 8; count++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		if (RSP_Vect[RSPOpC.rd].HW[el] < RSP_Vect[RSPOpC.rt].HW[del]) {
@@ -1164,7 +1164,7 @@ void RSP_Vector_VEQ (void) {
 	
 	RSP_Flags[1].UW = 0;
 	for ( count = 0; count < 8; count++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		if (RSP_Vect[RSPOpC.rd].UHW[el] == RSP_Vect[RSPOpC.rt].UHW[del]) {
@@ -1185,7 +1185,7 @@ void RSP_Vector_VNE (void) {
 	
 	RSP_Flags[1].UW = 0;
 	for ( count = 0; count < 8; count++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		if (RSP_Vect[RSPOpC.rd].UHW[el] != RSP_Vect[RSPOpC.rt].UHW[del]) {
@@ -1208,7 +1208,7 @@ void RSP_Vector_VGE (void) {
 	
 	RSP_Flags[1].UW = 0;
 	for ( count = 0; count < 8; count++ ) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		if (RSP_Vect[RSPOpC.rd].HW[el] == RSP_Vect[RSPOpC.rt].HW[del]) {
@@ -1236,7 +1236,7 @@ void RSP_Vector_VCL (void) {
 	VECTOR result;
 
 	for (count = 0;count < 8; count++) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		if ((RSP_Flags[0].UW & ( 1 << (7 - el))) != 0 ) {
@@ -1298,7 +1298,7 @@ void RSP_Vector_VCH (void) {
 	RSP_Flags[2].UW = 0;
 
 	for (count = 0;count < 8; count++) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 						
 		if ((RSP_Vect[RSPOpC.rd].HW[el] ^ RSP_Vect[RSPOpC.rt].HW[del]) < 0) {
@@ -1350,7 +1350,7 @@ void RSP_Vector_VCR (void) {
 	RSP_Flags[1].UW = 0;
 	RSP_Flags[2].UW = 0;
 	for (count = 0;count < 8; count++) {
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 		
 		if ((RSP_Vect[RSPOpC.rd].HW[el] ^ RSP_Vect[RSPOpC.rt].HW[del]) < 0) {
@@ -1384,7 +1384,7 @@ void RSP_Vector_VMRG (void) {
 	VECTOR result;
 
 	for ( count = 0; count < 8; count ++ ){
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 
 		if ((RSP_Flags[1].UW & ( 1 << (7 - el))) != 0) {
@@ -1402,7 +1402,7 @@ void RSP_Vector_VAND (void) {
 	VECTOR result;
 
 	for ( count = 0; count < 8; count ++ ){
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 		result.HW[el] = RSP_Vect[RSPOpC.rd].HW[el] & RSP_Vect[RSPOpC.rt].HW[del];
 		RSP_ACCUM[el].HW[1] = result.HW[el];
@@ -1415,7 +1415,7 @@ void RSP_Vector_VNAND (void) {
 	VECTOR result;
 
 	for ( count = 0; count < 8; count ++ ){
-		el = 7 - count;
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 		result.HW[el] = ~(RSP_Vect[RSPOpC.rd].HW[el] & RSP_Vect[RSPOpC.rt].HW[del]);
 		RSP_ACCUM[el].HW[1] = result.HW[el];
@@ -1428,7 +1428,7 @@ void RSP_Vector_VOR (void) {
 	VECTOR result;
 
 	for ( count = 0; count < 8; count ++ ){
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 		result.HW[el] = RSP_Vect[RSPOpC.rd].HW[el] | RSP_Vect[RSPOpC.rt].HW[del];
 		RSP_ACCUM[el].HW[1] = result.HW[el];
@@ -1441,7 +1441,7 @@ void RSP_Vector_VNOR (void) {
 	VECTOR result;
 
 	for ( count = 0; count < 8; count ++ ){
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 		result.HW[el] = ~(RSP_Vect[RSPOpC.rd].HW[el] | RSP_Vect[RSPOpC.rt].HW[del]);
 		RSP_ACCUM[el].HW[1] = result.HW[el];
@@ -1454,7 +1454,7 @@ void RSP_Vector_VXOR (void) {
 	VECTOR result;
 
 	for ( count = 0; count < 8; count ++ ){
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 		result.HW[el] = RSP_Vect[RSPOpC.rd].HW[el] ^ RSP_Vect[RSPOpC.rt].HW[del];
 		RSP_ACCUM[el].HW[1] = result.HW[el];
@@ -1467,7 +1467,7 @@ void RSP_Vector_VNXOR (void) {
 	VECTOR result;
 
 	for ( count = 0; count < 8; count ++ ){
-		el = Indx[RSPOpC.rs].B[count];
+		el = count;
 		del = EleSpec[RSPOpC.rs].B[el];
 		result.HW[el] = ~(RSP_Vect[RSPOpC.rd].HW[el] ^ RSP_Vect[RSPOpC.rt].HW[del]);
 		RSP_ACCUM[el].HW[1] = result.HW[el];


### PR DESCRIPTION
This old `Indx` array is no longer of any use whatsoever.
It is an impediment to accuracy, readability, and speed.

It was created when the RSP plugin was first being made in the late 90s.  Back then, there was a risk of prematurely overwriting the elements.  Take for example:
```asm
vand    $v0, $v1, $v0[3]
```
This would effectively do:
```c
for (i = 0; i < 8; i++)
    VR[0][i] = VR[1][i] & VR[0][3];
```
This loop had a fundamental problem:  On iteration i = 3, `VR[0][3] = VR[1][3] & VR[0][3];` prematurely updated what would be the source element for all future iterations.

To solve this problem, zilmar created the `Indx` array sometime before 2000.
He had since forgotten this was an element of preventing RSP bugs and not a piece of the algorithm of the RSP interpreter's opcodes.  (This extra array really has nothing to do with the hardware or any algorithms of any opcodes.)  It is a hack, and it has since already been superseded by zilmar's superior method of creating a new temporary vector:  `VECTOR result`, and then just before returning from each function, `RSP_Vect[sa] = result;`.

I have not yet done these readability/optimization changes to RSP recompiler.
If it is decided that this PR should be accepted, then I can work on analogizing these changes to the RSP recompiler as well.  It's trickier to do with the recompiler since it doesn't use the `VECTOR result` method yet, though for accuracy (and speed) I think it should in a future PR, with the eventual removal of the entire `Indx` array altogether from the DLL, unless it is decided to decline this PR.

Overall, the problem with the `Indx` array is that nobody can figure out the simplicity of the interpreter opcodes by looking at a function of a function, when it should really just be a function.  The loop to update the entire vector register should have one dimension of LUT, rather than a LUT going off of another LUT and scrambling the element definitions in pseudo-random order, just enough to evade the overwrite bug.  (It wasn't even readable enough for developer to remember what the Indx array was even existing for, causing him to think there was a bug with overwriting elements.)