### PR TITLE
Default to 6102 CIC for some weird but legit ROMs.

### DIFF
--- a/Source/Project64/N64 System/N64 Rom Class.cpp
+++ b/Source/Project64/N64 System/N64 Rom Class.cpp
@@ -244,9 +244,11 @@ void CN64Rom::CalculateCicChip ( void )
 	case 0x0000011A49F60E96: m_CicChip = CIC_NUS_6105; break;
 	case 0x000000D6D5BE5580: m_CicChip = CIC_NUS_6106; break;
 	default:
-		m_CicChip = CIC_UNKNOWN; break;
+#ifdef _DEBUG
+		g_Notify->DisplayError("Unknown CIC checksum:\n%016X.", CRC);
+#endif
+		m_CicChip = CIC_NUS_6102; break;
 	}
-
 }
 
 CICChip CN64Rom::CicChipID ( void ) {


### PR DESCRIPTION
I make this PR for roughly 3 reasons:

1.  fixes part of the error nagging in issue https://github.com/project64/project64/issues/61
2.  Improve debugging.  Right now Project64 merely says something like "Unknown CIC (-1)".  I want debugging to show the actual checksum that Project64 came up with, since we already know it's going to be an unknown CIC anyway.
3.  It might get other ROMs to work off the bat without nagging end users as well, since other emulators (1964, Mupen64) appear to also default to 6102 for whatever reason (is this normal practice...?!), and we can always have the nagging back when testing in Debug build mode instead.