### PR TITLE
Plugin code cleanup

### DIFF
--- a/Source/Project64/N64 System/Mips/Audio.cpp
+++ b/Source/Project64/N64 System/Mips/Audio.cpp
@@ -78,9 +78,9 @@ void CAudio::LenChanged ( void )
 		m_Status = 0;
 	}
 
-	if (g_Plugins->Audio()->LenChanged != NULL) 
+	if (g_Plugins->Audio()->AiLenChanged != NULL)
 	{
-		g_Plugins->Audio()->LenChanged(); 
+		g_Plugins->Audio()->AiLenChanged();
 	}
 	WriteTraceF(TraceAudio,__FUNCTION__ ": Done");
 }

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -677,9 +677,9 @@ void  CMipsMemoryVM::Compile_LW (x86Reg Reg, DWORD VAddr ) {
 					AfterCallDirect(m_RegWorkingSet);
 					MoveVariableToX86reg(&m_TempValue,"m_TempValue",Reg);
 				} else {
-					if (g_Plugins->Audio()->ReadLength != NULL) {
+					if (g_Plugins->Audio()->AiReadLength != NULL) {
 						BeforeCallDirect(m_RegWorkingSet);
-						Call_Direct(g_Plugins->Audio()->ReadLength,"AiReadLength");
+						Call_Direct(g_Plugins->Audio()->AiReadLength, "AiReadLength");
 						MoveX86regToVariable(x86_EAX,&m_TempValue,"m_TempValue"); 
 						AfterCallDirect(m_RegWorkingSet);
 						MoveVariableToX86reg(&m_TempValue,"m_TempValue",Reg);
@@ -1138,7 +1138,7 @@ void CMipsMemoryVM::Compile_SW_Const ( DWORD Value, DWORD VAddr ) {
 				MoveConstToX86reg((DWORD)g_Audio,x86_ECX);				
 				Call_Direct(AddressOf(&CAudio::LenChanged),"LenChanged");
 			} else {
-				Call_Direct(g_Plugins->Audio()->LenChanged,"AiLenChanged");
+				Call_Direct(g_Plugins->Audio()->AiLenChanged,"AiLenChanged");
 			}
 			AfterCallDirect(m_RegWorkingSet);
 			break;
@@ -1432,7 +1432,7 @@ void CMipsMemoryVM::Compile_SW_Register (x86Reg Reg, DWORD VAddr )
 				MoveConstToX86reg((DWORD)g_Audio,x86_ECX);				
 				Call_Direct(AddressOf(&CAudio::LenChanged),"LenChanged");
 			} else {
-				Call_Direct(g_Plugins->Audio()->LenChanged,"g_Plugins->Audio()->LenChanged");
+				Call_Direct(g_Plugins->Audio()->AiLenChanged, "g_Plugins->Audio()->LenChanged");
 			}
 			AfterCallDirect(m_RegWorkingSet);
 			break;
@@ -2055,8 +2055,8 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value ) {
 			{
 				*Value = g_Audio->GetLength();
 			} else {
-				if (g_Plugins->Audio()->ReadLength != NULL) {
-					*Value = g_Plugins->Audio()->ReadLength(); 
+				if (g_Plugins->Audio()->AiReadLength != NULL) {
+					*Value = g_Plugins->Audio()->AiReadLength();
 				} else {
 					*Value = 0;
 				}
@@ -2505,7 +2505,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value ) {
 			{
 				g_Audio->LenChanged();
 			} else {
-				if (g_Plugins->Audio()->LenChanged != NULL) { g_Plugins->Audio()->LenChanged(); }				
+				if (g_Plugins->Audio()->AiLenChanged != NULL) { g_Plugins->Audio()->AiLenChanged(); }
 			}
 			break;
 		case 0x04500008: g_Reg->AI_CONTROL_REG = (Value & 1); break;

--- a/Source/Project64/Plugin.h
+++ b/Source/Project64/Plugin.h
@@ -12,12 +12,15 @@
 
 #include "Support.h"
 
-#include ".\\Plugins\\Plugin Class.h"
-#include ".\\Plugins\\GFX Plugin.h"
-#include ".\\Plugins\\Audio Plugin.h"
-#include ".\\Plugins\\Controller Plugin.h"
-#include ".\\Plugins\\RSP Plugin.h"
-#include ".\\Plugins\\Plugin List.h"
+//Plugin controller
+#include "Plugins\Plugin Class.h"
 
+//Base Plugin class, all plugin derive from this, handles core  functions
+#include "Plugins\Plugin Base.h"
 
+#include "Plugins\GFX Plugin.h"
+#include "Plugins\Audio Plugin.h"
+#include "Plugins\Controller Plugin.h"
+#include "Plugins\RSP Plugin.h"
 
+#include "Plugins\Plugin List.h"

--- a/Source/Project64/Plugins/Audio Plugin.cpp
+++ b/Source/Project64/Plugins/Audio Plugin.cpp
@@ -10,305 +10,158 @@
 ****************************************************************************/
 #include "stdafx.h"
 
-void FixUPXIssue ( BYTE * ProgramLocation );
-
-CAudioPlugin::CAudioPlugin ( const char * FileName) :
-	m_hDll(NULL),
-	m_Initilized(false),
-	m_RomOpen(false),
+CAudioPlugin::CAudioPlugin(const char * FileName) : CPlugin(),
 	m_hAudioThread(NULL),
-	m_DacrateChanged(NULL),
-	LenChanged(NULL),
-	Config(NULL),
-	ReadLength(NULL),
-	RomOpen(NULL),
-	RomClosed(NULL),
-	CloseDLL(NULL),
-	ProcessAList(NULL),	
-	Update(NULL),
-	PluginOpened(NULL),
-	SetSettingInfo(NULL),
-	SetSettingInfo2(NULL)
+	InitiateAudio(NULL),
+	AiDacrateChanged(NULL),
+	AiLenChanged(NULL),
+	AiReadLength(NULL),
+	ProcessAList(NULL),
+	AiUpdate(NULL)
 {
-	memset(&m_PluginInfo,0,sizeof(m_PluginInfo));
 	Init(FileName);
 }
 
-void CAudioPlugin::Init ( const char * FileName )
+bool CAudioPlugin::Init(const char * FileName)
 {
-	//Make sure all parts of the class are initialized
-	UnloadPlugin();
-
-	//Try to load the DLL library
-	UINT LastErrorMode = SetErrorMode( SEM_FAILCRITICALERRORS );
-	m_hDll = LoadLibrary(FileName);
-	SetErrorMode(LastErrorMode);
-	
-	if (m_hDll == NULL) { 
+	if (!CPlugin::Init(FileName))
+	{
 		UnloadPlugin();
-		return;
+		return false;
 	}
-	FixUPXIssue((BYTE *)m_hDll);
 
-	//Get DLL information
-	void (__cdecl *GetDllInfo) ( PLUGIN_INFO * PluginInfo );
-	GetDllInfo = (void (__cdecl *)(PLUGIN_INFO *))GetProcAddress( (HMODULE)m_hDll, "GetDllInfo" );
-	if (GetDllInfo == NULL) { UnloadPlugin(); return; }
+	// Find entries for functions in DLL
+	LoadFunction(InitiateAudio);
+	LoadFunction(AiDacrateChanged);
+	LoadFunction(AiLenChanged);
+	LoadFunction(AiReadLength);
+	LoadFunction(AiUpdate);
+	LoadFunction(ProcessAList);
 
-	GetDllInfo(&m_PluginInfo);
-	if (!CPluginList::ValidPluginVersion(m_PluginInfo)) { UnloadPlugin(); return; }
-
-	//Find entries for functions in DLL
-	void  (__cdecl *InitFunc)     ( void );
-	m_DacrateChanged = (void (__cdecl *)(SYSTEM_TYPE))  GetProcAddress( (HMODULE)m_hDll, "AiDacrateChanged" );
-	LenChanged     = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "AiLenChanged" );
-	Config         = (void (__cdecl *)(DWORD))GetProcAddress( (HMODULE)m_hDll, "DllConfig" );
-	ReadLength     = (DWORD (__cdecl *)(void))GetProcAddress( (HMODULE)m_hDll, "AiReadLength" );
-	InitFunc       = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "InitiateAudio" );
-	RomOpen        = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "RomOpen" );
-	RomClosed      = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "RomClosed" );
-	CloseDLL       = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "CloseDLL" );
-	ProcessAList   = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "ProcessAList" );	
-
-	Update = (void (__cdecl *)(BOOL))GetProcAddress( (HMODULE)m_hDll, "AiUpdate" );
-
-	//version 102 functions
-	PluginOpened     = (void (__cdecl *)(void))GetProcAddress( (HMODULE)m_hDll, "PluginLoaded" );
-
-	//Make sure dll had all needed functions
-	if (m_DacrateChanged == NULL) { UnloadPlugin(); return;  }
-	if (LenChanged     == NULL) { UnloadPlugin(); return;  }
-	if (ReadLength     == NULL) { UnloadPlugin(); return;  }
-	if (InitFunc       == NULL) { UnloadPlugin(); return;  }
-	if (RomClosed      == NULL) { UnloadPlugin(); return;  }
-	if (ProcessAList   == NULL) { UnloadPlugin(); return;  }
-
-	SetSettingInfo3 = (void (__cdecl *)(PLUGIN_SETTINGS3 *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo3" );
-	if (SetSettingInfo3)
+	// Make sure dll has all needed functions
+	if (InitiateAudio == NULL
+		|| AiDacrateChanged == NULL
+		|| AiLenChanged == NULL
+		|| AiReadLength == NULL
+		|| ProcessAList == NULL
+		|| (m_PluginInfo.Version >= 0x0102
+		&& PluginLoaded == NULL))
 	{
-		PLUGIN_SETTINGS3 info;
-		info.FlushSettings = (void (*)( void * handle))CSettings::FlushSettings;
-		SetSettingInfo3(&info);
+		UnloadPlugin();
+		return false;
 	}
 
-	SetSettingInfo2 = (void (__cdecl *)(PLUGIN_SETTINGS2 *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo2" );
-	if (SetSettingInfo2)
-	{
-		PLUGIN_SETTINGS2 info;
-		info.FindSystemSettingId = (unsigned int (*)( void * handle, const char * ))CSettings::FindSetting;
-		SetSettingInfo2(&info);
-	}
+	if (PluginLoaded != NULL)
+		PluginLoaded();
 
-	SetSettingInfo   = (void (__cdecl *)(PLUGIN_SETTINGS *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo" );
-	if (SetSettingInfo)
-	{
-		PLUGIN_SETTINGS info;
-		info.dwSize = sizeof(PLUGIN_SETTINGS);
-		info.DefaultStartRange = FirstAudioDefaultSet;
-		info.SettingStartRange = FirstAudioSettings;
-		info.MaximumSettings   = MaxPluginSetting;
-		info.NoDefault         = Default_None;
-		info.DefaultLocation   = g_Settings->LoadDword(Setting_UseFromRegistry) ? SettingType_Registry : SettingType_CfgFile;
-		info.handle            = g_Settings;
-		info.RegisterSetting   = (void (*)(void *,int,int,SettingDataType,SettingType,const char *,const char *, DWORD))CSettings::RegisterSetting;
-		info.GetSetting        = (unsigned int (*)( void * handle, int ID ))CSettings::GetSetting;
-		info.GetSettingSz      = (const char * (*)( void *, int, char *, int ))CSettings::GetSettingSz;
-		info.SetSetting        = (void (*)(void *,int,unsigned int))CSettings::SetSetting;
-		info.SetSettingSz      = (void (*)(void *,int,const char *))CSettings::SetSettingSz;
-		info.UseUnregisteredSetting = NULL;
-
-		SetSettingInfo(&info);
-		//g_Settings->UnknownSetting_AUDIO = info.UseUnregisteredSetting;
-	}
-	
-	if (m_PluginInfo.Version >= 0x0102)
-	{
-		if (PluginOpened    == NULL) { UnloadPlugin(); return; }
-		PluginOpened();
-	}
+	return true;
 }
 
-CAudioPlugin::~CAudioPlugin (void) {
-	Close();
-	UnloadPlugin();
-}
+bool CAudioPlugin::Initiate(CN64System * System, CMainGui * RenderWindow)
+{
+	if (InitiateAudio == NULL)
+		return false;
 
-bool CAudioPlugin::Initiate ( CN64System * System, CMainGui * RenderWindow ) {
-	struct AUDIO_INFO {
-		HWND hwnd;
-		HINSTANCE hinst;
+	AUDIO_INFO Info = { 0 };
 
-		BOOL MemoryBswaped;    // If this is set to TRUE, then the memory has been pre
-							   //   bswap on a dword (32 bits) boundry 
-							   //	eg. the first 8 bytes are stored like this:
-							   //        4 3 2 1   8 7 6 5
-		BYTE * HEADER;	// This is the rom header (first 40h bytes of the rom
-						// This will be in the same memory format as the rest of the memory.
-		BYTE * RDRAM;
-		BYTE * DMEM;
-		BYTE * IMEM;
+	Info.hwnd = (HWND)RenderWindow->m_hMainWindow;;
+	Info.hinst = GetModuleHandle(NULL);
+	Info.MemoryBswaped = TRUE;
+	Info.CheckInterrupts = DummyCheckInterrupts;
 
-		DWORD * MI__INTR_REG;
-
-		DWORD * AI__DRAM_ADDR_REG;
-		DWORD * AI__LEN_REG;
-		DWORD * AI__CONTROL_REG;
-		DWORD * AI__STATUS_REG;
-		DWORD * AI__DACRATE_REG;
-		DWORD * AI__BITRATE_REG;
-
-		void (__cdecl *CheckInterrupts)( void );
-	};
-
-	//Get Function from DLL
-	BOOL (__cdecl *InitiateAudio)    ( AUDIO_INFO Audio_Info );
-	InitiateAudio = (BOOL (__cdecl *)(AUDIO_INFO))GetProcAddress( (HMODULE)m_hDll, "InitiateAudio" );
-	if (InitiateAudio == NULL) { return false; }
-
-	AUDIO_INFO Info;
-	memset(&Info,0,sizeof(Info));
-	//We are initilizing the plugin before any rom is loaded so we do not have any correct
-	//paramaters here .. just needed to we can config the DLL
-	if (System == NULL) {
+	// We are initializing the plugin before any rom is loaded so we do not have any correct
+	// parameters here.. just needed to we can config the DLL.
+	if (System == NULL)
+	{
 		BYTE Buffer[100];
 		DWORD Value = 0;
 
-		Info.hwnd              = (HWND)RenderWindow->m_hMainWindow;;
-		Info.hinst             = GetModuleHandle(NULL);
-		Info.MemoryBswaped     = TRUE;
-		Info.HEADER            = Buffer;
-		Info.RDRAM             = Buffer;
-		Info.DMEM              = Buffer;
-		Info.IMEM              = Buffer;
-		Info.MI__INTR_REG      = &Value;	
-		Info.AI__DRAM_ADDR_REG = &Value;	
-		Info.AI__LEN_REG       = &Value;	
-		Info.AI__CONTROL_REG   = &Value;	
-		Info.AI__STATUS_REG    = &Value;	
-		Info.AI__DACRATE_REG   = &Value;	
-		Info.AI__BITRATE_REG   = &Value;	
-		Info.CheckInterrupts   = DummyCheckInterrupts;
-
-		m_Initilized = InitiateAudio(Info) != 0;
-		//jabo had a bug so I call CreateThread so his dllmain gets called again
-		DWORD ThreadID;
-		HANDLE hthread = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)DummyFunction,NULL,0, &ThreadID);	
-		CloseHandle(hthread);
-		Sleep(100);
-		return m_Initilized;
+		Info.HEADER = Buffer;
+		Info.RDRAM = Buffer;
+		Info.DMEM = Buffer;
+		Info.IMEM = Buffer;
+		Info.MI__INTR_REG = &Value;
+		Info.AI__DRAM_ADDR_REG = &Value;
+		Info.AI__LEN_REG = &Value;
+		Info.AI__CONTROL_REG = &Value;
+		Info.AI__STATUS_REG = &Value;
+		Info.AI__DACRATE_REG = &Value;
+		Info.AI__BITRATE_REG = &Value;
 	}
-	
-	//Send Initilization information to the DLL
-	Info.hwnd              = (HWND)RenderWindow->m_hMainWindow;
-	Info.hinst             = GetModuleHandle(NULL);
-	Info.MemoryBswaped     = TRUE;
-	Info.HEADER            = g_Rom->GetRomAddress();
-	Info.RDRAM             = g_MMU->Rdram();
-	Info.DMEM              = g_MMU->Dmem();
-	Info.IMEM              = g_MMU->Imem();
-	Info.MI__INTR_REG      = &g_Reg->m_AudioIntrReg;	
-	Info.AI__DRAM_ADDR_REG = &g_Reg->AI_DRAM_ADDR_REG;	
-	Info.AI__LEN_REG       = &g_Reg->AI_LEN_REG;	
-	Info.AI__CONTROL_REG   = &g_Reg->AI_CONTROL_REG;	
-	Info.AI__STATUS_REG    = &g_Reg->AI_STATUS_REG;	
-	Info.AI__DACRATE_REG   = &g_Reg->AI_DACRATE_REG;	
-	Info.AI__BITRATE_REG   = &g_Reg->AI_BITRATE_REG;	
-	Info.CheckInterrupts   = DummyCheckInterrupts;
+	// Send initialization information to the DLL
+	else
+	{
+		Info.HEADER = g_Rom->GetRomAddress();
+		Info.RDRAM = g_MMU->Rdram();
+		Info.DMEM = g_MMU->Dmem();
+		Info.IMEM = g_MMU->Imem();
+		Info.MI__INTR_REG = &g_Reg->m_AudioIntrReg;
+		Info.AI__DRAM_ADDR_REG = &g_Reg->AI_DRAM_ADDR_REG;
+		Info.AI__LEN_REG = &g_Reg->AI_LEN_REG;
+		Info.AI__CONTROL_REG = &g_Reg->AI_CONTROL_REG;
+		Info.AI__STATUS_REG = &g_Reg->AI_STATUS_REG;
+		Info.AI__DACRATE_REG = &g_Reg->AI_DACRATE_REG;
+		Info.AI__BITRATE_REG = &g_Reg->AI_BITRATE_REG;
+	}
 
+	// NOTE: Sleep(100) call removed after InitiateAudio() in the System == NULL condition.
 	m_Initilized = InitiateAudio(Info) != 0;
+
 	//jabo had a bug so I call CreateThread so his dllmain gets called again
 	DWORD ThreadID;
-	HANDLE hthread = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)DummyFunction,NULL,0, &ThreadID);	
+	HANDLE hthread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)DummyFunction, NULL, 0, &ThreadID);
 	CloseHandle(hthread);
 
-	if (Update) { 
-		m_hAudioThread = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)AudioThread, (LPVOID)this,0, &ThreadID);			
+	if (System != NULL)
+	{
+		if (AiUpdate)
+			m_hAudioThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)AudioThread, (LPVOID)this, 0, &ThreadID);
+
+		if (g_Reg->AI_DACRATE_REG != 0)
+			DacrateChanged(System->SystemType());
 	}
