### PR TITLE
fixed 17 compiler warnings about RSP "nameless struct/union" cases

### DIFF
--- a/Source/RSP/OpCode.h
+++ b/Source/RSP/OpCode.h
@@ -29,49 +29,45 @@
 
 #include "Types.h"
 
-typedef struct tagOPCODE {
-	union {
+typedef union tagOPCODE {
+	unsigned long Hex;
+	unsigned char Ascii[4];
 
-		unsigned long Hex;
-		unsigned char Ascii[4];
-		
-		struct {
-			unsigned offset : 16;
-			unsigned rt : 5;
-			unsigned rs : 5;
-			unsigned op : 6;
-		};
+	struct {
+		unsigned offset : 16;
+		unsigned rt : 5;
+		unsigned rs : 5;
+		unsigned op : 6;
+	};
 
-		struct {
-			unsigned immediate : 16;
-			unsigned : 5;
-			unsigned base : 5;
-			unsigned : 6;
-		};
-		
-		struct {
-			unsigned target : 26;
-			unsigned : 6;
-		};
-		
-		struct {
-			unsigned funct : 6;
-			unsigned sa : 5;
-			unsigned rd : 5;
-			unsigned : 5;
-			unsigned : 5;
-			unsigned : 6;
-		};
+	struct {
+		unsigned immediate : 16;
+		unsigned : 5;
+		unsigned base : 5;
+		unsigned : 6;
+	};
 
-		struct {
-			signed   voffset : 7;
-			unsigned del    : 4;
-			unsigned : 5;
-			unsigned dest   : 5;
-			unsigned : 5;
-			unsigned : 6;
-		};
+	struct {
+		unsigned target : 26;
+		unsigned : 6;
+	};
 
+	struct {
+		unsigned funct : 6;
+		unsigned sa : 5;
+		unsigned rd : 5;
+		unsigned : 5;
+		unsigned : 5;
+		unsigned : 6;
+	};
+
+	struct {
+		signed   voffset : 7;
+		unsigned del    : 4;
+		unsigned : 5;
+		unsigned dest   : 5;
+		unsigned : 5;
+		unsigned : 6;
 	};
 } OPCODE;
 

--- a/Source/RSP/OpCode.h
+++ b/Source/RSP/OpCode.h
@@ -34,14 +34,14 @@ typedef union tagOPCODE {
 	unsigned char Ascii[4];
 
 	struct {
-		unsigned offset : 16;
+		unsigned immediate : 16;
 		unsigned rt : 5;
 		unsigned rs : 5;
 		unsigned op : 6;
 	};
 
 	struct {
-		unsigned immediate : 16;
+		unsigned offset : 16;
 		unsigned : 5;
 		unsigned base : 5;
 		unsigned : 6;

--- a/Source/RSP/X86.h
+++ b/Source/RSP/X86.h
@@ -246,16 +246,14 @@ void SseMoveUnalignedRegToN64Mem	( int sseReg, int AddrReg );
 void SseMoveRegToReg				( int Dest, int Source );
 void SseXorRegToReg					( int Dest, int Source );
 
-typedef struct {
-	union {
-		struct {
-			unsigned Reg0 : 2;
-			unsigned Reg1 : 2;
-			unsigned Reg2 : 2;
-			unsigned Reg3 : 2;
-		};
-		unsigned UB:8;
+typedef union {
+	struct {
+		unsigned Reg0 : 2;
+		unsigned Reg1 : 2;
+		unsigned Reg2 : 2;
+		unsigned Reg3 : 2;
 	};
+	unsigned UB:8;
 } SHUFFLE;
 
 void SseShuffleReg					( int Dest, int Source, BYTE Immed );


### PR DESCRIPTION
Most of the remaining build warnings are coming from the RSP module still...most of the remaining RSP compiler warnings are not easy to fix (without compromising something like conciseness, or sometimes register access for uninitialized variable warnings).

The warnings I fixed this time were, as MSVC calls it:
`warning C4201: nonstandard extension used : nameless struct/union`

It was caused typically by doing something like this in the source:
```c
typedef struct {
    union {
        struct {
            unsigned a : 4;
            unsigned b : 4;
        };
        unsigned char byte;
    }
} a_struct;
```
(That is just a made-up example really, not part of the source.)

Compilers complain about this since `a_struct.b` is not legally obligated by C standards to refer to the member access within a nameless struct within a nameless union.

One solution is to simply give the union within `a_struct`, a name.  Since this requires changing hundreds of lines of code (and probably thousands of times) across the RSP source, I couldn't approach that.  (And for that reason most of the nameless struct/union warnings still remain...I suppose in the future somebody could change things like RSPOpC.target, to RSPOpC.J.target, or RSPOpC.rd to RSPOpC.R.rd, to document R-type or J-type MIPS encoding while fixing the nameless struct warnings...but this still is a pretty big fundamental change to the naming across both the recompiler and interpreter sources, and I don't think it's a good time to tackle that.)

So the other solution, which I did do in this pull request, is to move the isolated union member of this nameless structure, outside of the nameless structure (thus deleting said nameless structure, as there were no other members besides the union itself):
```c
typedef union {
    struct {
        unsigned a : 4;
        unsigned b : 4;
    };
    unsigned char byte;
} a_struct;
```
Here, there is only one nameless struct/union remaining, and that's the innermost struct.
It did not fix all nameless struct/union warnings, but it cuts them in half, if we imagine the above block of code inside a header file named something like "OpCode.h", and "OpCode.h" is included 9 times...then 1 warning not fixed became 9 warnings not fixed, which is just more redundant output less worth caring about.