### PR TITLE
fixed almost all Glide64 warnings

### DIFF
--- a/Source/Glide64/Combine.cpp
+++ b/Source/Glide64/Combine.cpp
@@ -16007,12 +16007,15 @@ void InitCombine ()
 void ColorCombinerToExtension ()
 {
   wxUint32 ext_local, ext_local_a, ext_other, ext_other_a;
+
   switch (cmb.c_loc)
   {
   case GR_COMBINE_LOCAL_ITERATED:
     ext_local = GR_CMBX_ITRGB;
     ext_local_a = GR_CMBX_ITALPHA;
     break;
+  default:
+    FRDP("Invalid combiner locality %u.\n", cmb.c_loc);
   case GR_COMBINE_LOCAL_CONSTANT:
     ext_local = GR_CMBX_CONSTANT_COLOR;
     ext_local_a = GR_CMBX_CONSTANT_ALPHA;
@@ -16028,6 +16031,8 @@ void ColorCombinerToExtension ()
     ext_other = GR_CMBX_TEXTURE_RGB;
     ext_other_a = GR_CMBX_TEXTURE_ALPHA;
     break;
+  default:
+    FRDP("Invalid combiner flag %u.\n", cmb.c_oth);
   case GR_COMBINE_OTHER_CONSTANT:
     ext_other = GR_CMBX_CONSTANT_COLOR;
     ext_other_a = GR_CMBX_CONSTANT_ALPHA;
@@ -16373,6 +16378,8 @@ void TexColorCombinerToExtension (GrChipID_t tmu)
     tc_ext_c = GR_CMBX_OTHER_TEXTURE_ALPHA;
     tc_ext_c_invert = 1;
     break;
+  default:
+    FRDP("Invalid combiner TMU factor %u.\n", tmu_fac);
   case GR_COMBINE_FACTOR_ONE_MINUS_DETAIL_FACTOR:
     tc_ext_c = GR_CMBX_DETAIL_FACTOR;
     tc_ext_c_invert = 1;
@@ -16467,6 +16474,8 @@ void TexColorCombinerToExtension (GrChipID_t tmu)
     tc_ext_d = GR_CMBX_B;
     tc_ext_d_invert = 0;
     break;
+  default:
+    FRDP("Invalid combiner TMU function %u.\n", tmu_func);
   case GR_COMBINE_FUNCTION_SCALE_MINUS_LOCAL_ADD_LOCAL_ALPHA:
     tc_ext_a = GR_CMBX_LOCAL_TEXTURE_RGB;
     tc_ext_a_mode = GR_FUNC_MODE_ZERO;
@@ -16550,6 +16559,8 @@ void TexAlphaCombinerToExtension (GrChipID_t tmu)
     ta_ext_c = GR_CMBX_OTHER_TEXTURE_ALPHA;
     ta_ext_c_invert = 1;
     break;
+  default:
+    FRDP("Invalid combiner alpha factor %u.\n", tmu_a_fac);
   case GR_COMBINE_FACTOR_ONE_MINUS_DETAIL_FACTOR:
     ta_ext_c = GR_CMBX_DETAIL_FACTOR;
     ta_ext_c_invert = 1;
@@ -16613,6 +16624,8 @@ void TexAlphaCombinerToExtension (GrChipID_t tmu)
     ta_ext_d = GR_CMBX_B;
     ta_ext_d_invert = 0;
     break;
+  default:
+    FRDP("Invalid combiner alpha coverage function %u.\n", tmu_a_func);
   case GR_COMBINE_FUNCTION_SCALE_MINUS_LOCAL_ADD_LOCAL:
   case GR_COMBINE_FUNCTION_SCALE_MINUS_LOCAL_ADD_LOCAL_ALPHA:
     ta_ext_a = GR_CMBX_LOCAL_TEXTURE_ALPHA;

--- a/Source/Glide64/Combine.cpp
+++ b/Source/Glide64/Combine.cpp
@@ -15607,12 +15607,15 @@ void Combine ()
   left = cc_lookup[actual_combine>>24];
   right = cc_lookup[(actual_combine>>24)+1];
 
-  while (1)
-  {
+  do {
     last = current;
     current = left + ((right-left) >> 1);
     if (current == last)
+    {
+      FRDP("Warning!  Could not initialize current_combiner to valid index.\n");
+      current_combine = ~0u; /* Debug uncertain case, and fix warning (cxd4). */
       break;  // can't be found!
+    }
 
     current_combine = color_cmb_list[current].key;
     if (current_combine < actual_combine)
@@ -15621,7 +15624,7 @@ void Combine ()
       right = current;
     else
       break;  // found it!
-  }
+  } while (1);
 
   // Check if we didn't find it
   if (actual_combine != current_combine)

--- a/Source/Glide64/Combine.cpp
+++ b/Source/Glide64/Combine.cpp
@@ -15981,15 +15981,10 @@ void InitCombine ()
   if (const char * extstr = strstr(extensions, "COMBINE")) {
     if (!strncmp(extstr, "COMBINE", 7)) {
       LOG ("extensions ");
-      char strColorCombineExt[] = "grColorCombineExt";
       cmb.grColorCombineExt = (GRCOLORCOMBINEEXT) grColorCombineExt;
-      char strAlphaCombineExt[] = "grAlphaCombineExt";
       cmb.grAlphaCombineExt = (GRCOLORCOMBINEEXT)grAlphaCombineExt;
-      char strTexColorCombineExt[] = "grTexColorCombineExt";
       cmb.grTexColorCombineExt = (GRTEXCOLORCOMBINEEXT)grTexColorCombineExt ;
-      char strTexAlphaCombineExt[] = "grTexAlphaCombineExt";
       cmb.grTexAlphaCombineExt = (GRTEXCOLORCOMBINEEXT) grTexAlphaCombineExt ;
-      char strConstantColorValueExt[] = "grConstantColorValueExt";
       cmb.grConstantColorValueExt = (GRCONSTANTCOLORVALUEEXT) grConstantColorValueExt;
       if (cmb.grColorCombineExt && cmb.grAlphaCombineExt &&
         cmb.grTexColorCombineExt && cmb.grTexAlphaCombineExt)

--- a/Source/Glide64/TexBuffer.cpp
+++ b/Source/Glide64/TexBuffer.cpp
@@ -705,7 +705,12 @@ int FindTextureBuffer(wxUint32 addr, wxUint16 width)
         if (rdp.tbuff_tex->crc == 0)
         {
           rdp.tbuff_tex->crc = CalcCRC(rdp.tbuff_tex);
-          bCorrect = width == 1 || rdp.tbuff_tex->width == width || (rdp.tbuff_tex->width > 320 && rdp.tbuff_tex->width == width*2);
+          bCorrect =
+            (width == 1)
+         || (rdp.tbuff_tex->width == width)
+         || (   (rdp.tbuff_tex->width > 320)
+             && (rdp.tbuff_tex->width == (wxUint32)width*2)
+          );
         }
         else
           bCorrect = rdp.tbuff_tex->crc == CalcCRC(rdp.tbuff_tex);

--- a/Source/Glide64/TexCache.cpp
+++ b/Source/Glide64/TexCache.cpp
@@ -861,11 +861,13 @@ void TexCache ()
 
   if (fullscreen)
   {
+    int tmu_v[2];
+
+    tmu_v[0] = tmu_0;
+    tmu_v[1] = tmu_1;
     for (int i=0; i<2; i++)
     {
-      int tmu;
-      if (i==0) tmu=tmu_0;
-      else if (i==1) tmu=tmu_1;
+      const int tmu = tmu_v[i];
 
       if (tmu >= voodoo.num_tmu) continue;
 

--- a/Source/Glide64/TexLoad.h
+++ b/Source/Glide64/TexLoad.h
@@ -42,7 +42,14 @@
 #include "TexLoad16b.h"
 #include "TexLoad32b.h"
 
-wxUint32 LoadNone (wxUIntPtr dst, wxUIntPtr src, int wid_64, int height, int line, int /*real_width*/, int tile)
+wxUint32 LoadNone(
+	wxUIntPtr /*dst*/,
+	wxUIntPtr /*src*/,
+	int /*wid_64*/,
+	int /*height*/,
+	int /*line*/,
+	int /*real_width*/,
+	int /*tile*/)
 {
 	memset (texture, 0, 4096*4);
 	return (1 << 16) | GR_TEXFMT_ARGB_1555;

--- a/Source/Glide64/rdp.cpp
+++ b/Source/Glide64/rdp.cpp
@@ -3002,10 +3002,16 @@ input:    FrameBufferModifyEntry *plist
 size = size of the plist, max = 1024
 output:   none
 *******************************************************************/
+#ifdef RDP_LOGGING
 EXPORT void CALL FBWList(FrameBufferModifyEntry *plist, wxUint32 size)
+#else
+EXPORT void CALL FBWList(FrameBufferModifyEntry *plist, wxUint32)
+#endif
 {
   LOG ("FBWList ()\n");
+#ifdef RDP_LOGGING
   FRDP("FBWList. size: %d\n", size);
+#endif
 }
 
 
@@ -3018,7 +3024,7 @@ val                     val
 size            1 = wxUint8, 2 = wxUint16, 4 = wxUint32
 output:   none
 *******************************************************************/
-EXPORT void CALL FBWrite(wxUint32 addr, wxUint32 size)
+EXPORT void CALL FBWrite(wxUint32 addr, wxUint32 /*size*/)
 {
   LOG ("FBWrite ()\n");
   if (cpu_fb_ignore)

--- a/Source/Glide64/rdp.cpp
+++ b/Source/Glide64/rdp.cpp
@@ -1639,13 +1639,13 @@ static void rdp_setprimdepth()
 static void rdp_setothermode()
 {
 #define F3DEX2_SETOTHERMODE(cmd,sft,len,data) { \
-  rdp.cmd0 = (cmd<<24) | ((32-(sft)-(len))<<8) | (((len)-1)); \
-  rdp.cmd1 = data; \
+  rdp.cmd0 = (wxUint32)(((cmd)<<24) | ((32-(sft)-(len))<<8) | (((len)-1))); \
+  rdp.cmd1 = (wxUint32)(data); \
   gfx_instruction[settings.ucode][cmd] (); \
 }
 #define SETOTHERMODE(cmd,sft,len,data) { \
-  rdp.cmd0 = (cmd<<24) | ((sft)<<8) | (len); \
-  rdp.cmd1 = data; \
+  rdp.cmd0 = (wxUint32)(((cmd)<<24) | ((sft)<<8) | (len)); \
+  rdp.cmd1 = (wxUint32)(data); \
   gfx_instruction[settings.ucode][cmd] (); \
 }
 

--- a/Source/Glide64/rdp.cpp
+++ b/Source/Glide64/rdp.cpp
@@ -3003,9 +3003,9 @@ size = size of the plist, max = 1024
 output:   none
 *******************************************************************/
 #ifdef RDP_LOGGING
-EXPORT void CALL FBWList(FrameBufferModifyEntry *plist, wxUint32 size)
+EXPORT void CALL FBWList(FrameBufferModifyEntry* /*plist*/, wxUint32 size)
 #else
-EXPORT void CALL FBWList(FrameBufferModifyEntry *plist, wxUint32)
+EXPORT void CALL FBWList(FrameBufferModifyEntry* /*plist*/, wxUint32)
 #endif
 {
   LOG ("FBWList ()\n");

--- a/Source/Glide64/ucode09.h
+++ b/Source/Glide64/ucode09.h
@@ -408,7 +408,7 @@ static void uc9_mtxcat ()
     break;
   default:
     FRDP("Invalid mutex S-coordinate:  %u\n", S);
-    t = NULL; /* intentional segfault to alert for bugs in PJGlide64 (cxd4) */
+    s = NULL; /* intentional segfault to alert for bugs in PJGlide64 (cxd4) */
     break;
   }
   switch (T) {

--- a/Source/Glide64/ucode09.h
+++ b/Source/Glide64/ucode09.h
@@ -99,6 +99,8 @@ static void uc9_draw_object (wxUint8 * addr, wxUint32 type)
 {
   wxUint32 textured, vnum, vsize;
   switch (type) {
+    default: /* added to fix uninitialized variable warnings + debugging */
+      FRDP("Unknown geometric primitive type %u.\n", type);
     case 0: //null
       textured = vnum = vsize = 0;
       break;
@@ -264,6 +266,10 @@ static void uc9_fmlight ()
   case 8:
     m = (M44*)rdp.combined;
     break;
+  default:
+    m = NULL; /* allowing segfaults to debug in case of PJGlide64 bugs */
+    FRDP("Invalid FM light matrix ID %u.\n", mid);
+    break;
   }
 
   rdp.light[rdp.num_lights].r = (float)(((wxUint8*)gfx.DMEM)[(a+0)^3]) / 255.0f;
@@ -400,6 +406,10 @@ static void uc9_mtxcat ()
     s = (M44*)rdp.combined;
     LRDP("Comb * ");
     break;
+  default:
+    FRDP("Invalid mutex S-coordinate:  %u\n", S);
+    t = NULL; /* intentional segfault to alert for bugs in PJGlide64 (cxd4) */
+    break;
   }
   switch (T) {
   case 4:
@@ -413,6 +423,10 @@ static void uc9_mtxcat ()
   case 8:
     LRDP("Comb -> ");
     t = (M44*)rdp.combined;
+    break;
+  default:
+    FRDP("Invalid mutex T-coordinate:  %u\n", T);
+    t = NULL; /* intentional segfault to alert for bugs in PJGlide64 (cxd4) */
     break;
   }
   DECLAREALIGN16VAR(m[4][4]);

--- a/Source/Glitch64/main.cpp
+++ b/Source/Glitch64/main.cpp
@@ -500,8 +500,8 @@ grClipWindow( FxU32 minx, FxU32 miny, FxU32 maxx, FxU32 maxy )
     maxy = th - maxy;
     miny = th - miny;
     FxU32 tmp = maxy; maxy = miny; miny = tmp;
-    if (maxx > width) maxx = width;
-    if (maxy > height) maxy = height;
+    if ((FxI32)maxx > width) maxx = width;
+    if ((FxI32)maxy > height) maxy = height;
     if (int(minx) < 0) minx = 0;
     if (int(miny) < 0) miny = 0;
     if (maxx < minx) maxx = minx;

--- a/Source/Glitch64/main.cpp
+++ b/Source/Glitch64/main.cpp
@@ -352,7 +352,10 @@ static fb fbs[100];
 static int nb_fb = 0;
 static unsigned int curBufferAddr = 0;
 
-struct TMU_USAGE { int min, max; } tmu_usage[2] = { {0xfffffff, 0}, {0xfffffff, 0} };
+struct TMU_USAGE { unsigned long min, max; } tmu_usage[2] = {
+  { 0x0FFFFFFFul, 0x00000000ul },
+  { 0x0FFFFFFFul, 0x00000000ul },
+};
 
 struct texbuf_t {
   FxU32 start, end;
@@ -1175,8 +1178,8 @@ grSstWinClose( GrContext_t context )
   LOG("grSstWinClose(%d)\r\n", context);
 
   for (i=0; i<2; i++) {
-    tmu_usage[i].min = 0xfffffff;
-    tmu_usage[i].max = 0;
+    tmu_usage[i].min = 0x0FFFFFFFul;
+    tmu_usage[i].max = 0x00000000ul;
     invtex[i] = 0;
   }
 
@@ -1330,10 +1333,10 @@ FX_ENTRY void FX_CALL grTextureBufferExt( GrChipID_t  		tmu,
 
     int rtmu = startAddress < grTexMinAddress(GR_TMU1)? 0 : 1;
     int size = pBufferWidth*pBufferHeight*2; //grTexFormatSize(fmt);
-    if (tmu_usage[rtmu].min > pBufferAddress)
-      tmu_usage[rtmu].min = pBufferAddress;
-    if (tmu_usage[rtmu].max < pBufferAddress+size)
-      tmu_usage[rtmu].max = pBufferAddress+size;
+    if (tmu_usage[rtmu].min > pBufferAddress + 0)
+        tmu_usage[rtmu].min = pBufferAddress + 0;
+    if (tmu_usage[rtmu].max < pBufferAddress + size)
+        tmu_usage[rtmu].max = pBufferAddress + size;
     //   printf("tmu %d usage now %gMb - %gMb\n",
     //          rtmu, tmu_usage[rtmu].min/1024.0f, tmu_usage[rtmu].max/1024.0f);
 

--- a/Source/Glitch64/main.cpp
+++ b/Source/Glitch64/main.cpp
@@ -604,13 +604,15 @@ grSstWinOpenExt(
                 GrScreenRefresh_t    refresh_rate,
                 GrColorFormat_t      color_format,
                 GrOriginLocation_t   origin_location,
-                GrPixelFormat_t      pixelformat,
+                GrPixelFormat_t    /*pixelformat*/,
                 int                  nColBuffers,
                 int                  nAuxBuffers)
 {
-  LOG("grSstWinOpenExt(%d, %d, %d, %d, %d, %d %d)\r\n", hWnd, screen_resolution, refresh_rate, color_format, origin_location, nColBuffers, nAuxBuffers);
-  return grSstWinOpen(hWnd, screen_resolution, refresh_rate, color_format,
-    origin_location, nColBuffers, nAuxBuffers);
+  LOG(
+    "grSstWinOpenExt(%d, %d, %d, %d, %d, %d %d)\r\n",
+    hWnd, screen_resolution, refresh_rate, color_format, origin_location, nColBuffers, nAuxBuffers);
+  return grSstWinOpen(
+    hWnd, screen_resolution, refresh_rate, color_format, origin_location, nColBuffers, nAuxBuffers);
 }
 
 #ifdef WIN32

--- a/Source/Glitch64/main.cpp
+++ b/Source/Glitch64/main.cpp
@@ -213,7 +213,7 @@ int screen_width, screen_height;
 
 static inline void opt_glCopyTexImage2D( GLenum target,
                                         GLint level,
-                                        GLenum internalFormat,
+                                        GLint internalFormat,
                                         GLint x,
                                         GLint y,
                                         GLsizei width,


### PR DESCRIPTION
All compiler warnings (tested in VS2013 this time) in the Project64 solution have now been fixed for Glide64 with 3 exceptions.

Two of them are in the GlideHQ module.  I am not qualified to fix them...they seem to be PNG decoder regressions with texturing and I am not really a texture enhancements person so leave this to anyone else to fix.  I was reluctant enough to fix all of these warnings I already have...I usually prefer to let the official maintainer of the code fix the warnings or just copy off their methods (since it's the same coding personality throughout the rest of the project anyway which is more consistent).  I don't really know anything about GlideHQ though, just basic RDP stuff.

The other remaining warning is in Glide64 ucode06.h.  It says `d` is uninitialized potentially, even though it clearly was being read and written before even that line of the code where the warning complained.  So if I have no idea why the warning is even there, it's safest not to fix it.

I was able to safely fix all Glitch64 warnings.

In the process of fixing the "potentially uninitialized" warnings, I saw that it was often because they were getting initialized within a `switch` statement, where the expression being `switch`'d on was not necessarily one encompassing all the possible case indices.  To fix this, I added a `default` case to guarantee initialization, initializing things like pointers, to NULL pointers, encouraging a crash in Project64 in case such buggy behavior within PJGlide64 should arise so that it can be debugged later.