-	
-	if (g_Reg->AI_DACRATE_REG != 0) {
-		DacrateChanged(System->SystemType());
-	}
+
 	return m_Initilized;
 }
 
-void CAudioPlugin::RomOpened  ( void )
+void CAudioPlugin::UnloadPlugin(void)
 {
-	//Real system ... then make the file as open
-	if (!m_RomOpen && RomOpen)
+	if (m_hAudioThread)
 	{
-		RomOpen();
-		m_RomOpen = true;
-	}
-}
-
-void CAudioPlugin::RomClose  ( void )
-{
-	if (m_RomOpen)
-	{
-		RomClosed();
-		m_RomOpen = false;
-	}
-}
-
-void CAudioPlugin::Close(void) {
-	if (m_RomOpen) {
-		RomClosed();
-		m_RomOpen = false;
-	}
-	if (m_Initilized) {
-		CloseDLL();
-		m_Initilized = false;
-	}
-}
-
-void CAudioPlugin::GameReset(void)
-{
-	if (m_RomOpen) 
-	{
-		RomClosed();
-		if (RomOpen)
-		{
-			RomOpen();
-		}
-	}
-}
-
-void CAudioPlugin::UnloadPlugin(void) {
-	if (m_hAudioThread) 
-	{
-		WriteTraceF(TraceAudio,__FUNCTION__ ": Terminate Audio Thread");
-		TerminateThread(m_hAudioThread,0);
+		WriteTraceF(TraceAudio, __FUNCTION__ ": Terminate Audio Thread");
+		TerminateThread(m_hAudioThread, 0);
 		m_hAudioThread = NULL;
 	}
-	memset(&m_PluginInfo,0,sizeof(m_PluginInfo));
-	if (m_hDll != NULL ) {
-		FreeLibrary((HMODULE)m_hDll);
-		m_hDll = NULL;
-	}
-	m_DacrateChanged = NULL;
-	LenChanged     = NULL;
-	Config         = NULL;
-	ReadLength     = NULL;
-	Update         = NULL;
-	ProcessAList   = NULL;
-	RomClosed      = NULL;
-	CloseDLL       = NULL;
+
+	CPlugin::UnloadPlugin();
+
+	AiDacrateChanged = NULL;
+	AiLenChanged = NULL;
+	AiReadLength = NULL;
+	AiUpdate = NULL;
+	ProcessAList = NULL;
 }
 
-void CAudioPlugin::DacrateChanged  (SYSTEM_TYPE Type) 
+void CAudioPlugin::DacrateChanged(SYSTEM_TYPE Type)
 {
 	if (!Initilized()) { return; }
-	WriteTraceF(TraceAudio,__FUNCTION__ ": SystemType: %s", Type == SYSTEM_NTSC ? "SYSTEM_NTSC" : "SYSTEM_PAL");
+	WriteTraceF(TraceAudio, __FUNCTION__ ": SystemType: %s", Type == SYSTEM_NTSC ? "SYSTEM_NTSC" : "SYSTEM_PAL");
 
 	//DWORD Frequency = g_Reg->AI_DACRATE_REG * 30;
 	//DWORD CountsPerSecond = (g_Reg->VI_V_SYNC_REG != 0 ? (g_Reg->VI_V_SYNC_REG + 1) * g_Settings->LoadDword(Game_ViRefreshRate) : 500000) * 60;
-	m_DacrateChanged(Type);
+	AiDacrateChanged(Type);
 }
 
