### PR TITLE
removed invalid op-code from RSP commands stepper

### DIFF
--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -1105,10 +1105,6 @@ char * RSPLc2Name ( DWORD OpCode, DWORD PC ) {
 		sprintf(CommandName,"LFV\t$v%d [%d], 0x%04X (%s)",command.rt, command.del, 
 			(command.voffset << 4), GPR_Name(command.base));
 		break;
-	case RSP_LSC2_WV:
-		sprintf(CommandName,"LWV\t$v%d [%d], 0x%04X (%s)",command.rt, command.del, 
-			(command.voffset << 4), GPR_Name(command.base));
-		break;
 	case RSP_LSC2_TV:
 		sprintf(CommandName,"LTV\t$v%d [%d], 0x%04X (%s)",command.rt, command.del, 
 			(command.voffset << 4), GPR_Name(command.base));


### PR DESCRIPTION
I guess the RSP emulator treats LWC2:WV as an invalid op-code as it should, so the RSP debugger should probably do the same.  There is a SWV opcode:  It means "store transposed wrapped" and is based on STV.  There is even a LTWV opcode, just not on the RSP.  If it existed on the RSP it would have been named "LTWV", not "LWV", despite appearances.  Even so, the opcode is invalid and probably only existed in the commands stepper due to simple copy and paste, or it was just forgotten to remove it.