### PR TITLE
preliminary centralization of MIPS size types

### DIFF
--- a/Source/Project64/N64 System/Types.h
+++ b/Source/Project64/N64 System/Types.h
@@ -10,6 +10,63 @@
 ****************************************************************************/
 #pragma once
 
+/*
+ * Some compilers have <stdint.h> types built in to them internally.
+ * In those cases, the "dependency" on <stdint.h> can be overlooked.
+ */
+#if defined(__STDC__) && (__STDC_VERSION__ >= 199901L)
+#define C99_COMPLETE
+#include <stdint.h>
+#endif
+
+/*
+ * standard integer types usable by the MIPS ISA
+ * also used by the Ultra64 OS
+ */
+#if defined(_MSC_VER)
+typedef __int8                  i8;
+typedef signed __int8           s8;
+typedef unsigned __int8         u8;
+
+typedef __int16                 i16;
+typedef __int32                 i32;
+typedef __int64                 i64;
+typedef unsigned __int16        u16;
+typedef unsigned __int32        u32;
+typedef unsigned __int64        u64;
+#elif defined(C99_COMPLETE) || 1
+typedef int8_t                  i8;
+typedef int8_t                  s8;
+typedef uint8_t                 u8;
+
+typedef int16_t                 i16;
+typedef int32_t                 i32;
+typedef int64_t                 i64;
+typedef uint16_t                u16;
+typedef uint32_t                u32;
+typedef uint64_t                u64;
+#elif !defined(_STDINT_H) || defined(__LP64__)
+typedef char                    i8;
+typedef signed char             s8;
+typedef unsigned char           u8;
+
+typedef short                   i16;
+typedef int                     i32;
+typedef long                    i64;
+typedef unsigned short          u16;
+typedef unsigned int            u32;
+typedef unsigned long           u64;
+#else
+#error Unable to emulate all of the types from MIPS ISA.
+#endif
+
+typedef i16                     s16;
+typedef i32                     s32;
+typedef i64                     s64;
+
+typedef float                   f32;
+typedef double                  f64;
+
 typedef unsigned char    BYTE;
 typedef unsigned short   WORD;
 typedef unsigned long    DWORD;


### PR DESCRIPTION
Technically things like "WORD", "DWORD" etc. can mean many different things, especially when emulating MIPS as the target CPU on x86 which has different sizes.  I thought it could be more readable if we began taking some small steps to express variable/function declarations with exact type sizes.

For example, in the future, we might not have to say this:
```c
BOOL CMipsMemoryVM::LW_VAddr ( DWORD VAddr, DWORD & Value )
```
We could in theory document the MIPS system better by using fixed-size types like:
```c
BOOL CMipsMemoryVM::LW_VAddr ( u32 VAddr, u32 & Value )
```
It would be less likely to conflict with a MIPS word type and a <windows.h> DWORD typedef.

For whatever reason, SGI, too, used this style of types in the Ultra64 OS, but they're not the only ones.

Last and probably least, it's part of my uber-secret conspiracy to gradually make Project64 more portable.
As far as 64-bit portability it probably doesn't help all that much, as long as you assume MSVC compiler.

It's somewhat difficult to introduce this change globally for Project64 and each component, so I wanted to start off by just throwing the typedef's in `Source/Project64/N64 System/Types.h`.  Maybe in the future there could be a header file for these types that the RSP plugin and things like that could co-share.