### PR TITLE
fixes to linking (and compiling N-Rage) in VS2010

### DIFF
--- a/Source/Project64/Project64.vcproj
+++ b/Source/Project64/Project64.vcproj
@@ -51,6 +51,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				SubSystem="2"
+				RandomizedBaseAddress="1"
 				FixedBaseAddress="2"
 				DataExecutionPrevention="1"
 			/>

--- a/Source/nragev20/XInputController.h
+++ b/Source/nragev20/XInputController.h
@@ -33,6 +33,9 @@
 #include <oleauto.h>
 //#include <wmsstd.h> <-- only needed for SAFE_RELEASE(x)
 
+/* fixes undefined FILE, etc. type errors in MSVC 2010 build -- cxd4 */
+#include <stdio.h>
+
 #ifndef SAFE_RELEASE		// when Windows Media Device M? is not present
 #define SAFE_RELEASE(x) \
    if(x != NULL)        \


### PR DESCRIPTION
For some reason, /DYNAMICBASE was only off by default in the VS2008 project file for Project64 executable.  When attempting to build in VS2010 (haven't looked at VS2013) from converting the solution over to VS2010 format, the linker fails to build Project64.exe in **Debug** mode only, simply because the makefile paradoxically demands a fixed base address while also defaulting to /DYNAMICBASE being enabled (when really, it should be disabled, as it was when building with VS2008).

Well for whatever reason it was off as it should be, by default for 2008, but is on by default in 2010.  So I explicitly added a fixed setting to manually make it off in the 2008 file, so that when people go to build in MSVC 2010 and convert the project file over so it will recognize it, that this setting is copied so the link succeeds.

Similarly, I don't know why N-Rage compiles successfully in VS2008, but not in VS2010.  Must be some setting in the solution that didn't get copied over in the solution.  Either way, the compiler errors in N-Rage were all from using `stdio.h` symbols, without including `stdio.h`, so I #include'd it.  It now compiles.