### PR TITLE
Fix more warnings about function pointer implicit type casts.

### DIFF
--- a/Source/RSP/Cpu.c
+++ b/Source/RSP/Cpu.c
@@ -43,14 +43,14 @@ UDWORD EleSpec[32], Indx[32];
 OPCODE RSPOpC;
 DWORD *PrgCount, NextInstruction, RSP_Running, RSP_MfStatusCount;
 
-void * RSP_Opcode[64];
-void * RSP_RegImm[32];
-void * RSP_Special[64];
-void * RSP_Cop0[32];
-void * RSP_Cop2[32];
-void * RSP_Vector[64];
-void * RSP_Lc2[32];
-void * RSP_Sc2[32];
+p_func RSP_Opcode[64];
+p_func RSP_RegImm[32];
+p_func RSP_Special[64];
+p_func RSP_Cop0[32];
+p_func RSP_Cop2[32];
+p_func RSP_Vector[64];
+p_func RSP_Lc2[32];
+p_func RSP_Sc2[32];
 
 void BuildInterpreterCPU(void);
 void BuildRecompilerCPU(void);

--- a/Source/RSP/Cpu.h
+++ b/Source/RSP/Cpu.h
@@ -28,14 +28,14 @@
 
 extern UDWORD EleSpec[32], Indx[32];
 
-extern void * RSP_Opcode[64];
-extern void * RSP_RegImm[32];
-extern void * RSP_Special[64];
-extern void * RSP_Cop0[32];
-extern void * RSP_Cop2[32];
-extern void * RSP_Vector[64];
-extern void * RSP_Lc2[32];
-extern void * RSP_Sc2[32];
+extern p_func RSP_Opcode[64];
+extern p_func RSP_RegImm[32];
+extern p_func RSP_Special[64];
+extern p_func RSP_Cop0[32];
+extern p_func RSP_Cop2[32];
+extern p_func RSP_Vector[64];
+extern p_func RSP_Lc2[32];
+extern p_func RSP_Sc2[32];
 extern DWORD * PrgCount, RSP_Running;
 extern OPCODE RSPOpC;
 

