### PR TITLE
Make compiling easier for people with VS Express.

### DIFF
--- a/Source/Glide64/Glide64.rc
+++ b/Source/Glide64/Glide64.rc
@@ -3,11 +3,13 @@
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
-/////////////////////////////////////////////////////////////////////////////
-//
-// Generated from the TEXTINCLUDE 2 resource.
-//
-#include "afxres.h"
+
+#include "WinResrc.h"
+
+#ifdef IDC_STATIC
+#undef IDC_STATIC
+#endif
+#define IDC_STATIC              (-1)
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/Source/Project64/User Interface/UI Resources.rc
+++ b/Source/Project64/User Interface/UI Resources.rc
@@ -3,11 +3,13 @@
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
-/////////////////////////////////////////////////////////////////////////////
-//
-// Generated from the TEXTINCLUDE 2 resource.
-//
-#include "afxres.h"
+
+#include "WinResrc.h"
+
+#ifdef IDC_STATIC
+#undef IDC_STATIC
+#endif
+#define IDC_STATIC              (-1)
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/Source/RSP/RSP.rc
+++ b/Source/RSP/RSP.rc
@@ -3,11 +3,13 @@
 #include "resource.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
-/////////////////////////////////////////////////////////////////////////////
-//
-// Generated from the TEXTINCLUDE 2 resource.
-//
-#include "afxres.h"
+
+#include "WinResrc.h"
+
+#ifdef IDC_STATIC
+#undef IDC_STATIC
+#endif
+#define IDC_STATIC              (-1)
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS


### PR DESCRIPTION
Make compiling Project64 easier for people who happen to be using Visual Studio Express or otherwise have not installed the optional MFC libraries and components while installing Visual Studio.  Typically non-free VS will provide these by default, but @oddMLan has found evidence that it may come installed with VS2013 Community Edition as well:  https://github.com/project64/project64/issues/71.

This unfortunately was not the case on my laptop, and as MFC isn't even needed for these simple resources I decided to simplify this unnecessary high-level dependency to the bare-bones Windows API dependencies.

Here is another example I saw of somebody else on Git making this change for Visual Studio:
https://gitorious.org/0xdroid/external_libsdl-12/commit/b5f90cf4a544ee134e26ccc060c7f1793901186a