### PR TITLE
basic timing support for VI_V_CURRENT_LINE_REG alternating scan fields

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -2625,6 +2625,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value ) {
 	return TRUE;
 }
 
+extern unsigned int field_serration;
 void CMipsMemoryVM::UpdateHalfLine (void)
 {
 	DWORD NextViTimer = g_SystemTimer->GetTimer(CSystemTimer::ViTimer);
@@ -2634,7 +2635,6 @@ void CMipsMemoryVM::UpdateHalfLine (void)
 		return;
 	}
 	m_HalfLine = (DWORD)(NextViTimer / g_System->ViRefreshRate());
-	m_HalfLine &= ~1;
 
 	int check_value = (int)(m_HalfLineCheck - NextViTimer);
 	if (check_value > 0 && check_value < 40)
@@ -2647,10 +2647,15 @@ void CMipsMemoryVM::UpdateHalfLine (void)
 		g_SystemTimer->UpdateTimers();
 		NextViTimer = g_SystemTimer->GetTimer(CSystemTimer::ViTimer);
 		m_HalfLine = (DWORD)(NextViTimer / g_System->ViRefreshRate());
-		m_HalfLine &= ~1;
 	}
 	m_HalfLineCheck = NextViTimer;
 
+/*
+ * 2015.02.04 (cxd4)
+ * Basic support for VI serrated pulses to DAC alternating scan fields.
+ */
+	m_HalfLine &= ~1;
+	m_HalfLine |= field_serration;
 }
 
 void CMipsMemoryVM::ProtectMemory( DWORD StartVaddr, DWORD EndVaddr ) 

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -1751,7 +1751,11 @@ void CN64System::SyncToAudio ( void )
 	}
 }
 
+unsigned int field_serration = 0;
 void CN64System::RefreshScreen ( void ) {
+	unsigned long VI_STATUS_REG;
+	unsigned int interlaced;
+
 	SPECIAL_TIMERS CPU_UsageAddr = Timer_None/*, ProfilingAddr = Timer_None*/;
 	DWORD VI_INTR_TIME = 500000;
 	
@@ -1796,6 +1800,15 @@ void CN64System::RefreshScreen ( void ) {
 		WriteTrace(TraceGfxPlugin,__FUNCTION__ ": Exception caught");
 		WriteTrace(TraceError,__FUNCTION__ ": Exception caught");
 	}
+
+/*
+ * 2015.02.04 (cxd4)
+ * Alternate the LSB of VI_V_CURRENT_LINE_REG for N64 interlaced video modes.
+ */
+	VI_STATUS_REG = m_Reg.VI_STATUS_REG & 0x00000000FFFFFFFFul;
+	interlaced = !!(VI_STATUS_REG & 0x00000040);
+	field_serration ^= 1;
+	field_serration &= interlaced;
 
 	if ((bBasicMode() || bLimitFPS() ) && !bSyncToAudio()) {
 		if (bShowCPUPer()) { m_CPU_Usage.StartTimer(Timer_Idel); }


### PR DESCRIPTION
Currently Project64 does not really emulate VI_CURRENT_REG.  It has a field counter which is always AND'd by ~1, forcing the LSB to 0, but this breaks many games which do not necessarily run at a native FB resolution of 320x240.

For example, _Star Wars:  Rogue Squadron_, which has a native resolution of 640x480, not 320x240.  That game is currently unplayable, nothing but a black screen with no video output, when using a pixel-accurate graphics plugin with Project64.  By emulating alternating scan-fields when the VI is blitting the active video in interlaced mode (also known as the "serrated pulses" bit), we can draw every alternating scanline:  The first 240 even scanlines in the first call to UpdateScreen, then the alternating 240 odd scanlines in the second call to UpdateScreen.  This constructs the pixel-accurate 640x480 image, thus making Star Wars RS playable.

This affects many other games using high resolutions (not necessarily because of the expansion pak), such as _Killer Instinct Gold_ as reported in:  https://github.com/project64/project64/issues/23

And I know the commit most likely isn't done in the way that project64 would have liked.  I just didn't understand the source structure well enough, so make any additional stylistic commits necessary.