--- a/Source/RSP/Interpreter CPU.c
+++ b/Source/RSP/Interpreter CPU.c
@@ -443,7 +443,7 @@ DWORD RunInterpreterCPU(DWORD Cycles) {
 		RDP_LogLoc(*PrgCount);
 
 		RSP_LW_IMEM(*PrgCount, &RSPOpC.Hex);
-		((void (*)()) RSP_Opcode[ RSPOpC.op ])();
+		RSP_Opcode[ RSPOpC.op ]();
 
 		switch (RSP_NextInstruction) {
 		case NORMAL: 

--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -43,11 +43,11 @@ extern BOOL AudioHle, GraphicsHle;
 
 /************************* OpCode functions *************************/
 void RSP_Opcode_SPECIAL ( void ) {
-	((void (*)()) RSP_Special[ RSPOpC.funct ])();
+	RSP_Special[ RSPOpC.funct ]();
 }
 
 void RSP_Opcode_REGIMM ( void ) {
-	((void (*)()) RSP_RegImm[ RSPOpC.rt ])();
+	RSP_RegImm[ RSPOpC.rt ]();
 }
 
 void RSP_Opcode_J ( void ) {
@@ -152,11 +152,11 @@ void RSP_Opcode_LUI (void) {
 }
 
 void RSP_Opcode_COP0 (void) {
-	((void (*)()) RSP_Cop0[ RSPOpC.rs ])();
+	RSP_Cop0[ RSPOpC.rs ]();
 }
 
 void RSP_Opcode_COP2 (void) {
-	((void (*)()) RSP_Cop2[ RSPOpC.rs ])();
+	RSP_Cop2[ RSPOpC.rs ]();
 }
 
 void RSP_Opcode_LB ( void ) {
@@ -204,11 +204,11 @@ void RSP_Opcode_SW ( void ) {
 }
 
 void RSP_Opcode_LC2 (void) {
-	((void (*)()) RSP_Lc2 [ RSPOpC.rd ])();
+	RSP_Lc2 [ RSPOpC.rd ]();
 }
 
 void RSP_Opcode_SC2 (void) {
-	((void (*)()) RSP_Sc2 [ RSPOpC.rd ])();
+	RSP_Sc2 [ RSPOpC.rd ]();
 }
 /********************** R4300i OpCodes: Special **********************/
 void RSP_Special_SLL ( void ) {
@@ -527,7 +527,7 @@ void RSP_Cop2_CT (void) {
 }
 
 void RSP_COP2_VECTOR (void) {
-	((void (*)()) RSP_Vector[ RSPOpC.funct ])();
+	RSP_Vector[ RSPOpC.funct ]();
 }
 /************************** Vect functions **************************/
 void RSP_Vector_VMULF (void) {

--- a/Source/RSP/Recompiler CPU.c
+++ b/Source/RSP/Recompiler CPU.c
@@ -835,7 +835,7 @@ void CompilerRSPBlock ( void ) {
 			/* i think this pops up an unknown op dialog */
 			/* NextInstruction = FINISH_BLOCK; */
 		} else {
-			((void (*)()) RSP_Opcode[ RSPOpC.op ])();
+			RSP_Opcode[ RSPOpC.op ]();
 		}
 
 		switch (NextInstruction) {

--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -168,11 +168,11 @@ void CompileBranchExit(DWORD TargetPC, DWORD ContinuePC)
 
 /************************* OpCode functions *************************/
 void Compile_SPECIAL ( void ) {
-	((void (*)()) RSP_Special[ RSPOpC.funct ])();
+	RSP_Special[ RSPOpC.funct ]();
 }
 
 void Compile_REGIMM ( void ) {
-	((void (*)()) RSP_RegImm[ RSPOpC.rt ])();
+	RSP_RegImm[ RSPOpC.rt ]();
 }
 
 void Compile_J ( void ) {
@@ -572,11 +572,11 @@ void Compile_LUI ( void ) {
 }
 
 void Compile_COP0 (void) {
-	((void (*)()) RSP_Cop0[ RSPOpC.rs ])();
+	RSP_Cop0[ RSPOpC.rs ]();
 }
 
 void Compile_COP2 (void) {
-	((void (*)()) RSP_Cop2[ RSPOpC.rs ])();
+	RSP_Cop2[ RSPOpC.rs ]();
 }
 
 void Compile_LB ( void ) {
@@ -948,11 +948,11 @@ void Compile_SW ( void ) {
 }
 
 void Compile_LC2 (void) {
-	((void (*)()) RSP_Lc2 [ RSPOpC.rd ])();
+	RSP_Lc2 [ RSPOpC.rd ]();
 }
 
 void Compile_SC2 (void) {
-	((void (*)()) RSP_Sc2 [ RSPOpC.rd ])();
+	RSP_Sc2 [ RSPOpC.rd ]();
 }
 /********************** R4300i OpCodes: Special **********************/
 
@@ -1789,7 +1789,7 @@ void Compile_Cop2_CT ( void ) {
 }
 
 void Compile_COP2_VECTOR (void) {
-	((void (*)()) RSP_Vector[ RSPOpC.funct ])();
+	RSP_Vector[ RSPOpC.funct ]();
 }
 
 /************************** Vect functions **************************/

--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -118,13 +118,13 @@ void Branch_AddRef(DWORD Target, DWORD * X86Loc) {
 	}
 }
 
-void Cheat_r4300iOpcode ( void * FunctAddress, char * FunctName) {
+void Cheat_r4300iOpcode(p_func FunctAddress, char * FunctName) {
 	CPU_Message("  %X %s",CompilePC,RSPOpcodeName(RSPOpC.Hex,CompilePC));
 	MoveConstToVariable(RSPOpC.Hex, &RSPOpC.Hex, "RSPOpC.Hex" );
 	Call_Direct(FunctAddress, FunctName);
 }
 
-void Cheat_r4300iOpcodeNoMessage( void * FunctAddress, char * FunctName) {
+void Cheat_r4300iOpcodeNoMessage(p_func FunctAddress, char * FunctName) {
 	MoveConstToVariable(RSPOpC.Hex, &RSPOpC.Hex, "RSPOpC.Hex" );
 	Call_Direct(FunctAddress, FunctName);
 }

--- a/Source/RSP/Types.h
+++ b/Source/RSP/Types.h
@@ -27,6 +27,12 @@
 #ifndef __Types_h 
 #define __Types_h 
 
+/*
+ * pointer to RSP operation code functions or "func"
+ * This is the type of all RSP interpreter and recompiler functions.
+ */
+typedef void(*p_func)(void);
+
 typedef union tagUWORD {
 	long				W;
 	float				F;


### PR DESCRIPTION
The last time I fixed warnings just by changing GlideHQ/NRage warning levels from 4 to 3.

After that change, most of the remaining warnings when building Project64 are almost all coming from the RSP it seems, so I decided to do warning fixes in the RSP.

The only basic type of warning fixed was implicit type conversion of function pointers.

Many C compilers complain about storing all those RSP interpreter and RSP recompiler functions in arrays of type `void *`, complaining that this wasn't strict enough.  Well I personally think it was strict and readable enough, but maybe it couldn't have hurt to invent a more direct, exact type of pointer to prove to the compiler it must lead to a function:  `p_func`.  This type I have added a definition for in `Types.h` to note that all RSP recompiler and RSP interpreter functions are of the basic form `void RSP_function(void);`.

About 800 warnings total are fixed, but I didn't touch the `Call_Direct` recompiler warnings yet since those do not necessarily call RSP opcode functions (maybe functions with arguments or returning non-void) and should probably be handled differently in a separate investigation.

In the recompiler however, functions `Cheat_r4300iOpcode` and `Cheat_r4300iOpcodeNoMessage` do expect a RSP interpreter function to cheat to, so I was able to 100% safely able to change those to the new `p_func` type to fix a couple more warnings.