-void CAudioPlugin::AudioThread   (CAudioPlugin * _this) {
-	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
-	for (;;) 
-	{ 
-		_this->Update(true); 
+void CAudioPlugin::AudioThread(CAudioPlugin * _this) {
+	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+	for (;;)
+	{
+		_this->AiUpdate(true);
 	}
+}
+
+CAudioPlugin::~CAudioPlugin()
+{
+	Close();
+	UnloadPlugin();
 }

--- a/Source/Project64/Plugins/Audio Plugin.h
+++ b/Source/Project64/Plugins/Audio Plugin.h
@@ -10,47 +10,59 @@
 ****************************************************************************/
 #pragma once
 
-class CAudioPlugin 
+class CAudioPlugin : public CPlugin
 {
 public:
-	CAudioPlugin  ( const char * FileName);
-	~CAudioPlugin ( void );
+	CAudioPlugin(const char * FileName);
+	~CAudioPlugin();
 
-	void DacrateChanged ( SYSTEM_TYPE Type );
-	bool Initiate       ( CN64System * System, CMainGui * RenderWindow );
-	void Close          ( void );
-	void GameReset      ( void );
-	void RomOpened      ( void );
-	void RomClose       ( void );
-	stdstr PluginName ( void ) const { return m_PluginInfo.Name; }
+	virtual int GetDefaultSettingStartRange() const { return FirstAudioDefaultSet; }
+	virtual int GetSettingStartRange() const { return FirstAudioSettings; }
 
-	inline bool  Initilized    ( void ) const { return m_Initilized; }
+	void UnloadPlugin();
 
-	void  (__cdecl *LenChanged)     ( void );
-	void  (__cdecl *Config)         ( DWORD hParent );
-	DWORD (__cdecl *ReadLength)     ( void );
-	void  (__cdecl *ProcessAList)   ( void );
+	void DacrateChanged(SYSTEM_TYPE Type);
+	bool Initiate(CN64System * System, CMainGui * RenderWindow);
 
-private:
-	void * m_hDll;	
-	bool m_Initilized, m_RomOpen;
+	void(__cdecl *AiLenChanged)(void);
+	DWORD(__cdecl *AiReadLength)(void);
+	void(__cdecl *ProcessAList)(void);
+
+protected:
 	void * m_hAudioThread;
-	PLUGIN_INFO m_PluginInfo;
-	
-	void Init ( const char * FileName );
-	void UnloadPlugin         ( void );
 
-	void (__cdecl *CloseDLL)  ( void );
-	void (__cdecl *RomOpen)   ( void );
-	void (__cdecl *RomClosed) ( void );
-	void (__cdecl *Update)    ( BOOL Wait );
-	void (__cdecl *m_DacrateChanged) ( SYSTEM_TYPE Type );
-	void (__cdecl *PluginOpened)     ( void );
-	void (__cdecl *SetSettingInfo)   ( PLUGIN_SETTINGS * info );
-	void (__cdecl *SetSettingInfo2)  ( PLUGIN_SETTINGS2 * info );
-	void (__cdecl *SetSettingInfo3)  ( PLUGIN_SETTINGS3 * info );
+	bool Init(const char * FileName);
 
-	//Function used in a thread for using audio
-	static void AudioThread   (CAudioPlugin * _this);
+	struct AUDIO_INFO {
+		HWND hwnd;
+		HINSTANCE hinst;
 
+		BOOL MemoryBswaped;    // If this is set to TRUE, then the memory has been pre
+		//   bswap on a dword (32 bits) boundry 
+		//	eg. the first 8 bytes are stored like this:
+		//        4 3 2 1   8 7 6 5
+		BYTE * HEADER;	// This is the rom header (first 40h bytes of the rom
+		// This will be in the same memory format as the rest of the memory.
+		BYTE * RDRAM;
+		BYTE * DMEM;
+		BYTE * IMEM;
+
+		DWORD * MI__INTR_REG;
+
+		DWORD * AI__DRAM_ADDR_REG;
+		DWORD * AI__LEN_REG;
+		DWORD * AI__CONTROL_REG;
+		DWORD * AI__STATUS_REG;
+		DWORD * AI__DACRATE_REG;
+		DWORD * AI__BITRATE_REG;
+
+		void(__cdecl *CheckInterrupts)(void);
+	};
+
+	BOOL(__cdecl *InitiateAudio)   (AUDIO_INFO Audio_Info);
+	void(__cdecl *AiUpdate)		(BOOL Wait);
+	void(__cdecl *AiDacrateChanged)(SYSTEM_TYPE Type);
+
+	// Function used in a thread for using audio
+	static void AudioThread(CAudioPlugin * _this);
 };

--- a/Source/Project64/Plugins/Controller Plugin.cpp
+++ b/Source/Project64/Plugins/Controller Plugin.cpp
@@ -10,300 +10,131 @@
 ****************************************************************************/
 #include "stdafx.h"
 
-void FixUPXIssue ( BYTE * ProgramLocation );
-
-CControl_Plugin::CControl_Plugin ( const char * FileName) :
-	m_hDll(NULL),
-	m_Initilized(false),
-	m_RomOpen(false),
+CControl_Plugin::CControl_Plugin(const char * FileName) : CPlugin(),
 	m_AllocatedControllers(false),
-	Config(NULL),
+	InitiateControllers(NULL),
 	WM_KeyDown(NULL),
 	WM_KeyUp(NULL),
 	RumbleCommand(NULL),
 	GetKeys(NULL),
 	ReadController(NULL),
-	ControllerCommand(NULL),
-	CloseDLL(NULL),
-	RomOpen(NULL),
-	RomClosed(NULL),
-	PluginOpened(NULL),
-	SetSettingInfo(NULL),
-	SetSettingInfo2(NULL)
+	ControllerCommand(NULL)
 {
-	memset(&m_PluginInfo,0,sizeof(m_PluginInfo));
-	memset(&m_PluginControllers,0,sizeof(m_PluginControllers));
-	memset(&m_Controllers,0,sizeof(m_Controllers));
+	memset(&m_PluginControllers, 0, sizeof(m_PluginControllers));
+	memset(&m_Controllers, 0, sizeof(m_Controllers));
 
 	Init(FileName);
 }
 
-void CControl_Plugin::Init ( const char * FileName )
+bool CControl_Plugin::Init(const char * FileName)
 {
-	//Make sure all parts of the class are initialized
-	UnloadPlugin();
-
-	//Try to load the DLL library
-	UINT LastErrorMode = SetErrorMode( SEM_FAILCRITICALERRORS );
-	m_hDll = LoadLibrary(FileName);
-	SetErrorMode(LastErrorMode);
-	
-	if (m_hDll == NULL) { 
+	if (!CPlugin::Init(FileName))
+	{
 		UnloadPlugin();
-		return;
+		return false;
 	}
-	FixUPXIssue((BYTE *)m_hDll);
 
-	//Get DLL information
-	void (__cdecl *GetDllInfo) ( PLUGIN_INFO * PluginInfo );
-	GetDllInfo = (void (__cdecl *)(PLUGIN_INFO *))GetProcAddress( (HMODULE)m_hDll, "GetDllInfo" );
-	if (GetDllInfo == NULL) { UnloadPlugin(); return; }
+	// Find entries for functions in DLL
+	LoadFunction(InitiateControllers);
+	LoadFunction(ControllerCommand);
+	LoadFunction(GetKeys);
+	LoadFunction(ReadController);
+	LoadFunction(WM_KeyDown);
+	LoadFunction(WM_KeyUp);
+	LoadFunction(RumbleCommand);
 
-	GetDllInfo(&m_PluginInfo);
-	if (!CPluginList::ValidPluginVersion(m_PluginInfo)) { UnloadPlugin(); return; }
-
-	//Find entries for functions in DLL
-	void  (__cdecl *InitFunc)     ( void );
-	Config            = (void (__cdecl *)(DWORD))GetProcAddress( (HMODULE)m_hDll, "DllConfig" );
-	ControllerCommand = (void (__cdecl *)(int,BYTE *))GetProcAddress( (HMODULE)m_hDll, "ControllerCommand" );
-	GetKeys           = (void (__cdecl *)(int,BUTTONS*)) GetProcAddress( (HMODULE)m_hDll, "GetKeys" );
-	ReadController    = (void (__cdecl *)(int,BYTE *))GetProcAddress( (HMODULE)m_hDll, "ReadController" );
-	WM_KeyDown        = (void (__cdecl *)(DWORD,DWORD))GetProcAddress( (HMODULE)m_hDll, "WM_KeyDown" );
-	WM_KeyUp          = (void (__cdecl *)(DWORD,DWORD))GetProcAddress( (HMODULE)m_hDll, "WM_KeyUp" );
-	InitFunc          = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "InitiateControllers" );
-	RomOpen           = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "RomOpen" );
-	RomClosed         = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "RomClosed" );
-	CloseDLL          = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "CloseDLL" );
-	RumbleCommand     = (void (__cdecl *)(int, BOOL))GetProcAddress( (HMODULE)m_hDll, "RumbleCommand" );
-
-	//version 101 functions
-	PluginOpened     = (void (__cdecl *)(void))GetProcAddress( (HMODULE)m_hDll, "PluginLoaded" );
-
-	//Make sure dll had all needed functions
-	if (InitFunc       == NULL) { UnloadPlugin(); return;  }
-	if (CloseDLL       == NULL) { UnloadPlugin(); return;  }
-
-	SetSettingInfo3 = (void (__cdecl *)(PLUGIN_SETTINGS3 *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo3" );
-	if (SetSettingInfo3)
+	if (InitiateControllers == NULL
+		// NOTE: Comment says PluginLoaded is a 0x0101+ function, but the check states 0x0102
+		// Assuming existing code logic is correct...
+		|| (m_PluginInfo.Version >= 0x0102
+		&& PluginLoaded == NULL))
 	{
-		PLUGIN_SETTINGS3 info;
-		info.FlushSettings = (void (*)( void * handle))CSettings::FlushSettings;
-		SetSettingInfo3(&info);
+		UnloadPlugin();
+		return false;
 	}
 
-	SetSettingInfo2 = (void (__cdecl *)(PLUGIN_SETTINGS2 *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo2" );
-	if (SetSettingInfo2)
-	{
-		PLUGIN_SETTINGS2 info;
-		info.FindSystemSettingId = (unsigned int (*)( void * handle, const char * ))CSettings::FindSetting;
-		SetSettingInfo2(&info);
-	}
+	if (PluginLoaded != NULL)
+		PluginLoaded();
 
-	SetSettingInfo   = (void (__cdecl *)(PLUGIN_SETTINGS *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo" );
-	if (SetSettingInfo)
-	{
-		PLUGIN_SETTINGS info;
-		info.dwSize = sizeof(PLUGIN_SETTINGS);
-		info.DefaultStartRange = FirstCtrlDefaultSet;
-		info.SettingStartRange = FirstCtrlSettings;
-		info.MaximumSettings   = MaxPluginSetting;
-		info.NoDefault         = Default_None;
-		info.DefaultLocation   = g_Settings->LoadDword(Setting_UseFromRegistry) ? SettingType_Registry : SettingType_CfgFile;
-		info.handle            = g_Settings;
-		info.RegisterSetting   = (void (*)(void *,int,int,SettingDataType,SettingType,const char *,const char *, DWORD))CSettings::RegisterSetting;
-		info.GetSetting        = (unsigned int (*)( void * handle, int ID ))CSettings::GetSetting;
-		info.GetSettingSz      = (const char * (*)( void *, int, char *, int ))CSettings::GetSettingSz;
-		info.SetSetting        = (void (*)(void *,int,unsigned int))CSettings::SetSetting;
-		info.SetSettingSz      = (void (*)(void *,int,const char *))CSettings::SetSettingSz;
-		info.UseUnregisteredSetting = NULL;
-
-		SetSettingInfo(&info);
-//		g_Settings->UnknownSetting_CTRL = info.UseUnregisteredSetting;
-	}
-	
-	if (m_PluginInfo.Version >= 0x0102)
-	{
-		if (PluginOpened    == NULL) { UnloadPlugin(); return; }
-
-		PluginOpened();
-	}
-
-	//Allocate our own controller
+	// Allocate our own controller
 	m_AllocatedControllers = true;
-	m_Controllers[0] = new CCONTROL(m_PluginControllers[0].Present,m_PluginControllers[0].RawData,m_PluginControllers[0].Plugin);
-	m_Controllers[1] = new CCONTROL(m_PluginControllers[1].Present,m_PluginControllers[1].RawData,m_PluginControllers[1].Plugin);
-	m_Controllers[2] = new CCONTROL(m_PluginControllers[2].Present,m_PluginControllers[2].RawData,m_PluginControllers[2].Plugin);
-	m_Controllers[3] = new CCONTROL(m_PluginControllers[3].Present,m_PluginControllers[3].RawData,m_PluginControllers[3].Plugin);
+	for (int i = 0; i < 4; i++)
+		m_Controllers[i] = new CCONTROL(m_PluginControllers[i].Present, m_PluginControllers[i].RawData, m_PluginControllers[i].Plugin);
+
+	return true;
 }
 
-CControl_Plugin::~CControl_Plugin (void) {
-	Close();
-	UnloadPlugin();
-}
+bool CControl_Plugin::Initiate(CN64System * System, CMainGui * RenderWindow)
+{
+	for (int i = 0; i < 4; i++)
+	{
+		m_PluginControllers[i].Present = FALSE;
+		m_PluginControllers[i].RawData = FALSE;
+		m_PluginControllers[i].Plugin = PLUGIN_NONE;
+	}
 
-bool CControl_Plugin::Initiate ( CN64System * System, CMainGui * RenderWindow ) {
-	m_PluginControllers[0].Present = FALSE;
-	m_PluginControllers[0].RawData = FALSE;
-	m_PluginControllers[0].Plugin  = PLUGIN_NONE;
-
-	m_PluginControllers[1].Present = FALSE;
-	m_PluginControllers[1].RawData = FALSE;
-	m_PluginControllers[1].Plugin  = PLUGIN_NONE;
-
-	m_PluginControllers[2].Present = FALSE;
-	m_PluginControllers[2].RawData = FALSE;
-	m_PluginControllers[2].Plugin  = PLUGIN_NONE;
-
-	m_PluginControllers[3].Present = FALSE;
-	m_PluginControllers[3].RawData = FALSE;
-	m_PluginControllers[3].Plugin  = PLUGIN_NONE;
-
-	//Get DLL information
-	void (__cdecl *GetDllInfo) ( PLUGIN_INFO * PluginInfo );
-	GetDllInfo = (void (__cdecl *)(PLUGIN_INFO *))GetProcAddress( (HMODULE)m_hDll, "GetDllInfo" );
-	if (GetDllInfo == NULL) { return false; }
-
-	PLUGIN_INFO PluginInfo;
-	GetDllInfo(&PluginInfo);
-
-	//Test Plugin version
-	if (PluginInfo.Version == 0x0100) {
-		//Get Function from DLL
-		void (__cdecl *InitiateControllers_1_0)( HWND hMainWindow, CONTROL Controls[4] );
-		InitiateControllers_1_0 = (void (__cdecl *)(HWND, CONTROL *))GetProcAddress( (HMODULE)m_hDll, "InitiateControllers" );
-		if (InitiateControllers_1_0 == NULL) { return false; }
-		InitiateControllers_1_0((HWND)RenderWindow->m_hMainWindow,m_PluginControllers);
+	// Test Plugin version
+	if (m_PluginInfo.Version == 0x0100)
+	{
+		((fInitiateControllers_1_0)InitiateControllers)((HWND)RenderWindow->m_hMainWindow, m_PluginControllers);
 		m_Initilized = true;
 	}
-	if (PluginInfo.Version >= 0x0101) {
-		typedef struct {
-			HWND hMainWindow;
-			HINSTANCE hinst;
-
-			BOOL MemoryBswaped;		// If this is set to TRUE, then the memory has been pre
-									//   bswap on a dword (32 bits) boundry, only effects header. 
-									//	eg. the first 8 bytes are stored like this:
-									//        4 3 2 1   8 7 6 5
-			BYTE * HEADER;			// This is the rom header (first 40h bytes of the rom)
-			CONTROL *Controls;		// A pointer to an array of 4 controllers .. eg:
-									// CONTROL Controls[4];
-		} CONTROL_INFO;
-
-		//Get Function from DLL		
-		void (__cdecl *InitiateControllers_1_1)( CONTROL_INFO * ControlInfo );
-		InitiateControllers_1_1 = (void (__cdecl *)(CONTROL_INFO *))GetProcAddress( (HMODULE)m_hDll, "InitiateControllers" );
-		if (InitiateControllers_1_1 == NULL) { return false; }
-		
+	else if (m_PluginInfo.Version >= 0x0101)
+	{
 		CONTROL_INFO ControlInfo;
-		if (System == NULL) {
-			BYTE Buffer[100];
-			
-			ControlInfo.Controls      = m_PluginControllers;
-			ControlInfo.HEADER        = Buffer;
-			ControlInfo.hinst         = GetModuleHandle(NULL);
-			ControlInfo.hMainWindow   = (HWND)RenderWindow->m_hMainWindow;
-			ControlInfo.MemoryBswaped = TRUE;
-			InitiateControllers_1_1(&ControlInfo);
-			m_Initilized = true;
-		} else {
-			ControlInfo.Controls      = m_PluginControllers;
-			ControlInfo.HEADER        = g_Rom->GetRomAddress();
-			ControlInfo.hinst         = GetModuleHandle(NULL);
-			ControlInfo.hMainWindow   = (HWND)RenderWindow->m_hMainWindow;
-			ControlInfo.MemoryBswaped = TRUE;
-			InitiateControllers_1_1(&ControlInfo);
-			m_Initilized = true;
-		}
+		BYTE Buffer[100];
+
+		ControlInfo.Controls = m_PluginControllers;
+		ControlInfo.HEADER = (System == NULL ? Buffer : g_Rom->GetRomAddress());
+		ControlInfo.hinst = GetModuleHandle(NULL);
+		ControlInfo.hMainWindow = (HWND)RenderWindow->m_hMainWindow;
+		ControlInfo.MemoryBswaped = TRUE;
+
+		((fInitiateControllers_1_1)InitiateControllers)(&ControlInfo);
+		m_Initilized = true;
 	}
 
 	//jabo had a bug so I call CreateThread so his dllmain gets called again
 	DWORD ThreadID;
-	HANDLE hthread = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)DummyFunction,NULL,0, &ThreadID);	
+	HANDLE hthread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)DummyFunction, NULL, 0, &ThreadID);
 	CloseHandle(hthread);
 
-	
 	return m_Initilized;
 }
 
-void CControl_Plugin::RomOpened ( void )
+void CControl_Plugin::UnloadPlugin()
 {
-	//Real system ... then make the file as open
-	if (!m_RomOpen) 
+	CPlugin::UnloadPlugin();
+
+	if (m_AllocatedControllers)
 	{
-		RomOpen();
-		m_RomOpen = true;
-	}
-}
-
-void CControl_Plugin::RomClose  ( void )
-{
-	if (m_RomOpen)
-	{
-		RomClosed();
-		m_RomOpen = false;
-	}
-}
-
-void CControl_Plugin::Close(void) {
-	if (m_RomOpen) {
-		RomClosed();
-		m_RomOpen = false;
-	}
-	if (m_Initilized) {
-		CloseDLL();
-		m_Initilized = false;
-	}
-}
-
-void CControl_Plugin::GameReset(void)
-{
-	if (m_RomOpen) 
-	{
-		RomClosed();
-		RomOpen();
-	}
-}
-
-void CControl_Plugin::UnloadPlugin(void) {
-	if (m_AllocatedControllers) {
-		for (int count = 0; count < sizeof(m_Controllers) / sizeof(m_Controllers[0]); count++) {
+		for (int count = 0; count < sizeof(m_Controllers) / sizeof(m_Controllers[0]); count++)
+		{
 			delete m_Controllers[count];
 			m_Controllers[count] = NULL;
 		}
 	}
-	memset(&m_PluginInfo,0,sizeof(m_PluginInfo));
-	if (m_hDll != NULL ) {
-		FreeLibrary((HMODULE)m_hDll);
-		m_hDll = NULL;
-	}
-	m_AllocatedControllers = false;
-	m_Controllers[0]       = NULL;
-	m_Controllers[1]       = NULL;
-	m_Controllers[2]       = NULL;
-	m_Controllers[3]       = NULL;
-	Config                 = NULL;
-	ControllerCommand      = NULL;
-	GetKeys                = NULL;
-	ReadController         = NULL;
-	WM_KeyDown             = NULL;
-	WM_KeyUp               = NULL;
-	CloseDLL               = NULL;
-	RomOpen                = NULL;
-	RomClosed              = NULL;
 
+	m_AllocatedControllers = false;
+	ControllerCommand = NULL;
+	GetKeys = NULL;
+	ReadController = NULL;
+	WM_KeyDown = NULL;
+	WM_KeyUp = NULL;
 }
 
-void CControl_Plugin::UpdateKeys (void) {
+void CControl_Plugin::UpdateKeys(void) {
 	if (!m_AllocatedControllers) { return; }
 	for (int cont = 0; cont < sizeof(m_Controllers) / sizeof(m_Controllers[0]); cont++) {
 		if (!m_Controllers[cont]->m_Present) { continue; }
-		if (!m_Controllers[cont]->m_RawData) { 
-			GetKeys(cont,&m_Controllers[cont]->m_Buttons);
-		} else {
-			g_Notify->BreakPoint(__FILE__,__LINE__); 
+		if (!m_Controllers[cont]->m_RawData) {
+			GetKeys(cont, &m_Controllers[cont]->m_Buttons);
+		}
+		else {
+			g_Notify->BreakPoint(__FILE__, __LINE__);
 		}
 	}
-	if (ReadController) { ReadController(-1,NULL); }
+	if (ReadController) { ReadController(-1, NULL); }
 }
 
 void CControl_Plugin::SetControl(CControl_Plugin const * const Plugin)
@@ -318,11 +149,16 @@ void CControl_Plugin::SetControl(CControl_Plugin const * const Plugin)
 	for (int count = 0; count < sizeof(m_Controllers) / sizeof(m_Controllers[0]); count++) {
 		m_Controllers[count] = Plugin->m_Controllers[count];
 	}
-
 }
 
-CCONTROL::CCONTROL(DWORD &Present,DWORD &RawData, int &PlugType) :
-	m_Present(Present),m_RawData(RawData),m_PlugType(PlugType)
+CControl_Plugin::~CControl_Plugin()
+{
+	Close();
+	UnloadPlugin();
+}
+
+CCONTROL::CCONTROL(DWORD &Present, DWORD &RawData, int &PlugType) :
+m_Present(Present), m_RawData(RawData), m_PlugType(PlugType)
 {
 	m_Buttons.Value = 0;
 }

--- a/Source/Project64/Plugins/GFX plugin.cpp
+++ b/Source/Project64/Plugins/GFX plugin.cpp
@@ -10,12 +10,9 @@
 ****************************************************************************/
 #include "stdafx.h"
 
-void FixUPXIssue ( BYTE * ProgramLocation );
-
-CGfxPlugin::CGfxPlugin ( const char * FileName) :
+CGfxPlugin::CGfxPlugin(const char * FileName) : CPlugin(),
 	CaptureScreen(NULL),
 	ChangeWindow(NULL),
-	Config(NULL),
 	DrawScreen(NULL),
 	DrawStatus(NULL),
 	MoveScreen(NULL),
@@ -28,369 +25,227 @@ CGfxPlugin::CGfxPlugin ( const char * FileName) :
 	SoftReset(NULL),
 	GetRomBrowserMenu(NULL),
 	OnRomBrowserMenuItem(NULL),
-	CloseDLL(NULL),
-	RomOpen(NULL),
-	RomClosed(NULL),
 	GetDebugInfo(NULL),
-	InitiateDebugger(NULL),
-	PluginOpened(NULL),
-	SetSettingInfo(NULL),
-	SetSettingInfo2(NULL),
-	m_hDll(NULL),	
-	m_Initilized(false), 
-	m_RomOpen(false)
+	InitiateDebugger(NULL)
 {
-	memset(&m_GFXDebug,0,sizeof(m_GFXDebug));
-	memset(&m_PluginInfo,0,sizeof(m_PluginInfo));
+	memset(&m_GFXDebug, 0, sizeof(m_GFXDebug));
 	Init(FileName);
 }
 
-void CGfxPlugin::Init ( const char * FileName )
+bool CGfxPlugin::Init(const char * FileName)
 {
-	//Try to load the DLL library
-	UINT LastErrorMode = SetErrorMode( SEM_FAILCRITICALERRORS );
-	m_hDll = LoadLibrary(FileName);
-	SetErrorMode(LastErrorMode);
-	
-	if (m_hDll == NULL) { 
+	if (!CPlugin::Init(FileName))
+	{
 		UnloadPlugin();
-		return;
+		return false;
 	}
-	FixUPXIssue((BYTE *)m_hDll);
 
-	//Get DLL information
-	void (__cdecl *GetDllInfo) ( PLUGIN_INFO * PluginInfo );
-	GetDllInfo = (void (__cdecl *)(PLUGIN_INFO *))GetProcAddress( (HMODULE)m_hDll, "GetDllInfo" );
-	if (GetDllInfo == NULL) { UnloadPlugin(); return; }
+	// Find entries for functions in DLL
+	LoadFunction(InitiateGFX);
+	LoadFunction(ChangeWindow);
+	LoadFunction(DrawScreen);
+	LoadFunction(MoveScreen);
+	LoadFunction(ProcessDList);
+	LoadFunction(UpdateScreen);
+	LoadFunction(ViStatusChanged);
+	LoadFunction(ViWidthChanged);
+	LoadFunction(SoftReset);
 
-	GetDllInfo(&m_PluginInfo);
-	if (!CPluginList::ValidPluginVersion(m_PluginInfo)) { UnloadPlugin(); return; }
+	// version 0x104 functions
+	_LoadFunction("DrawFullScreenStatus", DrawStatus);
 
-	//Find entries for functions in DLL
-	BOOL (__cdecl *InitFunc) ( void * Gfx_Info );
-	CloseDLL        = (void (__cdecl *)(void))    GetProcAddress( (HMODULE)m_hDll, "CloseDLL" );
-	ChangeWindow    = (void (__cdecl *)(void))    GetProcAddress( (HMODULE)m_hDll, "ChangeWindow" );
-	Config          = (void (__cdecl *)(DWORD))   GetProcAddress( (HMODULE)m_hDll, "DllConfig" );
-	DrawScreen      = (void (__cdecl *)(void))    GetProcAddress( (HMODULE)m_hDll, "DrawScreen" );
-	InitFunc        = (BOOL (__cdecl *)(void *))  GetProcAddress( (HMODULE)m_hDll, "InitiateGFX" );
-	MoveScreen      = (void (__cdecl *)(int, int))GetProcAddress( (HMODULE)m_hDll, "MoveScreen" );
-	ProcessDList    = (void (__cdecl *)(void))    GetProcAddress( (HMODULE)m_hDll, "ProcessDList" );
-	RomClosed       = (void (__cdecl *)(void))    GetProcAddress( (HMODULE)m_hDll, "RomClosed" );
-	RomOpen         = (void (__cdecl *)(void))    GetProcAddress( (HMODULE)m_hDll, "RomOpen" );
-	UpdateScreen    = (void (__cdecl *)(void))    GetProcAddress( (HMODULE)m_hDll, "UpdateScreen" );
-	ViStatusChanged = (void (__cdecl *)(void))    GetProcAddress( (HMODULE)m_hDll, "ViStatusChanged" );
-	ViWidthChanged  = (void (__cdecl *)(void))    GetProcAddress( (HMODULE)m_hDll, "ViWidthChanged" );
-	SoftReset       = (void (__cdecl *)(void))    GetProcAddress( (HMODULE)m_hDll, "SoftReset" );
-
-	//version 104 functions
-	PluginOpened     = (void (__cdecl *)(void))GetProcAddress( (HMODULE)m_hDll, "PluginLoaded" );
-	DrawStatus       = (void (__cdecl *)(const char *, BOOL ))GetProcAddress((HMODULE)m_hDll, "DrawFullScreenStatus");
-	
 	// Rom Browser
-	GetRomBrowserMenu    = (HMENU (__cdecl *)( void ))GetProcAddress( (HMODULE)m_hDll, "GetRomBrowserMenu" );
-	OnRomBrowserMenuItem = (void (__cdecl *) ( int, HWND, BYTE * ))GetProcAddress( (HMODULE)m_hDll, "OnRomBrowserMenuItem" );
+	LoadFunction(GetRomBrowserMenu);
+	LoadFunction(OnRomBrowserMenuItem);
 
-	//Make sure dll had all needed functions
-	if (ChangeWindow == NULL)    { UnloadPlugin(); return; }
 	if (DrawScreen == NULL)      { DrawScreen = DummyDrawScreen; }
-	if (InitFunc == NULL)        { UnloadPlugin(); return; }
 	if (MoveScreen == NULL)      { MoveScreen = DummyMoveScreen; }
-	if (ProcessDList == NULL)    { UnloadPlugin(); return; }
-	if (RomClosed == NULL)       { UnloadPlugin(); return; }
-	if (RomOpen == NULL)         { UnloadPlugin(); return; }
-	if (UpdateScreen == NULL)    { UnloadPlugin(); return; }
 	if (ViStatusChanged == NULL) { ViStatusChanged = DummyViStatusChanged; }
-	if (ViWidthChanged == NULL)  { ViWidthChanged = DummyViWidthChanged; }	
-	if (CloseDLL == NULL)        { UnloadPlugin(); return; }
+	if (ViWidthChanged == NULL)  { ViWidthChanged = DummyViWidthChanged; }
 	if (SoftReset == NULL)       { SoftReset = DummySoftReset; }
-	
-	if (m_PluginInfo.Version >= 0x0103 ){
-		ProcessRDPList   = (void (__cdecl *)(void))GetProcAddress( (HMODULE)m_hDll, "ProcessRDPList" );
-		CaptureScreen    = (void (__cdecl *)(const char *))GetProcAddress( (HMODULE)m_hDll, "CaptureScreen" );
-		ShowCFB          = (void (__cdecl *)(void))GetProcAddress( (HMODULE)m_hDll, "ShowCFB" );
-		GetDebugInfo     = (void (__cdecl *)(GFXDEBUG_INFO *))GetProcAddress( (HMODULE)m_hDll, "GetGfxDebugInfo" );
-		InitiateDebugger = (void (__cdecl *)(DEBUG_INFO))GetProcAddress( (HMODULE)m_hDll, "InitiateGFXDebugger" );
 
-		if (ProcessRDPList == NULL) { UnloadPlugin(); return; }
-		if (CaptureScreen == NULL)  { UnloadPlugin(); return; }
-		if (ShowCFB == NULL)        { UnloadPlugin(); return; }
-
-		if (GetDebugInfo != NULL) { GetDebugInfo(&m_GFXDebug); }
-
-	}
-	
-	SetSettingInfo3 = (void (__cdecl *)(PLUGIN_SETTINGS3 *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo3" );
-	if (SetSettingInfo3)
+	if (m_PluginInfo.Version >= 0x0103)
 	{
-		PLUGIN_SETTINGS3 info;
-		info.FlushSettings = (void (*)( void * handle))CSettings::FlushSettings;
-		SetSettingInfo3(&info);
+		LoadFunction(ProcessRDPList);
+		LoadFunction(CaptureScreen);
+		LoadFunction(ShowCFB);
+		LoadFunction(GetDebugInfo);
+		_LoadFunction("InitiateGFXDebugger", InitiateDebugger);
 	}
 
-	SetSettingInfo2 = (void (__cdecl *)(PLUGIN_SETTINGS2 *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo2" );
-	if (SetSettingInfo2)
+	// Required functions for plugins
+	if (InitiateGFX == NULL
+		|| ChangeWindow == NULL
+		|| ProcessDList == NULL
+		|| UpdateScreen == NULL
+		// Required functions for plugins version 0x103+
+		|| (m_PluginInfo.Version >= 0x0103
+		&& (ProcessRDPList == NULL
+		|| CaptureScreen == NULL
+		|| ShowCFB == NULL))
+		// Required functions for plugins version 0x104+
+		|| (m_PluginInfo.Version >= 0x0104
+		&& PluginLoaded == NULL))
 	{
-		PLUGIN_SETTINGS2 info;
-		info.FindSystemSettingId = (unsigned int (*)( void * handle, const char * ))CSettings::FindSetting;
-		SetSettingInfo2(&info);
+		UnloadPlugin();
+		return false;
 	}
 
-	SetSettingInfo   = (void (__cdecl *)(PLUGIN_SETTINGS *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo" );
-	if (SetSettingInfo)
-	{
-		PLUGIN_SETTINGS info;
-		info.dwSize = sizeof(PLUGIN_SETTINGS);
-		info.DefaultStartRange = FirstGfxDefaultSet;
-		info.SettingStartRange = FirstGfxSettings;
-		info.MaximumSettings   = MaxPluginSetting;
-		info.NoDefault         = Default_None;
-		info.DefaultLocation   = g_Settings->LoadDword(Setting_UseFromRegistry) ? SettingType_Registry : SettingType_CfgFile;
-		info.handle            = g_Settings;
-		info.RegisterSetting   = (void (*)(void *,int,int,SettingDataType,SettingType,const char *,const char *, DWORD))CSettings::RegisterSetting;
-		info.GetSetting        = (unsigned int (*)( void * handle, int ID ))CSettings::GetSetting;
-		info.GetSettingSz      = (const char * (*)( void *, int, char *, int ))CSettings::GetSettingSz;
-		info.SetSetting        = (void (*)(void *,int,unsigned int))CSettings::SetSetting;
-		info.SetSettingSz      = (void (*)(void *,int,const char *))CSettings::SetSettingSz;
-		info.UseUnregisteredSetting = NULL;
+	if (GetDebugInfo != NULL)
+		GetDebugInfo(&m_GFXDebug);
 
-		SetSettingInfo(&info);
-//		g_Settings->UnknownSetting_GFX = info.UseUnregisteredSetting;
-	}
+	if (PluginLoaded != NULL)
+		PluginLoaded();
 
-	if (m_PluginInfo.Version >= 0x0104)
-	{
-		if (PluginOpened    == NULL) { UnloadPlugin(); return; }
-
-		PluginOpened();
-	}
-//	FrameBufferRead = (void (__cdecl *)(DWORD))GetProcAddress( (HMODULE)m_hDll, "FBRead" );
-//	FrameBufferWrite = (void (__cdecl *)(DWORD, DWORD))GetProcAddress( (HMODULE)m_hDll, "FBWrite" );
-
+	return true;
 }
 
-CGfxPlugin::~CGfxPlugin (void) {
-	Close();
-	UnloadPlugin();
-}
-
-bool CGfxPlugin::Initiate ( CN64System * System, CMainGui * RenderWindow ) 
+bool CGfxPlugin::Initiate(CN64System * System, CMainGui * RenderWindow)
 {
 	if (m_Initilized)
-	{
 		Close();
-	}
 
-	typedef struct {
-		HWND hWnd;			/* Render window */
-		HWND hStatusBar;    /* if render window does not have a status bar then this is NULL */
+	if (InitiateGFX == NULL)
+		return false;
 
-		BOOL MemoryBswaped;    // If this is set to TRUE, then the memory has been pre
-							   //   bswap on a dword (32 bits) boundry 
-							   //	eg. the first 8 bytes are stored like this:
-							   //        4 3 2 1   8 7 6 5
+	GFX_INFO Info = { 0 };
 
-		BYTE * HEADER;	// This is the rom header (first 40h bytes of the rom
-						// This will be in the same memory format as the rest of the memory.
-		BYTE * RDRAM;
-		BYTE * DMEM;
-		BYTE * IMEM;
+	Info.MemoryBswaped = TRUE;
+	Info.hWnd = (HWND)RenderWindow->m_hMainWindow;
+	Info.hStatusBar = (HWND)RenderWindow->m_hStatusWnd;
+	Info.CheckInterrupts = DummyCheckInterrupts;
 
-		DWORD * MI__INTR_REG;
-
-		DWORD * DPC__START_REG;
-		DWORD * DPC__END_REG;
-		DWORD * DPC__CURRENT_REG;
-		DWORD * DPC__STATUS_REG;
-		DWORD * DPC__CLOCK_REG;
-		DWORD * DPC__BUFBUSY_REG;
-		DWORD * DPC__PIPEBUSY_REG;
-		DWORD * DPC__TMEM_REG;
-
-		DWORD * VI__STATUS_REG;
-		DWORD * VI__ORIGIN_REG;
-		DWORD * VI__WIDTH_REG;
-		DWORD * VI__INTR_REG;
-		DWORD * VI__V_CURRENT_LINE_REG;
-		DWORD * VI__TIMING_REG;
-		DWORD * VI__V_SYNC_REG;
-		DWORD * VI__H_SYNC_REG;
-		DWORD * VI__LEAP_REG;
-		DWORD * VI__H_START_REG;
-		DWORD * VI__V_START_REG;
-		DWORD * VI__V_BURST_REG;
-		DWORD * VI__X_SCALE_REG;
-		DWORD * VI__Y_SCALE_REG;
-
-		void (__cdecl *CheckInterrupts)( void );
-	} GFX_INFO;
-
-	//Get Function from DLL
-	BOOL (__cdecl *InitiateGFX)( GFX_INFO Gfx_Info );
-	InitiateGFX = (BOOL (__cdecl *)(GFX_INFO))GetProcAddress( (HMODULE)m_hDll, "InitiateGFX" );
-	if (InitiateGFX == NULL) { return false; }
-
-	GFX_INFO Info;
-	memset(&Info,0,sizeof(Info));
-	//We are initilizing the plugin before any rom is loaded so we do not have any correct
-	//paramaters here .. just needed to we can config the DLL
-	if (System == NULL) {
+	// We are initializing the plugin before any rom is loaded so we do not have any correct
+	// parameters here.. it's just needed so we can config the DLL.
+	if (System == NULL)
+	{
 		BYTE Buffer[100];
 		DWORD Value = 0;
 
-		Info.MemoryBswaped          = TRUE;
-		Info.hWnd                   = (HWND)RenderWindow->m_hMainWindow;
-		Info.hStatusBar             = (HWND)RenderWindow->m_hStatusWnd;
-		Info.CheckInterrupts        = DummyCheckInterrupts;
-		Info.HEADER                 = Buffer;
-		Info.RDRAM                  = Buffer;
-		Info.DMEM                   = Buffer;
-		Info.IMEM                   = Buffer;
-		Info.MI__INTR_REG           = &Value;	
-		Info.VI__STATUS_REG         = &Value;
-		Info.VI__ORIGIN_REG         = &Value;
-		Info.VI__WIDTH_REG          = &Value;
-		Info.VI__INTR_REG           = &Value;
+		Info.HEADER = Buffer;
+		Info.RDRAM = Buffer;
+		Info.DMEM = Buffer;
+		Info.IMEM = Buffer;
+		Info.MI__INTR_REG = &Value;
+		Info.VI__STATUS_REG = &Value;
+		Info.VI__ORIGIN_REG = &Value;
+		Info.VI__WIDTH_REG = &Value;
+		Info.VI__INTR_REG = &Value;
 		Info.VI__V_CURRENT_LINE_REG = &Value;
-		Info.VI__TIMING_REG         = &Value;
-		Info.VI__V_SYNC_REG         = &Value;
-		Info.VI__H_SYNC_REG         = &Value;
-		Info.VI__LEAP_REG           = &Value;
-		Info.VI__H_START_REG        = &Value;
-		Info.VI__V_START_REG        = &Value;
-		Info.VI__V_BURST_REG        = &Value;
-		Info.VI__X_SCALE_REG        = &Value;
-		Info.VI__Y_SCALE_REG        = &Value;
-		m_Initilized = InitiateGFX(Info) != 0;
-		//jabo had a bug so I call CreateThread so his dllmain gets called again
-		DWORD ThreadID;
-		HANDLE hthread = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)DummyFunction,NULL,0, &ThreadID);	
-		CloseHandle(hthread);
-		Sleep(100);
-		return m_Initilized;
+		Info.VI__TIMING_REG = &Value;
+		Info.VI__V_SYNC_REG = &Value;
+		Info.VI__H_SYNC_REG = &Value;
+		Info.VI__LEAP_REG = &Value;
+		Info.VI__H_START_REG = &Value;
+		Info.VI__V_START_REG = &Value;
+		Info.VI__V_BURST_REG = &Value;
+		Info.VI__X_SCALE_REG = &Value;
+		Info.VI__Y_SCALE_REG = &Value;
 	}
-	
-	//Send Initilization information to the DLL
-	Info.MemoryBswaped          = TRUE;
-	Info.CheckInterrupts        = DummyCheckInterrupts;
-	Info.hWnd                   = (HWND)RenderWindow->m_hMainWindow;
-	Info.hStatusBar             = (HWND)RenderWindow->m_hStatusWnd;
-	Info.HEADER                 = g_Rom->GetRomAddress();
-	Info.RDRAM                  = g_MMU->Rdram();
-	Info.DMEM                   = g_MMU->Dmem();
-	Info.IMEM                   = g_MMU->Imem();
-	Info.MI__INTR_REG           = &g_Reg->m_GfxIntrReg;	
-	Info.DPC__START_REG         = &g_Reg->DPC_START_REG;
-	Info.DPC__END_REG           = &g_Reg->DPC_END_REG;
-	Info.DPC__CURRENT_REG       = &g_Reg->DPC_CURRENT_REG;
-	Info.DPC__STATUS_REG        = &g_Reg->DPC_STATUS_REG;
-	Info.DPC__CLOCK_REG         = &g_Reg->DPC_CLOCK_REG;
-	Info.DPC__BUFBUSY_REG       = &g_Reg->DPC_BUFBUSY_REG;
-	Info.DPC__PIPEBUSY_REG      = &g_Reg->DPC_PIPEBUSY_REG;
-	Info.DPC__TMEM_REG          = &g_Reg->DPC_TMEM_REG;
-	Info.VI__STATUS_REG         = &g_Reg->VI_STATUS_REG;
-	Info.VI__ORIGIN_REG         = &g_Reg->VI_ORIGIN_REG;
-	Info.VI__WIDTH_REG          = &g_Reg->VI_WIDTH_REG;
-	Info.VI__INTR_REG           = &g_Reg->VI_INTR_REG;
-	Info.VI__V_CURRENT_LINE_REG = &g_Reg->VI_CURRENT_REG;
-	Info.VI__TIMING_REG         = &g_Reg->VI_TIMING_REG;
-	Info.VI__V_SYNC_REG         = &g_Reg->VI_V_SYNC_REG;
-	Info.VI__H_SYNC_REG         = &g_Reg->VI_H_SYNC_REG;
-	Info.VI__LEAP_REG           = &g_Reg->VI_LEAP_REG;
-	Info.VI__H_START_REG        = &g_Reg->VI_H_START_REG;
-	Info.VI__V_START_REG        = &g_Reg->VI_V_START_REG;
-	Info.VI__V_BURST_REG        = &g_Reg->VI_V_BURST_REG;
-	Info.VI__X_SCALE_REG        = &g_Reg->VI_X_SCALE_REG;
-	Info.VI__Y_SCALE_REG        = &g_Reg->VI_Y_SCALE_REG;
-	
+	// Send initialization information to the DLL
+	else
+	{
+		Info.HEADER = g_Rom->GetRomAddress();
+		Info.RDRAM = g_MMU->Rdram();
+		Info.DMEM = g_MMU->Dmem();
+		Info.IMEM = g_MMU->Imem();
+		Info.MI__INTR_REG = &g_Reg->m_GfxIntrReg;
+		Info.DPC__START_REG = &g_Reg->DPC_START_REG;
+		Info.DPC__END_REG = &g_Reg->DPC_END_REG;
+		Info.DPC__CURRENT_REG = &g_Reg->DPC_CURRENT_REG;
+		Info.DPC__STATUS_REG = &g_Reg->DPC_STATUS_REG;
+		Info.DPC__CLOCK_REG = &g_Reg->DPC_CLOCK_REG;
+		Info.DPC__BUFBUSY_REG = &g_Reg->DPC_BUFBUSY_REG;
+		Info.DPC__PIPEBUSY_REG = &g_Reg->DPC_PIPEBUSY_REG;
+		Info.DPC__TMEM_REG = &g_Reg->DPC_TMEM_REG;
+		Info.VI__STATUS_REG = &g_Reg->VI_STATUS_REG;
+		Info.VI__ORIGIN_REG = &g_Reg->VI_ORIGIN_REG;
+		Info.VI__WIDTH_REG = &g_Reg->VI_WIDTH_REG;
+		Info.VI__INTR_REG = &g_Reg->VI_INTR_REG;
+		Info.VI__V_CURRENT_LINE_REG = &g_Reg->VI_CURRENT_REG;
+		Info.VI__TIMING_REG = &g_Reg->VI_TIMING_REG;
+		Info.VI__V_SYNC_REG = &g_Reg->VI_V_SYNC_REG;
+		Info.VI__H_SYNC_REG = &g_Reg->VI_H_SYNC_REG;
+		Info.VI__LEAP_REG = &g_Reg->VI_LEAP_REG;
+		Info.VI__H_START_REG = &g_Reg->VI_H_START_REG;
+		Info.VI__V_START_REG = &g_Reg->VI_V_START_REG;
+		Info.VI__V_BURST_REG = &g_Reg->VI_V_BURST_REG;
+		Info.VI__X_SCALE_REG = &g_Reg->VI_X_SCALE_REG;
+		Info.VI__Y_SCALE_REG = &g_Reg->VI_Y_SCALE_REG;
+	}
+
+	// NOTE: Sleep(100) call removed after InitiateGFX() in the System == NULL condition.
 	m_Initilized = InitiateGFX(Info) != 0;
+
 	//jabo had a bug so I call CreateThread so his dllmain gets called again
 	DWORD ThreadID;
-	HANDLE hthread = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)DummyFunction,NULL,0, &ThreadID);	
+	HANDLE hthread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)DummyFunction, NULL, 0, &ThreadID);
 	CloseHandle(hthread);
-	
+
 	return m_Initilized;
 }
 
-void CGfxPlugin::Close(void) {
-	if (m_RomOpen) 
-	{
-		RomClose();
-	}
-	if (m_Initilized) 
-	{
-		CloseDLL();
-		m_Initilized = false;
-	}
-}
-
-void CGfxPlugin::RomOpened  ( void )
+#if 0
+void CGfxPlugin::RomOpened(void)
 {
 	//Real system ... then make the file as open
 	if (!m_RomOpen)
 	{
-		WriteTrace(TraceGfxPlugin,__FUNCTION__ ": Before RomOpen");
+		WriteTrace(TraceGfxPlugin, __FUNCTION__ ": Before RomOpen");
 		RomOpen();
-		WriteTrace(TraceGfxPlugin,__FUNCTION__ ": After RomOpen");
+		WriteTrace(TraceGfxPlugin, __FUNCTION__ ": After RomOpen");
 		m_RomOpen = true;
 	}
 }
 
-void CGfxPlugin::RomClose  ( void )
+void CGfxPlugin::RomClose(void)
 {
 	if (m_RomOpen)
 	{
-		WriteTrace(TraceGfxPlugin,__FUNCTION__ ": Before RomClosed");
+		WriteTrace(TraceGfxPlugin, __FUNCTION__ ": Before RomClosed");
 		RomClosed();
-		WriteTrace(TraceGfxPlugin,__FUNCTION__ ": After RomClosed");
+		WriteTrace(TraceGfxPlugin, __FUNCTION__ ": After RomClosed");
 		m_RomOpen = false;
 	}
 }
+#endif
 
-void CGfxPlugin::GameReset(void)
+void CGfxPlugin::UnloadPlugin()
 {
-	if (m_RomOpen) 
-	{
-		RomClose();
-		RomOpened();
-	}
-}
+	CPlugin::UnloadPlugin();
 
-void CGfxPlugin::UnloadPlugin(void) {
-	if (m_hDll != NULL ) {
-		FreeLibrary((HMODULE)m_hDll);
-		m_hDll = NULL;
-	}
-	memset(&m_GFXDebug,0,sizeof(m_GFXDebug));
-	memset(&m_PluginInfo,0,sizeof(m_PluginInfo));
+	memset(&m_GFXDebug, 0, sizeof(m_GFXDebug));
 
-//	CaptureScreen        = NULL;
-	ChangeWindow         = NULL;
-	GetDebugInfo         = NULL;
-	CloseDLL             = NULL;
-//	DllAbout             = NULL;
-	Config               = NULL;
-	RomClosed            = NULL;
-	RomOpen              = NULL;
-	DrawScreen           = NULL;
-	DrawStatus           = NULL;
-//	FrameBufferRead      = NULL;
-//	FrameBufferWrite     = NULL;
-	InitiateDebugger     = NULL;
-	MoveScreen           = NULL;
-	ProcessDList         = NULL;
-	ProcessRDPList       = NULL;
-	ShowCFB              = NULL;
-	UpdateScreen         = NULL;
-	ViStatusChanged      = NULL;
-	ViWidthChanged       = NULL;
-	GetRomBrowserMenu    = NULL;
+	InitiateGFX = NULL;
+	//	CaptureScreen        = NULL;
+	ChangeWindow = NULL;
+	GetDebugInfo = NULL;
+	DrawScreen = NULL;
+	DrawStatus = NULL;
+	//	FrameBufferRead      = NULL;
+	//	FrameBufferWrite     = NULL;
+	InitiateDebugger = NULL;
+	MoveScreen = NULL;
+	ProcessDList = NULL;
+	ProcessRDPList = NULL;
+	ShowCFB = NULL;
+	UpdateScreen = NULL;
+	ViStatusChanged = NULL;
+	ViWidthChanged = NULL;
+	GetRomBrowserMenu = NULL;
 	OnRomBrowserMenuItem = NULL;
 }
 
-void CGfxPlugin::ProcessMenuItem (int id )
+void CGfxPlugin::ProcessMenuItem(int id)
 {
 	if (m_GFXDebug.ProcessMenuItem)
 	{
-		m_GFXDebug.ProcessMenuItem(id); 
+		m_GFXDebug.ProcessMenuItem(id);
 	}
+}
+
+CGfxPlugin::~CGfxPlugin()
+{
+	Close();
+	UnloadPlugin();
 }

--- a/Source/Project64/Plugins/GFX plugin.h
+++ b/Source/Project64/Plugins/GFX plugin.h
@@ -10,100 +10,133 @@
 ****************************************************************************/
 #pragma once
 
-class CGfxPlugin  
+class CGfxPlugin : public CPlugin
 {
 	typedef struct {
 		/* Menu */
 		/* Items should have an ID between 5101 and 5200 */
 		HMENU hGFXMenu;
-		void (__cdecl *ProcessMenuItem) ( int ID );
+		void(__cdecl *ProcessMenuItem) (int ID);
 
 		/* Break Points */
 		BOOL UseBPoints;
 		char BPPanelName[20];
-		void (__cdecl *Add_BPoint)      ( void );
-		void (__cdecl *CreateBPPanel)   ( HWND hDlg, RECT_STRUCT rcBox );
-		void (__cdecl *HideBPPanel)     ( void );
-		void (__cdecl *PaintBPPanel)    ( WINDOWS_PAINTSTRUCT ps );
-		void (__cdecl *ShowBPPanel)     ( void );
-		void (__cdecl *RefreshBpoints)  ( HWND hList );
-		void (__cdecl *RemoveBpoint)    ( HWND hList, int index );
-		void (__cdecl *RemoveAllBpoint) ( void );
-		
+		void(__cdecl *Add_BPoint)      (void);
+		void(__cdecl *CreateBPPanel)   (HWND hDlg, RECT_STRUCT rcBox);
+		void(__cdecl *HideBPPanel)     (void);
+		void(__cdecl *PaintBPPanel)    (WINDOWS_PAINTSTRUCT ps);
+		void(__cdecl *ShowBPPanel)     (void);
+		void(__cdecl *RefreshBpoints)  (HWND hList);
+		void(__cdecl *RemoveBpoint)    (HWND hList, int index);
+		void(__cdecl *RemoveAllBpoint) (void);
+
 		/* GFX command Window */
-		void (__cdecl *Enter_GFX_Commands_Window) ( void );
+		void(__cdecl *Enter_GFX_Commands_Window) (void);
 	} GFXDEBUG_INFO;
 
 	typedef struct {
-		void (__cdecl *UpdateBreakPoints)( void );
-		void (__cdecl *UpdateMemory)( void );
-		void (__cdecl *UpdateR4300iRegisters)( void );
-		void (__cdecl *Enter_BPoint_Window)( void );
-		void (__cdecl *Enter_R4300i_Commands_Window)( void );
-		void (__cdecl *Enter_R4300i_Register_Window)( void );
-		void (__cdecl *Enter_RSP_Commands_Window) ( void );
-		void (__cdecl *Enter_Memory_Window)( void );
+		void(__cdecl *UpdateBreakPoints)(void);
+		void(__cdecl *UpdateMemory)(void);
+		void(__cdecl *UpdateR4300iRegisters)(void);
+		void(__cdecl *Enter_BPoint_Window)(void);
+		void(__cdecl *Enter_R4300i_Commands_Window)(void);
+		void(__cdecl *Enter_R4300i_Register_Window)(void);
+		void(__cdecl *Enter_RSP_Commands_Window) (void);
+		void(__cdecl *Enter_Memory_Window)(void);
 	} DEBUG_INFO;
 
 public:
-	CGfxPlugin  ( const char * FileName);
-	~CGfxPlugin ( void );
+	CGfxPlugin(const char * FileName);
+	~CGfxPlugin();
 
-	bool Initiate   ( CN64System * System, CMainGui * RenderWindow );
-	bool Initilized ( void ) { return m_Initilized; }
-	void Close      ( void );
-	void RomOpened  ( void );
-	void RomClose   ( void );
-	void GameReset  ( void );
-	stdstr PluginName ( void ) const { return m_PluginInfo.Name; }
+	bool Initiate(CN64System * System, CMainGui * RenderWindow);
 
-	void (__cdecl *CaptureScreen)      ( const char * );
-	void (__cdecl *ChangeWindow)       ( void );
-	void (__cdecl *Config)          ( DWORD hParent );
-	void (__cdecl *DrawScreen)         ( void );
-	void (__cdecl *DrawStatus)         ( const char * lpString, BOOL RightAlign );
-	void (__cdecl *MoveScreen)         ( int xpos, int ypos );
-	void (__cdecl *ProcessDList)       ( void );
-	void (__cdecl *ProcessRDPList)     ( void );
-	void (__cdecl *ShowCFB)			   ( void );
-	void (__cdecl *UpdateScreen)       ( void );
-	void (__cdecl *ViStatusChanged)    ( void );
-	void (__cdecl *ViWidthChanged)     ( void );
-	void (__cdecl *SoftReset)          ( void );
+	void(__cdecl *CaptureScreen)      (const char *);
+	void(__cdecl *ChangeWindow)       (void);
+	void(__cdecl *DrawScreen)         (void);
+	void(__cdecl *DrawStatus)         (const char * lpString, BOOL RightAlign);
+	void(__cdecl *MoveScreen)         (int xpos, int ypos);
+	void(__cdecl *ProcessDList)       (void);
+	void(__cdecl *ProcessRDPList)     (void);
+	void(__cdecl *ShowCFB)			   (void);
+	void(__cdecl *UpdateScreen)       (void);
+	void(__cdecl *ViStatusChanged)    (void);
+	void(__cdecl *ViWidthChanged)     (void);
+	void(__cdecl *SoftReset)          (void);
 
 	//Rom Browser
-	HMENU (__cdecl * GetRomBrowserMenu)  ( void ); /* Items should have an ID between 4101 and 4200 */
-	void (__cdecl * OnRomBrowserMenuItem) ( int MenuID, HWND hParent, BYTE * HEADER );
-	
-	HMENU GetDebugMenu (void ) { return m_GFXDebug.hGFXMenu; }
-	void ProcessMenuItem (int id );
+	HMENU(__cdecl * GetRomBrowserMenu)  (void); /* Items should have an ID between 4101 and 4200 */
+	void(__cdecl * OnRomBrowserMenuItem) (int MenuID, HWND hParent, BYTE * HEADER);
+
+	HMENU GetDebugMenu(void) { return m_GFXDebug.hGFXMenu; }
+	void ProcessMenuItem(int id);
+
+	void UnloadPlugin();
 
 private:
 	CGfxPlugin(void);							// Disable default constructor
 	CGfxPlugin(const CGfxPlugin&);				// Disable copy constructor
 	CGfxPlugin& operator=(const CGfxPlugin&);	// Disable assignment
 
-	void Init ( const char * FileName );
-	void UnloadPlugin         ( void );
+	virtual int GetDefaultSettingStartRange() const { return FirstGfxDefaultSet; }
+	virtual int GetSettingStartRange() const { return FirstGfxSettings; }
+
+	bool Init(const char * FileName);
 
 	GFXDEBUG_INFO m_GFXDebug;
-	void * m_hDll;	
-	bool m_Initilized, m_RomOpen;
-	PLUGIN_INFO m_PluginInfo;
 
-	void (__cdecl *CloseDLL)         ( void );
-	void (__cdecl *RomOpen)          ( void );
-	void (__cdecl *RomClosed)        ( void );
-	void (__cdecl *GetDebugInfo)     ( GFXDEBUG_INFO * GFXDebugInfo );
-	void (__cdecl *InitiateDebugger) ( DEBUG_INFO DebugInfo);
-	void (__cdecl *PluginOpened)     ( void );
-	void (__cdecl *SetSettingInfo)   ( PLUGIN_SETTINGS * info );
-	void (__cdecl *SetSettingInfo2)  ( PLUGIN_SETTINGS2 * info );
-	void (__cdecl *SetSettingInfo3)  ( PLUGIN_SETTINGS3 * info );
 
-	static void __cdecl DummyDrawScreen      ( void ) {}
-	static void __cdecl DummyMoveScreen      ( int /*xpos*/, int /*ypos*/ ) {}
-	static void __cdecl DummyViStatusChanged ( void ) {}
-	static void __cdecl DummyViWidthChanged  ( void ) {}
-	static void __cdecl DummySoftReset       ( void ) {}
+	typedef struct {
+		HWND hWnd;			/* Render window */
+		HWND hStatusBar;    /* if render window does not have a status bar then this is NULL */
+
+		BOOL MemoryBswaped;    // If this is set to TRUE, then the memory has been pre
+		//   bswap on a dword (32 bits) boundry 
+		//	eg. the first 8 bytes are stored like this:
+		//        4 3 2 1   8 7 6 5
+
+		BYTE * HEADER;	// This is the rom header (first 40h bytes of the rom
+		// This will be in the same memory format as the rest of the memory.
+		BYTE * RDRAM;
+		BYTE * DMEM;
+		BYTE * IMEM;
+
+		DWORD * MI__INTR_REG;
+
+		DWORD * DPC__START_REG;
+		DWORD * DPC__END_REG;
+		DWORD * DPC__CURRENT_REG;
+		DWORD * DPC__STATUS_REG;
+		DWORD * DPC__CLOCK_REG;
+		DWORD * DPC__BUFBUSY_REG;
+		DWORD * DPC__PIPEBUSY_REG;
+		DWORD * DPC__TMEM_REG;
+
+		DWORD * VI__STATUS_REG;
+		DWORD * VI__ORIGIN_REG;
+		DWORD * VI__WIDTH_REG;
+		DWORD * VI__INTR_REG;
+		DWORD * VI__V_CURRENT_LINE_REG;
+		DWORD * VI__TIMING_REG;
+		DWORD * VI__V_SYNC_REG;
+		DWORD * VI__H_SYNC_REG;
+		DWORD * VI__LEAP_REG;
+		DWORD * VI__H_START_REG;
+		DWORD * VI__V_START_REG;
+		DWORD * VI__V_BURST_REG;
+		DWORD * VI__X_SCALE_REG;
+		DWORD * VI__Y_SCALE_REG;
+
+		void(__cdecl *CheckInterrupts)(void);
+	} GFX_INFO;
+
+	BOOL(__cdecl *InitiateGFX)		(GFX_INFO Gfx_Info);
+	void(__cdecl *GetDebugInfo)	(GFXDEBUG_INFO * GFXDebugInfo);
+	void(__cdecl *InitiateDebugger)(DEBUG_INFO DebugInfo);
+
+	static void __cdecl DummyDrawScreen(void) {}
+	static void __cdecl DummyMoveScreen(int /*xpos*/, int /*ypos*/) {}
+	static void __cdecl DummyViStatusChanged(void) {}
+	static void __cdecl DummyViWidthChanged(void) {}
+	static void __cdecl DummySoftReset(void) {}
 };

--- a/Source/Project64/Plugins/Plugin Base.cpp
+++ b/Source/Project64/Plugins/Plugin Base.cpp
@@ -1,0 +1,246 @@
+/****************************************************************************
+*                                                                           *
+* Project 64 - A Nintendo 64 emulator.                                      *
+* http://www.pj64-emu.com/                                                  *
+* Copyright (C) 2012 Project64. All rights reserved.                        *
+*                                                                           *
+* License:                                                                  *
+* GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
+*                                                                           *
+****************************************************************************/
+#include "stdafx.h"
+
+void FixUPXIssue(BYTE * ProgramLocation);
+
+CPlugin::CPlugin() :
+	m_hDll(NULL),
+	m_Initilized(false),
+	m_RomOpen(false),
+	RomOpen(NULL),
+	RomClosed(NULL),
+	CloseDLL(NULL),
+	PluginLoaded(NULL),
+	DllAbout(NULL),
+	DllConfig(NULL),
+	SetSettingInfo(NULL),
+	SetSettingInfo2(NULL),
+	SetSettingInfo3(NULL)
+{
+	memset(&m_PluginInfo, 0, sizeof(m_PluginInfo));
+}
+
+// Load & initialise arbitrary plugin
+CPlugin * CPlugin::InitPlugin(const char * FileName)
+{
+	/*
+	This is done in two steps.
+	First we need to load the plugin to determine what type of plugin it is (GFX, audio, RSP, controller)...
+	and then we need to create an appropriate plugin instance, and load it properly according to the plugin.
+
+	This way plugin behaviour is consistent.
+	*/
+	CPlugin * plugin = NULL;
+	HMODULE hModule = LoadPlugin(FileName);
+	if (hModule == NULL)
+		return plugin;
+
+	// Ensure we can pull information about the plugin.
+	void(__cdecl *GetDllInfo)(PLUGIN_INFO *) = (void(__cdecl *)(PLUGIN_INFO *))GetProcAddress(hModule, "GetDllInfo");
+	if (GetDllInfo == NULL)
+	{
+		FreeLibrary(hModule);
+		return plugin;
+	}
+
+	// Attempt to retrieve plugin information.
+	PLUGIN_INFO PluginInfo;
+	GetDllInfo(&PluginInfo);
+
+	// We no longer need this DLL instance for anything (we'll load it again properly, if all is well).
+	FreeLibrary(hModule);
+
+	// Verify that the plugin version is indeed correct (no point continuing, otherwise)
+	if (!CPluginList::ValidPluginVersion(PluginInfo))
+		return plugin;
+
+	// Now initialise the plugin appropriately, for consistency.
+	switch (PluginInfo.Type)
+	{
+	case PLUGIN_TYPE_RSP:
+		plugin = new CRSP_Plugin(FileName);
+		break;
+
+	case PLUGIN_TYPE_GFX:
+		plugin = new CGfxPlugin(FileName);
+		break;
+
+	case PLUGIN_TYPE_AUDIO:
+		plugin = new CAudioPlugin(FileName);
+		break;
+
+	case PLUGIN_TYPE_CONTROLLER:
+		plugin = new CControl_Plugin(FileName);
+		break;
+	}
+
+	// We should now have an initialised plugin instance...
+	// or NULL.
+	return plugin;
+}
+
+HMODULE CPlugin::LoadPlugin(const char * FileName)
+{
+	HMODULE hModule = NULL;
+	UINT LastErrorMode = SetErrorMode(SEM_FAILCRITICALERRORS);
+	hModule = LoadLibrary(FileName);
+	SetErrorMode(LastErrorMode);
+	if (hModule == NULL)
+		return NULL;
+
+	FixUPXIssue((BYTE *)hModule);
+	return hModule;
+}
+
+bool CPlugin::Init(const char * FileName)
+{
+	// Already loaded, so unload first.
+	if (m_hDll != NULL)
+		UnloadPlugin();
+
+	// Try to load the plugin DLL
+	m_hDll = LoadPlugin(FileName);
+	if (m_hDll == NULL)
+		return false;
+
+	// Get DLL information
+	void(__cdecl *GetDllInfo) (PLUGIN_INFO * PluginInfo);
+	LoadFunction(GetDllInfo);
+	if (GetDllInfo == NULL)
+		return false;
+
+	GetDllInfo(&m_PluginInfo);
+	if (!CPluginList::ValidPluginVersion(m_PluginInfo))
+		return false;
+
+	LoadFunction(CloseDLL);
+	LoadFunction(RomOpen);
+	LoadFunction(RomClosed);
+	LoadFunction(DllAbout);
+	LoadFunction(DllConfig);
+
+	if (RomClosed == NULL)
+		return false;
+
+	// GFX: version 0x104, audio: version 0x102
+	LoadFunction(PluginLoaded);
+
+	LoadFunction(SetSettingInfo3);
+	LoadFunction(SetSettingInfo2);
+	LoadFunction(SetSettingInfo);
+
+	if (SetSettingInfo3)
+	{
+		PLUGIN_SETTINGS3 info;
+		info.FlushSettings = (void(*)(void *))&CSettings::FlushSettings;
+		SetSettingInfo3(&info);
+	}
+
+	if (SetSettingInfo2)
+	{
+		PLUGIN_SETTINGS2 info;
+		info.FindSystemSettingId = (unsigned int(*)(void *, const char *))&CSettings::FindSetting;
+		SetSettingInfo2(&info);
+	}
+
+	if (SetSettingInfo)
+	{
+		PLUGIN_SETTINGS info;
+		info.dwSize = sizeof(PLUGIN_SETTINGS);
+		info.DefaultStartRange = GetDefaultSettingStartRange();
+		info.SettingStartRange = GetSettingStartRange();
+		info.MaximumSettings = MaxPluginSetting;
+		info.NoDefault = Default_None;
+		info.DefaultLocation = g_Settings->LoadDword(Setting_UseFromRegistry) ? SettingType_Registry : SettingType_CfgFile;
+		info.handle = g_Settings;
+		info.RegisterSetting = (void(*)(void *, int, int, SettingDataType, SettingType, const char *, const char *, DWORD))&CSettings::RegisterSetting;
+		info.GetSetting = (unsigned int(*)(void *, int))&CSettings::GetSetting;
+		info.GetSettingSz = (const char * (*)(void *, int, char *, int))&CSettings::GetSettingSz;
+		info.SetSetting = (void(*)(void *, int, unsigned int))&CSettings::SetSetting;
+		info.SetSettingSz = (void(*)(void *, int, const char *))&CSettings::SetSettingSz;
+		info.UseUnregisteredSetting = NULL;
+
+		SetSettingInfo(&info);
+		//		g_Settings->UnknownSetting_GFX = info.UseUnregisteredSetting;
+	}
+
+	return true;
+}
+
+void CPlugin::RomOpened()
+{
+	if (m_RomOpen || RomOpen == NULL)
+		return;
+
+	RomOpen();
+	m_RomOpen = true;
+}
+
+void CPlugin::RomClose()
+{
+	if (!m_RomOpen)
+		return;
+
+	RomClosed();
+	m_RomOpen = false;
+}
+
+void CPlugin::GameReset()
+{
+	if (!m_RomOpen)
+		return;
+
+	RomClosed();
+	RomOpen();
+}
+
+void CPlugin::Close()
+{
+	RomClose();
+
+	if (m_Initilized)
+	{
+		CloseDLL();
+		m_Initilized = false;
+	}
+}
+
+void CPlugin::UnloadPlugin()
+{
+	memset(&m_PluginInfo, 0, sizeof(m_PluginInfo));
+	if (m_hDll != NULL)
+	{
+		FreeLibrary((HMODULE)m_hDll);
+		m_hDll = NULL;
+	}
+
+	//	DllAbout		= NULL;
+	CloseDLL = NULL;
+	RomOpen = NULL;
+	RomClosed = NULL;
+	PluginLoaded = NULL;
+	DllConfig = NULL;
+	SetSettingInfo = NULL;
+	SetSettingInfo2 = NULL;
+	SetSettingInfo3 = NULL;
+}
+
+CPlugin::~CPlugin()
+{
+	// NOTE: Unless the cleanup code is changed, we need to reimplement this in each derived plugin class
+	// as the object most likely will have changed at this point, and refer to CPlugin's vtable rather than
+	// the derived plugin class' vtable.
+#if 0
+	Close();
+	UnloadPlugin();
+#endif
+}

--- a/Source/Project64/Plugins/Plugin Base.h
+++ b/Source/Project64/Plugins/Plugin Base.h
@@ -1,0 +1,68 @@
+/****************************************************************************
+*                                                                           *
+* Project 64 - A Nintendo 64 emulator.                                      *
+* http://www.pj64-emu.com/                                                  *
+* Copyright (C) 2012 Project64. All rights reserved.                        *
+*                                                                           *
+* License:                                                                  *
+* GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
+*                                                                           *
+****************************************************************************/
+#pragma once
+
+class CPlugin
+{
+public:
+	CPlugin();
+
+	inline PLUGIN_INFO * GetInfo() { return &m_PluginInfo; }
+	inline stdstr PluginName() const { return m_PluginInfo.Name; }
+	inline bool Initilized() { return m_Initilized; }
+
+	virtual int GetDefaultSettingStartRange() const = 0;
+	virtual int GetSettingStartRange() const = 0;
+
+	// Load & initialise arbitrary plugin
+	static CPlugin * InitPlugin(const char * FileName);
+
+private:
+	static HMODULE LoadPlugin(const char * FileName);
+
+public:
+	virtual bool Init(const char * FileName);
+
+	void RomOpened();
+	void RomClose();
+	void GameReset();
+	void Close();
+
+	virtual void UnloadPlugin();
+	virtual ~CPlugin();
+
+	void(__cdecl *CloseDLL)		(void);
+	void(__cdecl *RomOpen)			(void);
+	void(__cdecl *RomClosed)	    (void);
+	void(__cdecl *PluginLoaded)	(void);
+
+	void(__cdecl *DllAbout)			(HWND hWnd);
+	void(__cdecl *DllConfig)		(DWORD hParent);
+
+	void(__cdecl *SetSettingInfo)	(PLUGIN_SETTINGS  *);
+	void(__cdecl *SetSettingInfo2)	(PLUGIN_SETTINGS2 *);
+	void(__cdecl *SetSettingInfo3)	(PLUGIN_SETTINGS3 *);
+
+protected:
+	void * m_hDll;
+	bool   m_Initilized, m_RomOpen;
+	PLUGIN_INFO m_PluginInfo;
+
+	// Loads a function pointer from the currently loaded DLL
+	template <typename T>
+	void _LoadFunction(const char * szFunctionName, T & functionPointer) {
+		functionPointer = (T)GetProcAddress((HMODULE)m_hDll, szFunctionName);
+	}
+
+	// Simple wrapper around _LoadFunction() to avoid having to specify the same two arguments
+	// i.e. _LoadFunction("CloseDLL", CloseDLL);
+#define LoadFunction(functionName) _LoadFunction(#functionName, functionName)
+};

--- a/Source/Project64/Plugins/Plugin Class.cpp
+++ b/Source/Project64/Plugins/Plugin Class.cpp
@@ -247,7 +247,9 @@ bool CPlugins::Initiate ( CN64System * System )
 	WriteTrace(TraceDebug,__FUNCTION__ ": Audio Initiate Starting");
 	if (!m_Audio->Initiate(System,m_RenderWindow)) { return false; }
 	WriteTrace(TraceDebug,__FUNCTION__ ": Audio Initiate Done");
+	WriteTrace(TraceDebug, __FUNCTION__ ": Control Initiate Starting");
 	if (!m_Control->Initiate(System,m_RenderWindow)) { return false; }
+	WriteTrace(TraceDebug, __FUNCTION__ ": Control Initiate Done");
 	WriteTrace(TraceRSP,__FUNCTION__ ": RSP Initiate Starting");
 	if (!m_RSP->Initiate(this,System))   { return false; }
 	WriteTrace(TraceRSP,__FUNCTION__ ": RSP Initiate Done");
@@ -369,42 +371,41 @@ void CPlugins::Reset ( void )
 void CPlugins::ConfigPlugin ( DWORD hParent, PLUGIN_TYPE Type ) {
 	switch (Type) {
 	case PLUGIN_TYPE_RSP:
-		if (m_RSP == NULL || m_RSP->Config == NULL) { break; }
+		if (m_RSP == NULL || m_RSP->DllConfig == NULL) { break; }
 		if (!m_RSP->Initilized()) {
 			if (!m_RSP->Initiate(NULL,NULL)) {				
 				break;
 			}
 		}
-		m_RSP->Config(hParent);
+		m_RSP->DllConfig(hParent);
 		break;
 	case PLUGIN_TYPE_GFX:
-		if (m_Gfx == NULL || m_Gfx->Config == NULL) { break; }
+		if (m_Gfx == NULL || m_Gfx->DllConfig == NULL) { break; }
 		if (!m_Gfx->Initilized()) {
 			if (!m_Gfx->Initiate(NULL,m_DummyWindow)) {
 				break;
 			}
 		}
-		m_Gfx->Config(hParent);
+		m_Gfx->DllConfig(hParent);
 		break;
 	case PLUGIN_TYPE_AUDIO:
-		if (m_Audio == NULL || m_Audio->Config == NULL) { break; }
+		if (m_Audio == NULL || m_Audio->DllConfig == NULL) { break; }
 		if (!m_Audio->Initilized()) {
 			if (!m_Audio->Initiate(NULL,m_DummyWindow)) {
 				break;
 			}
 		}
-		m_Audio->Config(hParent);
+		m_Audio->DllConfig(hParent);
 		break;
 	case PLUGIN_TYPE_CONTROLLER:
-		if (m_Control == NULL || m_Control->Config == NULL) { break; }
+		if (m_Control == NULL || m_Control->DllConfig == NULL) { break; }
 		if (!m_Control->Initilized()) {
 			if (!m_Control->Initiate(NULL,m_DummyWindow)) {
 				break;
 			}
 		}
-		m_Control->Config(hParent);
+		m_Control->DllConfig(hParent);
 		break;
-
 	}
 }
 

--- a/Source/Project64/Plugins/Plugin List.cpp
+++ b/Source/Project64/Plugins/Plugin List.cpp
@@ -61,55 +61,25 @@ void CPluginList::AddPluginFromDir ( CPath Dir)
 	Dir.SetNameExtension("*.dll");
 	if (Dir.FindFirst())
 	{
-		HMODULE hLib = NULL;
-		do {
-			if (hLib)
-			{
-				FreeLibrary(hLib);
-				hLib = NULL;
-			}
+		do
+		{
+			WriteTraceF(TraceDebug, __FUNCTION__ ": loading %s", (LPCSTR)Dir);
 
-			UINT LastErrorMode = SetErrorMode( SEM_FAILCRITICALERRORS );
-			WriteTraceF(TraceDebug,__FUNCTION__ ": loading %s",(LPCSTR)Dir);
-			hLib = LoadLibrary(Dir);		
-			SetErrorMode(LastErrorMode);
-
-			if (hLib == NULL) 
-			{ 
+			CPlugin * plugin = CPlugin::InitPlugin((LPCTSTR)Dir);
+			if (plugin == NULL)
 				continue;
-			}
 
-			void (__cdecl *GetDllInfo) ( PLUGIN_INFO * PluginInfo );
-			GetDllInfo = (void (__cdecl *)(PLUGIN_INFO *))GetProcAddress( hLib, "GetDllInfo" );
-			if (GetDllInfo == NULL) 
-			{
-				continue;
-			}
-			
-			PLUGIN Plugin;
-			memset(&Plugin.Info,0,sizeof(Plugin.Info));
-			Plugin.Info.MemoryBswaped = true;
-			GetDllInfo(&Plugin.Info);
-			if (!ValidPluginVersion(Plugin.Info))
-			{
-				continue;
-			}
-
+			PLUGIN Plugin = { 0 };
+			memcpy(&Plugin.Info, plugin->GetInfo(), sizeof(PLUGIN_INFO));
 			Plugin.FullPath = Dir;
 			Plugin.FileName = ((stdstr &)Dir).substr(((stdstr &)m_PluginDir).length());
 
-			if (GetProcAddress(hLib,"DllAbout") != NULL) 
-			{
+			if (plugin->DllAbout != NULL)
 				Plugin.AboutFunction = true;
-			}
-			m_PluginList.push_back(Plugin);
-		} while (Dir.FindNext());
 
-		if (hLib)
-		{
-			FreeLibrary(hLib);
-			hLib = NULL;
-		}
+			m_PluginList.push_back(Plugin);
+			delete plugin;
+		} while (Dir.FindNext());
 	}
 }
 
@@ -142,115 +112,3 @@ bool CPluginList::ValidPluginVersion ( PLUGIN_INFO & PluginInfo ) {
 	}
 	return FALSE;
 }
-
-
-#ifdef toremove
-CPluginList::CPluginList (CSettings * Settings) {
-	g_Settings = Settings;
-}
-
-#include <windows.h>
-
-void CPluginList::AddPluginFromDir (const char * PluginDir, const char * Dir, PluginList * Plugins) {
-	WIN32_FIND_DATA FindData;
-	char SearchDir[300];
-
-	//Go through all directories
-	strncpy(SearchDir,Dir,sizeof(SearchDir));
-	strncat(SearchDir,"*.*",sizeof(SearchDir));
-	
-	HANDLE hFind = FindFirstFile(SearchDir, &FindData);
-	while (hFind != INVALID_HANDLE_VALUE) {
-		if (strcmp(FindData.cFileName,".") == 0 || strcmp(FindData.cFileName,"..") == 0){
-			if (FindNextFile(hFind,&FindData) == 0) { 
-				hFind = INVALID_HANDLE_VALUE; 
-			}
-			continue;
-		}
-		if ((FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
-			char NewDir[300];
-			
-			strncpy(NewDir,Dir,sizeof(NewDir));
-			strncat(NewDir,FindData.cFileName,sizeof(NewDir));
-			strncat(NewDir,"\\",sizeof(NewDir));
-			AddPluginFromDir(PluginDir,NewDir,Plugins);
-		}
-		if (FindNextFile(hFind,&FindData) == 0) { 
-			hFind = INVALID_HANDLE_VALUE; 
-		}
-	}
-	
-
-	//Create the search path for all dll in directory
-	strncpy(SearchDir,Dir,sizeof(SearchDir));
-	strncat(SearchDir,"*.dll",sizeof(SearchDir));
-
-	//Add all DLL's to the list of plugins
-	hFind = FindFirstFile(SearchDir, &FindData);
-	while (hFind != INVALID_HANDLE_VALUE) {
-		PLUGIN Plugin;
-		Plugin.FullPath = Dir;
-		Plugin.FullPath += FindData.cFileName;
-		Plugin.FileName = Plugin.FullPath.substr(strlen(PluginDir));
-		Plugin.InfoFunction = false;
-		
-		//Load the plugin
-		UINT LastErrorMode = SetErrorMode( SEM_FAILCRITICALERRORS );
-		HMODULE hLib = LoadLibrary(Plugin.FullPath.c_str());		
-		SetErrorMode(LastErrorMode);
-
-		if (hLib != NULL) { 
-			void (__cdecl *GetDllInfo) ( PLUGIN_INFO * PluginInfo );
-
-			GetDllInfo = (void (__cdecl *)(PLUGIN_INFO *))GetProcAddress( hLib, "GetDllInfo" );
-			if (GetDllInfo != NULL) {
-				if (GetProcAddress(hLib,"DllAbout") != NULL) {
-					Plugin.InfoFunction = true;
-				}
-				GetDllInfo(&Plugin.info);
-				if (ValidPluginVersion(&Plugin.info) &&
-					!(Plugin.info.Type != PLUGIN_TYPE_CONTROLLER && Plugin.info.MemoryBswaped == FALSE))
-				{
-					Plugins->push_back(Plugin);
-				}
-			}
-			FreeLibrary(hLib);
-		}
-
-		if (FindNextFile(hFind,&FindData) == 0) { 
-			hFind = INVALID_HANDLE_VALUE; 
-		}
-	}
-}
-
-void CPluginList::DllAbout (void * hParent, const char * PluginFile ) {
-	//Load the plugin
-	UINT LastErrorMode = SetErrorMode( SEM_FAILCRITICALERRORS );
-	HMODULE hLib = LoadLibrary(PluginFile);		
-	SetErrorMode(LastErrorMode);
-	
-	//Get DLL about
-	void (__cdecl *DllAbout) ( HWND hWnd );
-	DllAbout = (void (__cdecl *)(HWND))GetProcAddress( hLib, "DllAbout" );
-	
-	//call the function from the dll
-	DllAbout((HWND)hParent);
-
-	FreeLibrary(hLib);
-}
-
-PluginList CPluginList::GetPluginList (void) {
-	PluginList Plugins;
-
-	//Create search path for plugins
-	Notify().BreakPoint(__FILE__,__LINE__);
-/*	char SearchDir[300] = "";
-	g_Settings->LoadString(PluginDirectory,SearchDir,sizeof(SearchDir));
-
-	//recursively scan search dir, and add files in that dir 
-	AddPluginFromDir(SearchDir,SearchDir,&Plugins);
-	*/
-	return Plugins;
-}
-
-#endif

--- a/Source/Project64/Plugins/RSP Plugin.cpp
+++ b/Source/Project64/Plugins/RSP Plugin.cpp
@@ -10,347 +10,172 @@
 ****************************************************************************/
 #include "stdafx.h"
 
-void FixUPXIssue ( BYTE * ProgramLocation );
-void DummyFunc1 ( BOOL /*a*/) {}
+void DummyFunc1(BOOL /*a*/) {}
 
-CRSP_Plugin::CRSP_Plugin ( const char * FileName) :
-	Config(NULL),
+CRSP_Plugin::CRSP_Plugin(const char * FileName) : CPlugin(),
+	InitiateRSP(NULL),
 	DoRspCycles(NULL),
 	EnableDebugging(NULL),
-	CloseDLL(NULL),
-	RomOpen(NULL),
-	RomClosed(NULL),
 	GetDebugInfo(NULL),
 	InitiateDebugger(NULL),
-	PluginOpened(NULL),
-	SetSettingInfo(NULL),
-	SetSettingInfo2(NULL),
-	m_hDll(NULL),	
-	m_Initilized(false), 
-	m_RomOpen(false),
 	m_CycleCount(0)
 {
-	memset(&m_RSPDebug,0,sizeof(m_RSPDebug));
-	memset(&m_PluginInfo,0,sizeof(m_PluginInfo));
+	memset(&m_RSPDebug, 0, sizeof(m_RSPDebug));
 	Init(FileName);
 }
 
-void CRSP_Plugin::Init ( const char * FileName )
+bool CRSP_Plugin::Init(const char * FileName)
 {
-	//Try to load the DLL library
-	UINT LastErrorMode = SetErrorMode( SEM_FAILCRITICALERRORS );
-	m_hDll = LoadLibrary(FileName);
-	SetErrorMode(LastErrorMode);
-	
-	if (m_hDll == NULL) { 
+	if (!CPlugin::Init(FileName))
+	{
 		UnloadPlugin();
-		return;
+		return false;
 	}
-	FixUPXIssue((BYTE *)m_hDll);
 
-	//Get DLL information
-	void (__cdecl *GetDllInfo) ( PLUGIN_INFO * PluginInfo );
-	GetDllInfo = (void (__cdecl *)(PLUGIN_INFO *))GetProcAddress( (HMODULE)m_hDll, "GetDllInfo" );
-	if (GetDllInfo == NULL) { UnloadPlugin(); return; }
-
-	GetDllInfo(&m_PluginInfo);
-	if (!CPluginList::ValidPluginVersion(m_PluginInfo)) { UnloadPlugin(); return; }
-
-	//Find entries for functions in DLL
-	void (__cdecl *InitFunc)( void );
-	DoRspCycles      = (DWORD (__cdecl *)(DWORD))GetProcAddress( (HMODULE)m_hDll, "DoRspCycles" );
-	InitFunc         = (void (__cdecl *)(void))  GetProcAddress( (HMODULE)m_hDll, "InitiateRSP" );
-	RomClosed        = (void (__cdecl *)(void))  GetProcAddress( (HMODULE)m_hDll, "RomClosed" );
-	RomOpen          = (void (__cdecl *)(void))  GetProcAddress( (HMODULE)m_hDll, "RomOpen" );
-	CloseDLL         = (void (__cdecl *)(void))  GetProcAddress( (HMODULE)m_hDll, "CloseDLL" );
-	Config           = (void (__cdecl *)(DWORD)) GetProcAddress( (HMODULE)m_hDll, "DllConfig" );
-	GetDebugInfo     = (void (__cdecl *)(RSPDEBUG_INFO *))GetProcAddress( (HMODULE)m_hDll, "GetRspDebugInfo" );
-	InitiateDebugger = (void (__cdecl *)(DEBUG_INFO))GetProcAddress( (HMODULE)m_hDll, "InitiateRSPDebugger" );
-	EnableDebugging  = (void (__cdecl *)(BOOL))GetProcAddress( (HMODULE)m_hDll, "EnableDebugging" );
+	// Find entries for functions in DLL
+	LoadFunction(InitiateRSP);
+	LoadFunction(DoRspCycles);
+	_LoadFunction("GetRspDebugInfo", GetDebugInfo);
+	_LoadFunction("InitiateRSPDebugger", InitiateDebugger);
+	LoadFunction(EnableDebugging);
 	if (EnableDebugging == NULL) { EnableDebugging = DummyFunc1; }
 
-	//version 102 functions
-	PluginOpened     = (void (__cdecl *)(void))GetProcAddress( (HMODULE)m_hDll, "PluginLoaded" );
-
 	//Make sure dll had all needed functions
-	if (DoRspCycles == NULL) { UnloadPlugin(); return; }
-	if (InitFunc    == NULL) { UnloadPlugin(); return; }
-	if (RomClosed   == NULL) { UnloadPlugin(); return; }
-	if (CloseDLL    == NULL) { UnloadPlugin(); return; }
-
-	SetSettingInfo3 = (void (__cdecl *)(PLUGIN_SETTINGS3 *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo3" );
-	if (SetSettingInfo3)
+	if (DoRspCycles == NULL
+		|| InitiateRSP == NULL
+		|| (m_PluginInfo.Version >= 0x0102
+		&& PluginLoaded == NULL))
 	{
-		PLUGIN_SETTINGS3 info;
-		info.FlushSettings = (void (*)( void * handle))CSettings::FlushSettings;
-		SetSettingInfo3(&info);
-	}
-
-	SetSettingInfo2 = (void (__cdecl *)(PLUGIN_SETTINGS2 *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo2" );
-	if (SetSettingInfo2)
-	{
-		PLUGIN_SETTINGS2 info;
-		info.FindSystemSettingId = (unsigned int (*)( void * handle, const char * ))CSettings::FindSetting;
-		SetSettingInfo2(&info);
-	}
-
-	SetSettingInfo   = (void (__cdecl *)(PLUGIN_SETTINGS *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo" );
-	if (SetSettingInfo)
-	{
-		PLUGIN_SETTINGS info;
-		info.dwSize = sizeof(PLUGIN_SETTINGS);
-		info.DefaultStartRange = FirstRSPDefaultSet;
-		info.SettingStartRange = FirstRSPSettings;
-		info.MaximumSettings   = MaxPluginSetting;
-		info.NoDefault         = Default_None;
-		info.DefaultLocation   = g_Settings->LoadDword(Setting_UseFromRegistry) ? SettingType_Registry : SettingType_CfgFile;
-		info.handle            = g_Settings;
-		info.RegisterSetting   = (void (*)(void *,int,int,SettingDataType,SettingType,const char *,const char *, DWORD))CSettings::RegisterSetting;
-		info.GetSetting        = (unsigned int (*)( void * handle, int ID ))CSettings::GetSetting;
-		info.GetSettingSz      = (const char * (*)( void *, int, char *, int ))CSettings::GetSettingSz;
-		info.SetSetting        = (void (*)(void *,int,unsigned int))CSettings::SetSetting;
-		info.SetSettingSz      = (void (*)(void *,int,const char *))CSettings::SetSettingSz;
-		info.UseUnregisteredSetting = NULL;
-
-		SetSettingInfo(&info);
-		//g_Settings->UnknownSetting_RSP = info.UseUnregisteredSetting;
-	}
-
-	if (m_PluginInfo.Version >= 0x0102)
-	{
-		if (PluginOpened    == NULL) { UnloadPlugin(); return; }
-
-		PluginOpened();
-	}
-
-	//Get debug info if able
-	if (GetDebugInfo != NULL) { GetDebugInfo(&m_RSPDebug); }
-
-}
-
-CRSP_Plugin::~CRSP_Plugin (void) {
-	Close();
-	UnloadPlugin();
-}
-
-bool CRSP_Plugin::Initiate ( CPlugins * Plugins, CN64System * System ) 
-{
-	//Get DLL information
-	void (__cdecl *GetDllInfo) ( PLUGIN_INFO * PluginInfo );
-	GetDllInfo = (void (__cdecl *)(PLUGIN_INFO *))GetProcAddress( (HMODULE)m_hDll, "GetDllInfo" );
-	if (GetDllInfo == NULL) { return false; }
-
-	PLUGIN_INFO PluginInfo;
-	GetDllInfo(&PluginInfo);
-
-	if (PluginInfo.Version == 1 || PluginInfo.Version  == 0x100) {
+		UnloadPlugin();
 		return false;
-	//	return Initiate_1_0(System,RenderWindow);
 	}
 
-	typedef struct {
-		HINSTANCE hInst;
-		BOOL MemoryBswaped;    /* If this is set to TRUE, then the memory has been pre
-								  bswap on a dword (32 bits) boundry */
-		BYTE * RDRAM;
-		BYTE * DMEM;
-		BYTE * IMEM;
+	if (PluginLoaded != NULL)
+		PluginLoaded();
 
-		DWORD * MI__INTR_REG;
+	// Get debug info if able
+	if (GetDebugInfo != NULL)
+		GetDebugInfo(&m_RSPDebug);
 
-		DWORD * SP__MEM_ADDR_REG;
-		DWORD * SP__DRAM_ADDR_REG;
-		DWORD * SP__RD_LEN_REG;
-		DWORD * SP__WR_LEN_REG;
-		DWORD * SP__STATUS_REG;
-		DWORD * SP__DMA_FULL_REG;
-		DWORD * SP__DMA_BUSY_REG;
-		DWORD * SP__PC_REG;
-		DWORD * SP__SEMAPHORE_REG;
+	return true;
+}
 
-		DWORD * DPC__START_REG;
-		DWORD * DPC__END_REG;
-		DWORD * DPC__CURRENT_REG;
-		DWORD * DPC__STATUS_REG;
-		DWORD * DPC__CLOCK_REG;
-		DWORD * DPC__BUFBUSY_REG;
-		DWORD * DPC__PIPEBUSY_REG;
-		DWORD * DPC__TMEM_REG;
+bool CRSP_Plugin::Initiate(CPlugins * Plugins, CN64System * System)
+{
+	if (m_PluginInfo.Version == 1
+		|| m_PluginInfo.Version == 0x100
+		|| InitiateRSP == NULL)
+		return false;
 
-		void ( __cdecl *CheckInterrupts)( void );
-		void (__cdecl *ProcessDlist)( void );
-		void (__cdecl *ProcessAlist)( void );
-		void (__cdecl *ProcessRdpList)( void );
-		void (__cdecl *ShowCFB)( void );
-	} RSP_INFO_1_1;
+	RSP_INFO_1_1 Info = { 0 };
 
-	//Get Function from DLL
-	void (__cdecl *InitiateRSP)    ( RSP_INFO_1_1 Audio_Info,DWORD * Cycles );
-	InitiateRSP = (void (__cdecl *)(RSP_INFO_1_1,DWORD *))GetProcAddress( (HMODULE)m_hDll, "InitiateRSP" );
-	if (InitiateRSP == NULL) { return false; }
+	Info.hInst = GetModuleHandle(NULL);
+	Info.CheckInterrupts = DummyCheckInterrupts;
+	Info.MemoryBswaped = (System == NULL); // only true when the system's not yet loaded
 
-	RSP_INFO_1_1 Info;
-	memset(&Info,0,sizeof(Info));
-	//We are initilizing the plugin before any rom is loaded so we do not have any correct
-	//paramaters here .. just needed to we can config the DLL
-
-	if (System == NULL) 
+	// We are initializing the plugin before any rom is loaded so we do not have any correct
+	// parameters here.. just needed to we can config the DLL.
+	if (System == NULL)
 	{
 		BYTE Buffer[100];
 		DWORD Value = 0;
 
-		Info.CheckInterrupts   = DummyCheckInterrupts;
-		Info.ProcessDlist      = DummyCheckInterrupts;
-		Info.ProcessRdpList    = DummyCheckInterrupts;
-		Info.ShowCFB           = DummyCheckInterrupts;
-		Info.ProcessAlist      = DummyCheckInterrupts;
+		Info.ProcessDlist = DummyCheckInterrupts;
+		Info.ProcessRdpList = DummyCheckInterrupts;
+		Info.ShowCFB = DummyCheckInterrupts;
+		Info.ProcessAlist = DummyCheckInterrupts;
 
-		Info.hInst             = GetModuleHandle(NULL);;
-		Info.RDRAM             = Buffer;
-		Info.DMEM              = Buffer;
-		Info.IMEM              = Buffer;
-		Info.MemoryBswaped     = TRUE;
-		
-		Info.MI__INTR_REG      = &Value;
-			
-		Info.SP__MEM_ADDR_REG  = &Value;
+		Info.RDRAM = Buffer;
+		Info.DMEM = Buffer;
+		Info.IMEM = Buffer;
+
+		Info.MI__INTR_REG = &Value;
+
+		Info.SP__MEM_ADDR_REG = &Value;
 		Info.SP__DRAM_ADDR_REG = &Value;
-		Info.SP__RD_LEN_REG    = &Value;
-		Info.SP__WR_LEN_REG    = &Value;
-		Info.SP__STATUS_REG    = &Value;
-		Info.SP__DMA_FULL_REG  = &Value;
-		Info.SP__DMA_BUSY_REG  = &Value;
-		Info.SP__PC_REG        = &Value;
+		Info.SP__RD_LEN_REG = &Value;
+		Info.SP__WR_LEN_REG = &Value;
+		Info.SP__STATUS_REG = &Value;
+		Info.SP__DMA_FULL_REG = &Value;
+		Info.SP__DMA_BUSY_REG = &Value;
+		Info.SP__PC_REG = &Value;
 		Info.SP__SEMAPHORE_REG = &Value;
-			
-		Info.DPC__START_REG    = &Value;
-		Info.DPC__END_REG      = &Value;
-		Info.DPC__CURRENT_REG  = &Value;
-		Info.DPC__STATUS_REG   = &Value;
-		Info.DPC__CLOCK_REG    = &Value;
-		Info.DPC__BUFBUSY_REG  = &Value;
-		Info.DPC__PIPEBUSY_REG = &Value;
-		Info.DPC__TMEM_REG     = &Value;
 
-		InitiateRSP(Info,&m_CycleCount);
-		m_Initilized = TRUE;
-		//jabo had a bug so I call CreateThread so his dllmain gets called again
-		DWORD ThreadID;
-		HANDLE hthread = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)DummyFunction,NULL,0, &ThreadID);	
-		CloseHandle(hthread);
-		Sleep(100);
-		return m_Initilized;
+		Info.DPC__START_REG = &Value;
+		Info.DPC__END_REG = &Value;
+		Info.DPC__CURRENT_REG = &Value;
+		Info.DPC__STATUS_REG = &Value;
+		Info.DPC__CLOCK_REG = &Value;
+		Info.DPC__BUFBUSY_REG = &Value;
+		Info.DPC__PIPEBUSY_REG = &Value;
+		Info.DPC__TMEM_REG = &Value;
+	}
+	// Send initialization information to the DLL
+	else
+	{
+		Info.ProcessDlist = Plugins->Gfx()->ProcessDList;
+		Info.ProcessRdpList = Plugins->Gfx()->ProcessRDPList;
+		Info.ShowCFB = Plugins->Gfx()->ShowCFB;
+		Info.ProcessAlist = Plugins->Audio()->ProcessAList;
+
+		Info.RDRAM = g_MMU->Rdram();
+		Info.DMEM = g_MMU->Dmem();
+		Info.IMEM = g_MMU->Imem();
+
+		Info.MI__INTR_REG = &g_Reg->m_RspIntrReg;
+
+		Info.SP__MEM_ADDR_REG = &g_Reg->SP_MEM_ADDR_REG;
+		Info.SP__DRAM_ADDR_REG = &g_Reg->SP_DRAM_ADDR_REG;
+		Info.SP__RD_LEN_REG = &g_Reg->SP_RD_LEN_REG;
+		Info.SP__WR_LEN_REG = &g_Reg->SP_WR_LEN_REG;
+		Info.SP__STATUS_REG = &g_Reg->SP_STATUS_REG;
+		Info.SP__DMA_FULL_REG = &g_Reg->SP_DMA_FULL_REG;
+		Info.SP__DMA_BUSY_REG = &g_Reg->SP_DMA_BUSY_REG;
+		Info.SP__PC_REG = &g_Reg->SP_PC_REG;
+		Info.SP__SEMAPHORE_REG = &g_Reg->SP_SEMAPHORE_REG;
+
+		Info.DPC__START_REG = &g_Reg->DPC_START_REG;
+		Info.DPC__END_REG = &g_Reg->DPC_END_REG;
+		Info.DPC__CURRENT_REG = &g_Reg->DPC_CURRENT_REG;
+		Info.DPC__STATUS_REG = &g_Reg->DPC_STATUS_REG;
+		Info.DPC__CLOCK_REG = &g_Reg->DPC_CLOCK_REG;
+		Info.DPC__BUFBUSY_REG = &g_Reg->DPC_BUFBUSY_REG;
+		Info.DPC__PIPEBUSY_REG = &g_Reg->DPC_PIPEBUSY_REG;
+		Info.DPC__TMEM_REG = &g_Reg->DPC_TMEM_REG;
 	}
 
-	//Send Initilization information to the DLL
-	Info.CheckInterrupts   = DummyCheckInterrupts;
-	Info.ProcessDlist      = Plugins->Gfx()->ProcessDList;
-	Info.ProcessRdpList    = Plugins->Gfx()->ProcessRDPList;
-	Info.ShowCFB           = Plugins->Gfx()->ShowCFB;
-	Info.ProcessAlist      = Plugins->Audio()->ProcessAList;
-
-	Info.hInst             = GetModuleHandle(NULL);;
-	Info.RDRAM             = g_MMU->Rdram();
-	Info.DMEM              = g_MMU->Dmem();
-	Info.IMEM              = g_MMU->Imem();
-	Info.MemoryBswaped     = FALSE;
-
-	Info.MI__INTR_REG      = &g_Reg->m_RspIntrReg;
-		
-	Info.SP__MEM_ADDR_REG  = &g_Reg->SP_MEM_ADDR_REG;
-	Info.SP__DRAM_ADDR_REG = &g_Reg->SP_DRAM_ADDR_REG;
-	Info.SP__RD_LEN_REG    = &g_Reg->SP_RD_LEN_REG;
-	Info.SP__WR_LEN_REG    = &g_Reg->SP_WR_LEN_REG;
-	Info.SP__STATUS_REG    = &g_Reg->SP_STATUS_REG;
-	Info.SP__DMA_FULL_REG  = &g_Reg->SP_DMA_FULL_REG;
-	Info.SP__DMA_BUSY_REG  = &g_Reg->SP_DMA_BUSY_REG;
-	Info.SP__PC_REG        = &g_Reg->SP_PC_REG;
-	Info.SP__SEMAPHORE_REG = &g_Reg->SP_SEMAPHORE_REG;
-		
-	Info.DPC__START_REG    = &g_Reg->DPC_START_REG;
-	Info.DPC__END_REG      = &g_Reg->DPC_END_REG;
-	Info.DPC__CURRENT_REG  = &g_Reg->DPC_CURRENT_REG;
-	Info.DPC__STATUS_REG   = &g_Reg->DPC_STATUS_REG;
-	Info.DPC__CLOCK_REG    = &g_Reg->DPC_CLOCK_REG;
-	Info.DPC__BUFBUSY_REG  = &g_Reg->DPC_BUFBUSY_REG;
-	Info.DPC__PIPEBUSY_REG = &g_Reg->DPC_PIPEBUSY_REG;
-	Info.DPC__TMEM_REG     = &g_Reg->DPC_TMEM_REG;
-
-	InitiateRSP(Info,&m_CycleCount);
+	// NOTE: Sleep(100) call removed after InitiateRSP() in the System == NULL condition.
+	InitiateRSP(Info, &m_CycleCount);
 	m_Initilized = true;
 
 	//jabo had a bug so I call CreateThread so his dllmain gets called again
 	DWORD ThreadID;
-	HANDLE hthread = CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)DummyFunction,NULL,0, &ThreadID);	
+	HANDLE hthread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)DummyFunction, NULL, 0, &ThreadID);
 	CloseHandle(hthread);
 	return m_Initilized;
 }
 
-void CRSP_Plugin::Close(void) {
-	if (m_RomOpen) 
-	{
-		RomClose();
-	}
-	if (m_Initilized) 
-	{
-		CloseDLL();
-		m_Initilized = false;
-	}
-}
-
-void CRSP_Plugin::RomOpened  ( void )
+void CRSP_Plugin::UnloadPlugin()
 {
-	//Real system ... then make the file as open
-	if (!m_RomOpen)
-	{
-		if (RomOpen)
-		{
-			RomOpen();
-		}
-		m_RomOpen = true;
-	}
-}
+	CPlugin::UnloadPlugin();
 
-void CRSP_Plugin::RomClose  ( void )
-{
-	if (m_RomOpen)
-	{
-		RomClosed();
-		m_RomOpen = false;
-	}
-}
-
-void CRSP_Plugin::GameReset(void)
-{
-	if (m_RomOpen) 
-	{
-		RomClose();
-		RomOpened();
-	}
-}
-
-void CRSP_Plugin::UnloadPlugin(void) {
-	if (m_hDll != NULL ) {
-		FreeLibrary((HMODULE)m_hDll);
-		m_hDll = NULL;
-	}
-	memset(&m_RSPDebug,0,sizeof(m_RSPDebug));
-	memset(&m_PluginInfo,0,sizeof(m_PluginInfo));
-	DoRspCycles      = NULL;
-	RomClosed        = NULL;
-	Config           = NULL;
-	CloseDLL         = NULL;
-	SetSettingInfo   = NULL;
-	EnableDebugging  = NULL;
-	GetDebugInfo     = NULL;
-	PluginOpened     = NULL;
+	memset(&m_RSPDebug, 0, sizeof(m_RSPDebug));
+	DoRspCycles = NULL;
+	EnableDebugging = NULL;
+	GetDebugInfo = NULL;
 	InitiateDebugger = NULL;
 }
 
-void CRSP_Plugin::ProcessMenuItem (int id )
+void CRSP_Plugin::ProcessMenuItem(int id)
 {
 	if (m_RSPDebug.ProcessMenuItem)
 	{
-		m_RSPDebug.ProcessMenuItem(id); 
+		m_RSPDebug.ProcessMenuItem(id);
 	}
+}
+
+CRSP_Plugin::~CRSP_Plugin()
+{
+	Close();
+	UnloadPlugin();
 }

--- a/Source/Project64/Plugins/RSP Plugin.h
+++ b/Source/Project64/Plugins/RSP Plugin.h
@@ -10,7 +10,7 @@
 ****************************************************************************/
 #pragma once
 
-class CRSP_Plugin
+class CRSP_Plugin : public CPlugin
 {
 	typedef struct {
 		/* Menu */
@@ -46,46 +46,69 @@ class CRSP_Plugin
 	} DEBUG_INFO;
 
 public:
-	CRSP_Plugin  ( const char * FileName);
-	~CRSP_Plugin ( void );
+	CRSP_Plugin(const char * FileName);
+	~CRSP_Plugin();
 
-	bool Initiate   ( CPlugins * Plugins, CN64System * System );
-	bool Initilized ( void ) { return m_Initilized; }
-	void Close      ( void );
-	void RomOpened  ( void );
-	void RomClose   ( void );
-	void GameReset  ( void );
-	stdstr PluginName ( void ) const { return m_PluginInfo.Name; }
+	virtual int GetDefaultSettingStartRange() const { return FirstRSPDefaultSet; }
+	virtual int GetSettingStartRange() const { return FirstRSPSettings; }
 
-	void  (__cdecl *Config)          ( DWORD hParent );
-	DWORD (__cdecl *DoRspCycles)     ( DWORD );
-	void  (__cdecl *EnableDebugging) ( BOOL Enable );
+	bool Initiate(CPlugins * Plugins, CN64System * System);
+
+	typedef struct {
+		HINSTANCE hInst;
+		BOOL MemoryBswaped;    /* If this is set to TRUE, then the memory has been pre
+							   bswap on a dword (32 bits) boundry */
+		BYTE * RDRAM;
+		BYTE * DMEM;
+		BYTE * IMEM;
+
+		DWORD * MI__INTR_REG;
+
+		DWORD * SP__MEM_ADDR_REG;
+		DWORD * SP__DRAM_ADDR_REG;
+		DWORD * SP__RD_LEN_REG;
+		DWORD * SP__WR_LEN_REG;
+		DWORD * SP__STATUS_REG;
+		DWORD * SP__DMA_FULL_REG;
+		DWORD * SP__DMA_BUSY_REG;
+		DWORD * SP__PC_REG;
+		DWORD * SP__SEMAPHORE_REG;
+
+		DWORD * DPC__START_REG;
+		DWORD * DPC__END_REG;
+		DWORD * DPC__CURRENT_REG;
+		DWORD * DPC__STATUS_REG;
+		DWORD * DPC__CLOCK_REG;
+		DWORD * DPC__BUFBUSY_REG;
+		DWORD * DPC__PIPEBUSY_REG;
+		DWORD * DPC__TMEM_REG;
+
+		void(__cdecl *CheckInterrupts)(void);
+		void(__cdecl *ProcessDlist)(void);
+		void(__cdecl *ProcessAlist)(void);
+		void(__cdecl *ProcessRdpList)(void);
+		void(__cdecl *ShowCFB)(void);
+	} RSP_INFO_1_1;
+
+	void(__cdecl *InitiateRSP)	(RSP_INFO_1_1 Audio_Info, DWORD * Cycles);
+	DWORD(__cdecl *DoRspCycles)	(DWORD);
+	void(__cdecl *EnableDebugging)(BOOL Enable);
 
 	HMENU GetDebugMenu (void ) { return m_RSPDebug.hRSPMenu; }
-	void ProcessMenuItem (int id );
+	void ProcessMenuItem(int id);
 
-private:
+	void UnloadPlugin(); 
+
+protected:
 	CRSP_Plugin(void);							// Disable default constructor
 	CRSP_Plugin(const CRSP_Plugin&);			// Disable copy constructor
 	CRSP_Plugin& operator=(const CRSP_Plugin&);	// Disable assignment
 
-	void Init ( const char * FileName );
-	bool Initiate_1_0         ( CPlugins * Plugins, CN64System * System );
-	void UnloadPlugin         ( void );
-	
-	RSPDEBUG_INFO m_RSPDebug;
-	void        * m_hDll;	
-	bool          m_Initilized, m_RomOpen;
-	DWORD         m_CycleCount;
-	PLUGIN_INFO   m_PluginInfo;
+	bool Init(const char * FileName);
 
-	void (__cdecl *CloseDLL)         ( void );
-	void (__cdecl *RomOpen)          ( void );
-	void (__cdecl *RomClosed)        ( void );
-	void (__cdecl *GetDebugInfo)     ( RSPDEBUG_INFO * GFXDebugInfo );
-	void (__cdecl *InitiateDebugger) ( DEBUG_INFO DebugInfo);
-	void (__cdecl *PluginOpened)     ( void );
-	void (__cdecl *SetSettingInfo)   ( PLUGIN_SETTINGS * info );
-	void (__cdecl *SetSettingInfo2)  ( PLUGIN_SETTINGS2 * info );
-	void (__cdecl *SetSettingInfo3)  ( PLUGIN_SETTINGS3 * info );
+	RSPDEBUG_INFO m_RSPDebug;
+	DWORD         m_CycleCount;
+
+	void(__cdecl *GetDebugInfo)     (RSPDEBUG_INFO * GFXDebugInfo);
+	void(__cdecl *InitiateDebugger) (DEBUG_INFO DebugInfo);
 };

--- a/Source/Project64/Project64.vcproj
+++ b/Source/Project64/Project64.vcproj
@@ -649,6 +649,10 @@
 				Name="Plugin Source"
 				>
 				<File
+					RelativePath="Plugins\Plugin Base.cpp"
+					>
+				</File>
+				<File
 					RelativePath="Plugins\Audio Plugin.cpp"
 					>
 				</File>
@@ -1401,6 +1405,10 @@
 			<Filter
 				Name="Plugin Headers"
 				>
+				<File
+					RelativePath="Plugins\Plugin Base.h"
+					>
+				</File>
 				<File
 					RelativePath="Plugins\Audio Plugin.h"
 					>

--- a/Source/Project64/Project64.vcxproj
+++ b/Source/Project64/Project64.vcxproj
@@ -56,6 +56,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="Plugins\Plugin Base.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
@@ -197,6 +198,7 @@
     <ClInclude Include="Multilanguage.h" />
     <ClInclude Include="N64 System.h" />
     <ClInclude Include="Plugin.h" />
+    <ClInclude Include="Plugins\Plugin Base.h" />
     <ClInclude Include="Settings.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="User Interface.h" />

--- a/Source/Project64/Project64.vcxproj.filters
+++ b/Source/Project64/Project64.vcxproj.filters
@@ -417,6 +417,9 @@
     <ClCompile Include="3rd Party\zlib\zip.c">
       <Filter>Source Files\3rd Party Source\ZLib Source</Filter>
     </ClCompile>
+    <ClCompile Include="Plugins\Plugin Base.cpp">
+      <Filter>Source Files\Plugin Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="User Interface\Bitmaps\AboutScreenBottom.bmp">
@@ -838,6 +841,9 @@
     </ClInclude>
     <ClInclude Include="3rd Party\zlib\ZLIB.H">
       <Filter>Header Files\3rd Party Headers\Zlib Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="Plugins\Plugin Base.h">
+      <Filter>Header Files\Plugin Headers</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Source/Project64/User Interface/Main Menu Class.cpp
+++ b/Source/Project64/User Interface/Main Menu Class.cpp
@@ -888,24 +888,24 @@ void CMainMenu::FillOutMenu ( HMENU hMenu ) {
 	OptionMenu.push_back(MENU_ITEM(SPLITER                   ));
 
 	Item.Reset(ID_OPTIONS_CONFIG_GFX, MENU_CONFG_GFX,m_ShortCuts.ShortCutString(ID_OPTIONS_CONFIG_GFX,AccessLevel));
-	if (g_Plugins->Gfx() == NULL || g_Plugins->Gfx()->Config == NULL) { 
+	if (g_Plugins->Gfx() == NULL || g_Plugins->Gfx()->DllConfig == NULL) {
 		Item.ItemEnabled = false; 
 	}
 	OptionMenu.push_back(Item);
 	Item.Reset(ID_OPTIONS_CONFIG_AUDIO, MENU_CONFG_AUDIO,m_ShortCuts.ShortCutString(ID_OPTIONS_CONFIG_AUDIO,AccessLevel));
-	if (g_Plugins->Audio() == NULL || g_Plugins->Audio()->Config == NULL) { 
+	if (g_Plugins->Audio() == NULL || g_Plugins->Audio()->DllConfig == NULL) {
 		Item.ItemEnabled = false; 
 	}
 	OptionMenu.push_back(Item);
 	if (!inBasicMode) {
 		Item.Reset(ID_OPTIONS_CONFIG_RSP, MENU_CONFG_RSP,m_ShortCuts.ShortCutString(ID_OPTIONS_CONFIG_RSP,AccessLevel));
-		if (g_Plugins->RSP() == NULL || g_Plugins->RSP()->Config == NULL) { 
+		if (g_Plugins->RSP() == NULL || g_Plugins->RSP()->DllConfig == NULL) {
 			Item.ItemEnabled = false; 
 		}
 		OptionMenu.push_back(Item);
 	}
 	Item.Reset(ID_OPTIONS_CONFIG_CONT, MENU_CONFG_CTRL,m_ShortCuts.ShortCutString(ID_OPTIONS_CONFIG_CONT,AccessLevel));
-	if (g_Plugins->Control() == NULL || g_Plugins->Control()->Config == NULL) { 
+	if (g_Plugins->Control() == NULL || g_Plugins->Control()->DllConfig == NULL) {
 		Item.ItemEnabled = false; 
 	}
 	OptionMenu.push_back(Item);

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - Plugin.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - Plugin.cpp
@@ -115,23 +115,14 @@ void CGamePluginPage::ShowAboutButton ( int id )
 		return;
 	}
 	
-	//Load the plugin
-	UINT LastErrorMode = SetErrorMode( SEM_FAILCRITICALERRORS );
-	HMODULE hLib = LoadLibrary(Plugin->FullPath);		
-	SetErrorMode(LastErrorMode);
-	if (hLib == NULL)
-	{
-		return;
-	}
-	
-	//Get DLL about
-	void (__cdecl *DllAbout) ( HWND hWnd );
-	DllAbout = (void (__cdecl *)(HWND))GetProcAddress( hLib, "DllAbout" );
-	
-	//call the function from the dll
-	DllAbout(m_hWnd);
+	// Load plugin on demand
+	CPlugin * plugin = CPlugin::InitPlugin(Plugin->FullPath);
 
-	FreeLibrary(hLib);
+	if (plugin != NULL && plugin->DllAbout != NULL)
+		plugin->DllAbout(m_hWnd);
+
+	// ... and free. Not needed anymore.
+	delete plugin;
 }
 
 void CGamePluginPage::PluginItemChanged ( int id, int AboutID, bool bSetChanged )

--- a/Source/Project64/User Interface/Settings/Settings Page - Plugin.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Plugin.cpp
@@ -107,23 +107,14 @@ void COptionPluginPage::ShowAboutButton ( int id )
 		return;
 	}
 	
-	//Load the plugin
-	UINT LastErrorMode = SetErrorMode( SEM_FAILCRITICALERRORS );
-	HMODULE hLib = LoadLibrary(Plugin->FullPath);		
-	SetErrorMode(LastErrorMode);
-	if (hLib == NULL)
-	{
-		return;
-	}
-	
-	//Get DLL about
-	void (__cdecl *DllAbout) ( HWND hWnd );
-	DllAbout = (void (__cdecl *)(HWND))GetProcAddress( hLib, "DllAbout" );
-	
-	//call the function from the dll
-	DllAbout(m_hWnd);
+	// Load plugin on demand
+	CPlugin * plugin = CPlugin::InitPlugin(Plugin->FullPath);
 
-	FreeLibrary(hLib);
+	if (plugin != NULL && plugin->DllAbout != NULL)
+		plugin->DllAbout(m_hWnd);
+
+	// ... and free. Not needed anymore.
+	delete plugin;
 }
 
 void COptionPluginPage::PluginItemChanged ( int id, int AboutID, bool bSetChanged )


### PR DESCRIPTION
Implement @Twostars cleanup of the plugin system, makes all plugin (RSP,AUDIO,GFX and CONTROLLER) derive functions from a singular class. Cleans up the code significantly and removes the need to have duplicate code in every seperate plugin file that does the same thing. Should also make it much easier to modify and add new specifications that apply to all plugins.