### PR TITLE
Fixed some problems with GetInstructionInfo

### DIFF
--- a/Source/RSP/Recompiler Analysis.c
+++ b/Source/RSP/Recompiler Analysis.c
@@ -1399,7 +1399,11 @@ void GetInstructionInfo(DWORD PC, OPCODE * RspOp, OPCODE_INFO * info) {
 			info->DestReg = RspOp->rt;
 			info->SourceReg0 = (DWORD)-1;
 			info->SourceReg1 = (DWORD)-1;
-			info->flags = COPO_MF_Instruction | GPR_Instruction | Load_Operation;
+			if (RspOp->rd == 0x4 || RspOp->rd == 0x7){
+				info->flags = InvalidOpcode;
+			} else{
+				info->flags = COPO_MF_Instruction | GPR_Instruction | Load_Operation;
+			}			
 			break;
 
 		case RSP_COP0_MT:

--- a/Source/RSP/Recompiler Analysis.c
+++ b/Source/RSP/Recompiler Analysis.c
@@ -102,6 +102,7 @@ BOOL IsNextInstructionMmx(DWORD PC) {
 				return TRUE;
 
 		case RSP_VECTOR_VADD:
+		case RSP_VECTOR_VSUB:
 			/* Requires no accumulator write! & No flags! */
 			if (WriteToAccum(Low16BitAccum, CompilePC) == TRUE) {
 				return FALSE;
@@ -1421,16 +1422,25 @@ void GetInstructionInfo(DWORD PC, OPCODE * RspOp, OPCODE_INFO * info) {
 				break;
 
 			case RSP_VECTOR_VMULF:
+			case RSP_VECTOR_VMULU:
 			case RSP_VECTOR_VMUDL:
 			case RSP_VECTOR_VMUDM:
 			case RSP_VECTOR_VMUDN:
 			case RSP_VECTOR_VMUDH:
+			case RSP_VECTOR_VABS:
+			case RSP_VECTOR_VAND:
+			case RSP_VECTOR_VOR:
+			case RSP_VECTOR_VXOR:
+			case RSP_VECTOR_VNAND:
+			case RSP_VECTOR_VNOR:
+			case RSP_VECTOR_VNXOR:
 				info->DestReg = RspOp->sa;
 				info->SourceReg0 = RspOp->rd;
 				info->SourceReg1 = RspOp->rt;
 				info->flags = VEC_Instruction | VEC_ResetAccum | Accum_Operation;
 				break;
 			case RSP_VECTOR_VMACF:
+			case RSP_VECTOR_VMACU:
 			case RSP_VECTOR_VMADL:
 			case RSP_VECTOR_VMADM:
 			case RSP_VECTOR_VMADN:
@@ -1440,23 +1450,13 @@ void GetInstructionInfo(DWORD PC, OPCODE * RspOp, OPCODE_INFO * info) {
 				info->SourceReg1 = RspOp->rt;
 				info->flags = VEC_Instruction | VEC_Accumulate | Accum_Operation;
 				break;
-			case RSP_VECTOR_VABS:
 			case RSP_VECTOR_VADD:
 			case RSP_VECTOR_VADDC:
 			case RSP_VECTOR_VSUB:
 			case RSP_VECTOR_VSUBC:
-			case RSP_VECTOR_VAND:
-			case RSP_VECTOR_VOR:
-			case RSP_VECTOR_VXOR:
-			case RSP_VECTOR_VNXOR:
 			case RSP_VECTOR_VCR:
 			case RSP_VECTOR_VCH:
 			case RSP_VECTOR_VCL:
-			case RSP_VECTOR_VRCP:
-			case RSP_VECTOR_VRCPL:
-			case RSP_VECTOR_VRCPH:
-			case RSP_VECTOR_VRSQL:
-			case RSP_VECTOR_VRSQH:
 			case RSP_VECTOR_VLT:
 			case RSP_VECTOR_VEQ:
 			case RSP_VECTOR_VGE:
@@ -1468,19 +1468,22 @@ void GetInstructionInfo(DWORD PC, OPCODE * RspOp, OPCODE_INFO * info) {
 				break;
 
 			case RSP_VECTOR_VMOV:
-				info->flags = InvalidOpcode;
-			/*	info->DestReg = RspOp->sa;
+			case RSP_VECTOR_VRCP:
+			case RSP_VECTOR_VRCPL:
+			case RSP_VECTOR_VRCPH:
+			case RSP_VECTOR_VRSQL:
+			case RSP_VECTOR_VRSQH:
+				info->DestReg = RspOp->sa;
 				info->SourceReg0 = RspOp->rt;
 				info->SourceReg1 = -1;
-				info->flags = VEC_Instruction; /* Assume reset? */
+				info->flags = VEC_Instruction | VEC_ResetAccum | Accum_Operation; /* Assume reset? */
 				break;
 
 			case RSP_VECTOR_VMRG:
-				info->flags = InvalidOpcode;
-			/*	info->DestReg = RspOp->sa;
+			 	info->DestReg = RspOp->sa;
 				info->SourceReg0 = RspOp->rt;
 				info->SourceReg1 = RspOp->rd;
-				info->flags = VEC_Instruction; /* Assum reset? */
+				info->flags = VEC_Instruction | VEC_ResetAccum | Accum_Operation | Flag_Instruction; /* Assum reset? */
 				break;
 
 			case RSP_VECTOR_VSAW:


### PR DESCRIPTION
I originally was going to submit my changes for MFC0, but I decided to keep it simple. I think what messed instruction reordering up, was the fact that when RSPOpC.rd == 4 or 7 for COP0_MF, it finishes sub block. I personally would rather not have it finish sub block. That can be changed some other time i guess. There are some other changes that need to be done in MFC0 as well.

Mia Hamm should work with Instruction Reordering enabled now.