### PR TITLE
Start to debug memory leaks or RDP messages in Glide64 debug.

### DIFF
--- a/Source/Glide64/Combine.cpp
+++ b/Source/Glide64/Combine.cpp
@@ -15612,7 +15612,7 @@ void Combine ()
     current = left + ((right-left) >> 1);
     if (current == last)
     {
-      FRDP("Warning!  Could not initialize current_combiner to valid index.\n");
+      FRDP_E("Could not initialize current_combiner to valid index.\n");
       current_combine = ~0u; /* Debug uncertain case, and fix warning (cxd4). */
       break;  // can't be found!
     }
@@ -16018,7 +16018,7 @@ void ColorCombinerToExtension ()
     ext_local_a = GR_CMBX_ITALPHA;
     break;
   default:
-    FRDP("Invalid combiner locality %u.\n", cmb.c_loc);
+    FRDP_E("Invalid combiner locality %u.\n", cmb.c_loc);
   case GR_COMBINE_LOCAL_CONSTANT:
     ext_local = GR_CMBX_CONSTANT_COLOR;
     ext_local_a = GR_CMBX_CONSTANT_ALPHA;
@@ -16035,7 +16035,7 @@ void ColorCombinerToExtension ()
     ext_other_a = GR_CMBX_TEXTURE_ALPHA;
     break;
   default:
-    FRDP("Invalid combiner flag %u.\n", cmb.c_oth);
+    FRDP_E("Invalid combiner flag %u.\n", cmb.c_oth);
   case GR_COMBINE_OTHER_CONSTANT:
     ext_other = GR_CMBX_CONSTANT_COLOR;
     ext_other_a = GR_CMBX_CONSTANT_ALPHA;
@@ -16382,7 +16382,7 @@ void TexColorCombinerToExtension (GrChipID_t tmu)
     tc_ext_c_invert = 1;
     break;
   default:
-    FRDP("Invalid combiner TMU factor %u.\n", tmu_fac);
+    FRDP_E("Invalid combiner TMU factor %u.\n", tmu_fac);
   case GR_COMBINE_FACTOR_ONE_MINUS_DETAIL_FACTOR:
     tc_ext_c = GR_CMBX_DETAIL_FACTOR;
     tc_ext_c_invert = 1;
@@ -16478,7 +16478,7 @@ void TexColorCombinerToExtension (GrChipID_t tmu)
     tc_ext_d_invert = 0;
     break;
   default:
-    FRDP("Invalid combiner TMU function %u.\n", tmu_func);
+    FRDP_E("Invalid combiner TMU function %u.\n", tmu_func);
   case GR_COMBINE_FUNCTION_SCALE_MINUS_LOCAL_ADD_LOCAL_ALPHA:
     tc_ext_a = GR_CMBX_LOCAL_TEXTURE_RGB;
     tc_ext_a_mode = GR_FUNC_MODE_ZERO;
@@ -16563,7 +16563,7 @@ void TexAlphaCombinerToExtension (GrChipID_t tmu)
     ta_ext_c_invert = 1;
     break;
   default:
-    FRDP("Invalid combiner alpha factor %u.\n", tmu_a_fac);
+    FRDP_E("Invalid combiner alpha factor %u.\n", tmu_a_fac);
   case GR_COMBINE_FACTOR_ONE_MINUS_DETAIL_FACTOR:
     ta_ext_c = GR_CMBX_DETAIL_FACTOR;
     ta_ext_c_invert = 1;
@@ -16628,7 +16628,7 @@ void TexAlphaCombinerToExtension (GrChipID_t tmu)
     ta_ext_d_invert = 0;
     break;
   default:
-    FRDP("Invalid combiner alpha coverage function %u.\n", tmu_a_func);
+    FRDP_E("Invalid combiner alpha coverage function %u.\n", tmu_a_func);
   case GR_COMBINE_FUNCTION_SCALE_MINUS_LOCAL_ADD_LOCAL:
   case GR_COMBINE_FUNCTION_SCALE_MINUS_LOCAL_ADD_LOCAL_ALPHA:
     ta_ext_a = GR_CMBX_LOCAL_TEXTURE_ALPHA;

