### PR TITLE
better hardware support for odd PI_WR_LEN_REG addresses

### DIFF
--- a/Source/Project64/N64 System/Mips/Dma.cpp
+++ b/Source/Project64/N64 System/Mips/Dma.cpp
@@ -88,6 +88,18 @@ void CDMA::PI_DMA_WRITE (void) {
 
 	PI_WR_LEN_REG = (g_Reg -> PI_WR_LEN_REG) & 0x00FFFFFFul;
 	PI_write_data_length = PI_WR_LEN_REG + 1;
+/*
+ * 2015.02.08
+ * Test schibo's experiment with unaligned PI DMA write.
+ */
+	if (PI_write_data_length & 1)
+	{ /*
+		g_Notify -> DisplayError(
+			"PI DMA WRITE\nlength %ul",
+			PI_write_data_length
+		); */
+		PI_write_data_length += 1; /* fixes AI Shougi 3, Doraemon 3, etc. */
+	}
 
 	g_Reg->PI_STATUS_REG |= PI_STATUS_DMA_BUSY;
 	if (g_Reg->PI_DRAM_ADDR_REG + PI_write_data_length > g_MMU->RdramSize())

--- a/Source/Project64/N64 System/Mips/Dma.cpp
+++ b/Source/Project64/N64 System/Mips/Dma.cpp
@@ -83,9 +83,12 @@ void CDMA::PI_DMA_READ (void) {
 }
 
 void CDMA::PI_DMA_WRITE (void) {
+	unsigned long PI_WR_LEN_REG;
+
+	PI_WR_LEN_REG = (g_Reg -> PI_WR_LEN_REG) & 0x00FFFFFFul;
 
 	g_Reg->PI_STATUS_REG |= PI_STATUS_DMA_BUSY;
-	if ( g_Reg->PI_DRAM_ADDR_REG + g_Reg->PI_WR_LEN_REG + 1 > g_MMU->RdramSize()) 
+	if (g_Reg->PI_DRAM_ADDR_REG + PI_WR_LEN_REG + 1 > g_MMU->RdramSize())
 	{
 		if (g_Settings->LoadBool(Debugger_ShowUnhandledMemory)) { g_Notify->DisplayError("PI_DMA_WRITE not in Memory"); }
 		g_Reg->PI_STATUS_REG &= ~PI_STATUS_DMA_BUSY;
@@ -100,7 +103,7 @@ void CDMA::PI_DMA_WRITE (void) {
 			m_Sram.DmaFromSram(
 				g_MMU->Rdram()+g_Reg->PI_DRAM_ADDR_REG,
 				g_Reg->PI_CART_ADDR_REG - 0x08000000,
-				g_Reg->PI_WR_LEN_REG + 1
+				PI_WR_LEN_REG + 1
 			);
 			g_Reg->PI_STATUS_REG &= ~PI_STATUS_DMA_BUSY;
 			g_Reg->MI_INTR_REG |= MI_INTR_PI;
@@ -111,7 +114,7 @@ void CDMA::PI_DMA_WRITE (void) {
 			m_FlashRam.DmaFromFlashram(
 				g_MMU->Rdram()+g_Reg->PI_DRAM_ADDR_REG,
 				g_Reg->PI_CART_ADDR_REG - 0x08000000,
-				g_Reg->PI_WR_LEN_REG + 1
+				PI_WR_LEN_REG + 1
 			);
 			g_Reg->PI_STATUS_REG &= ~PI_STATUS_DMA_BUSY;
 			g_Reg->MI_INTR_REG |= MI_INTR_PI;
@@ -134,8 +137,8 @@ void CDMA::PI_DMA_WRITE (void) {
 		BYTE * ROM   = g_Rom->GetRomAddress();
 		BYTE * RDRAM = g_MMU->Rdram();
 		g_Reg->PI_CART_ADDR_REG -= 0x10000000;
-		if (g_Reg->PI_CART_ADDR_REG + g_Reg->PI_WR_LEN_REG + 1 < g_Rom->GetRomSize()) {
-			for (i = 0; i < g_Reg->PI_WR_LEN_REG + 1; i ++) {
+		if (g_Reg->PI_CART_ADDR_REG + PI_WR_LEN_REG + 1 < g_Rom->GetRomSize()) {
+			for (i = 0; i < PI_WR_LEN_REG + 1; i ++) {
 				*(RDRAM+((g_Reg->PI_DRAM_ADDR_REG + i) ^ 3)) =  *(ROM+((g_Reg->PI_CART_ADDR_REG + i) ^ 3));
 			}
 		} else {
@@ -144,7 +147,7 @@ void CDMA::PI_DMA_WRITE (void) {
 			for (i = 0; i < Len; i ++) {
 				*(RDRAM+((g_Reg->PI_DRAM_ADDR_REG + i) ^ 3)) =  *(ROM+((g_Reg->PI_CART_ADDR_REG + i) ^ 3));
 			}
-			for (i = Len; i < g_Reg->PI_WR_LEN_REG + 1 - Len; i ++) {
+			for (i = Len; i < PI_WR_LEN_REG + 1 - Len; i ++) {
 				*(RDRAM+((g_Reg->PI_DRAM_ADDR_REG + i) ^ 3)) =  0;
 			}
 		}
@@ -157,7 +160,7 @@ void CDMA::PI_DMA_WRITE (void) {
 		}
 		if (g_Recompiler && g_System->bSMM_PIDMA())
 		{
-			g_Recompiler->ClearRecompCode_Phys(g_Reg->PI_DRAM_ADDR_REG, g_Reg->PI_WR_LEN_REG,CRecompiler::Remove_DMA);
+			g_Recompiler->ClearRecompCode_Phys(g_Reg->PI_DRAM_ADDR_REG, PI_WR_LEN_REG,CRecompiler::Remove_DMA);
 		}
 		g_Reg->PI_STATUS_REG &= ~PI_STATUS_DMA_BUSY;
 		g_Reg->MI_INTR_REG |= MI_INTR_PI;


### PR DESCRIPTION
I have no idea how to test something like this on actual hardware to validate it.  I may be able to send some particular information which may or may not help confirm the accuracy of these changes.

In the meantime, after making this pull request, AI Shougi 3 looks like this in a pixel-accurate render:
![aishougiyay](https://cloud.githubusercontent.com/assets/1396303/6097285/3e700292-af86-11e4-93d7-351f99bf4f0f.png)

Before, it was broken.  See issue:  https://github.com/project64/project64/issues/59.

The basic element to this fix goes something like:
```c
if ((g_Reg->PI_WR_LEN_REG + 1) & 0x00000001)
    g_Reg->PI_WR_LEN_REG += 1;
```
Except, the safest approach was to declare new variables to contain the actual length and manage things better that way.  While I was at it, I felt inclined to `&= 0x00FFFFFF` the RDRAM address, since it's well-established that physical RDRAM can never comprise more than 16 MB of memory, although there is a gate limit of `&= 0x3FFFFFFF` (1 GB of addressing space...or was it 2, forget).  I suppose it's questionable what to AND it by, or even whether to AND it at all like 1964 does, since I can prove nothing without doing hardware tests.  Still, only the low 24 bits are documented to have a purpose, and this decision can always be changed in a later commit now that PI_WR_LEN_REG has been centralized to a single variable storage for more maintainability rather than saying `g_Reg->PI_WR_LEN_REG` all the time.