--- a/Source/Glide64/Glide64.vcproj
+++ b/Source/Glide64/Glide64.vcproj
@@ -38,7 +38,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalIncludeDirectories="&quot;$(Root)Source/3rd Party/wx/include&quot;;&quot;$(Root)Source/3rd Party/wx/include/msvc&quot;;inc"
-				PreprocessorDefinitions="__MSC__;RDP_LOGGING;"
+				PreprocessorDefinitions="__MSC__;RDP_LOGGING;RDP_ERROR_LOG;"
 				UsePrecompiledHeader="0"
 			/>
 			<Tool

--- a/Source/Glide64/Glide64.vcproj
+++ b/Source/Glide64/Glide64.vcproj
@@ -38,7 +38,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				AdditionalIncludeDirectories="&quot;$(Root)Source/3rd Party/wx/include&quot;;&quot;$(Root)Source/3rd Party/wx/include/msvc&quot;;inc"
-				PreprocessorDefinitions="__MSC__;"
+				PreprocessorDefinitions="__MSC__;RDP_LOGGING;"
 				UsePrecompiledHeader="0"
 			/>
 			<Tool

--- a/Source/Glide64/Glide64.vcxproj
+++ b/Source/Glide64/Glide64.vcxproj
@@ -49,7 +49,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(Root)Source/3rd Party/wx/include;$(Root)Source/3rd Party/wx/include/msvc;inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__MSC__;RDP_LOGGING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__MSC__;RDP_LOGGING;RDP_ERROR_LOG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader />
     </ClCompile>
     <Link>

--- a/Source/Glide64/Glide64.vcxproj
+++ b/Source/Glide64/Glide64.vcxproj
@@ -49,7 +49,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <AdditionalIncludeDirectories>$(Root)Source/3rd Party/wx/include;$(Root)Source/3rd Party/wx/include/msvc;inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>__MSC__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__MSC__;RDP_LOGGING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader />
     </ClCompile>
     <Link>

--- a/Source/Glide64/ucode09.h
+++ b/Source/Glide64/ucode09.h
@@ -100,7 +100,7 @@ static void uc9_draw_object (wxUint8 * addr, wxUint32 type)
   wxUint32 textured, vnum, vsize;
   switch (type) {
     default: /* added to fix uninitialized variable warnings + debugging */
-      FRDP("Unknown geometric primitive type %u.\n", type);
+      FRDP_E("Unknown geometric primitive type %u.\n", type);
     case 0: //null
       textured = vnum = vsize = 0;
       break;
@@ -268,7 +268,7 @@ static void uc9_fmlight ()
     break;
   default:
     m = NULL; /* allowing segfaults to debug in case of PJGlide64 bugs */
-    FRDP("Invalid FM light matrix ID %u.\n", mid);
+    FRDP_E("Invalid FM light matrix ID %u.\n", mid);
     break;
   }
 
@@ -407,7 +407,7 @@ static void uc9_mtxcat ()
     LRDP("Comb * ");
     break;
   default:
-    FRDP("Invalid mutex S-coordinate:  %u\n", S);
+    FRDP_E("Invalid mutex S-coordinate:  %u\n", S);
     s = NULL; /* intentional segfault to alert for bugs in PJGlide64 (cxd4) */
     break;
   }
@@ -425,7 +425,7 @@ static void uc9_mtxcat ()
     t = (M44*)rdp.combined;
     break;
   default:
-    FRDP("Invalid mutex T-coordinate:  %u\n", T);
+    FRDP_E("Invalid mutex T-coordinate:  %u\n", T);
     t = NULL; /* intentional segfault to alert for bugs in PJGlide64 (cxd4) */
     break;
   }


### PR DESCRIPTION
I wanted to have more commits to glue at the end of this, but so far I haven't gotten any other RDP messages, just a memory leak reported in this issue I filed:  https://github.com/project64/project64/issues/51

I didn't understand any of that class-based C++ so had no idea how to tackle it.  Or if GLideN64 came out sooner and become part of Project64 that would also close that issue, but while PJGlide64 is still in this repo I figured it could be wise to add debugging before the pj64 2.2 release.