### PR TITLE
Cic changes

### DIFF
--- a/Source/Project64/N64 System/Mips/Dma.cpp
+++ b/Source/Project64/N64 System/Mips/Dma.cpp
@@ -19,6 +19,7 @@ CDMA::CDMA(CFlashram & FlashRam, CSram & Sram) :
 void CDMA::OnFirstDMA (void) {
 	switch (g_Rom->CicChipID()) {
 	case CIC_NUS_6101: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
+	case CIC_UNKNOWN:
 	case CIC_NUS_6102: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
 	case CIC_NUS_6103: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
 	case CIC_NUS_6105: *(DWORD *)&((g_MMU->Rdram())[0x3F0]) = g_MMU->RdramSize(); break;

--- a/Source/Project64/N64 System/Mips/Dma.cpp
+++ b/Source/Project64/N64 System/Mips/Dma.cpp
@@ -18,11 +18,11 @@ CDMA::CDMA(CFlashram & FlashRam, CSram & Sram) :
 
 void CDMA::OnFirstDMA (void) {
 	switch (g_Rom->CicChipID()) {
-	case 1: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
-	case 2: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
-	case 3: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
-	case 5: *(DWORD *)&((g_MMU->Rdram())[0x3F0]) = g_MMU->RdramSize(); break;
-	case 6: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
+	case CIC_NUS_6101: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
+	case CIC_NUS_6102: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
+	case CIC_NUS_6103: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
+	case CIC_NUS_6105: *(DWORD *)&((g_MMU->Rdram())[0x3F0]) = g_MMU->RdramSize(); break;
+	case CIC_NUS_6106: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
 	default: g_Notify->DisplayError("Unhandled CicChip(%d) in first DMA",g_Rom->CicChipID());
 	}
 }

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -734,6 +734,7 @@ void CN64System::InitRegisters( bool bPostPif, CMipsMemory & MMU )
 		case Europe:  case Spanish: case Australia:
 		case X_PAL:   case Y_PAL:
 			switch (g_Rom->CicChipID()) {
+			case CIC_UNKNOWN:
 			case CIC_NUS_6102:
 				m_Reg.m_GPR[5].DW=0xFFFFFFFFC0F1D859;
 				m_Reg.m_GPR[14].DW=0x000000002DE108EA;
@@ -764,6 +765,7 @@ void CN64System::InitRegisters( bool bPostPif, CMipsMemory & MMU )
 		case NTSC_BETA: case X_NTSC: case USA: case Japan:
 		default:
 			switch (g_Rom->CicChipID()) {
+			case CIC_UNKNOWN:
 			case CIC_NUS_6102:
 				m_Reg.m_GPR[5].DW=0xFFFFFFFFC95973D5;
 				m_Reg.m_GPR[14].DW=0x000000002449A366;
@@ -791,6 +793,7 @@ void CN64System::InitRegisters( bool bPostPif, CMipsMemory & MMU )
 		case CIC_NUS_6101: 
 			m_Reg.m_GPR[22].DW=0x000000000000003F; 
 			break;
+		case CIC_UNKNOWN:
 		case CIC_NUS_6102: 
 			m_Reg.m_GPR[1].DW=0x0000000000000001;
 			m_Reg.m_GPR[2].DW=0x000000000EBDA536;
@@ -849,6 +852,7 @@ void CN64System::InitRegisters( bool bPostPif, CMipsMemory & MMU )
 
 		switch (g_Rom->CicChipID()) {
 		case CIC_NUS_6101: PIF_Ram[37] = 0x06; PIF_Ram[38] = 0x3F; break;
+		case CIC_UNKNOWN:
 		case CIC_NUS_6102: PIF_Ram[37] = 0x02; PIF_Ram[38] = 0x3F; break;
 		case CIC_NUS_6103:	PIF_Ram[37] = 0x02; PIF_Ram[38] = 0x78; break;
 		case CIC_NUS_6105:	PIF_Ram[37] = 0x02; PIF_Ram[38] = 0x91; break;

--- a/Source/Project64/N64 System/N64 Rom Class.cpp
+++ b/Source/Project64/N64 System/N64 Rom Class.cpp
@@ -244,6 +244,8 @@ void CN64Rom::CalculateCicChip ( void )
 	case 0x0000011A49F60E96: m_CicChip = CIC_NUS_6105; break;
 	case 0x000000D6D5BE5580: m_CicChip = CIC_NUS_6106; break;
 	default:
+		if (bHaveDebugger())
+			g_Notify->DisplayError("Unknown CIC checksum:\n%I64d.", CRC);
 		m_CicChip = CIC_UNKNOWN; break;
 	}
 

--- a/Source/Project64/N64 System/N64 Rom Class.h
+++ b/Source/Project64/N64 System/N64 Rom Class.h
@@ -12,7 +12,8 @@
 
 #include "N64 Types.h"
 
-class CN64Rom 
+class CN64Rom :
+	protected CDebugSettings
 {	
 	//constant values
 	enum { ReadFromRomSection = 0x400000 };

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -728,14 +728,14 @@ int CRomBrowser::GetCicChipID (BYTE * RomData) {
 		CRC += *(DWORD *)(RomData+count);
 	}
 	switch (CRC) {
-	case 0x000000D0027FDF31: return 1;
-	case 0x000000CFFB631223: return 1;
-	case 0x000000D057C85244: return 2;
-	case 0x000000D6497E414B: return 3;
-	case 0x0000011A49F60E96: return 5;
-	case 0x000000D6D5BE5580: return 6;
+	case 0x000000D0027FDF31: return CIC_NUS_6101;
+	case 0x000000CFFB631223: return CIC_NUS_6101;
+	case 0x000000D057C85244: return CIC_NUS_6102;
+	case 0x000000D6497E414B: return CIC_NUS_6103;
+	case 0x0000011A49F60E96: return CIC_NUS_6105;
+	case 0x000000D6D5BE5580: return CIC_NUS_6106;
 	default:
-		return -1;
+		return CIC_UNKNOWN;
 	}
 }
 


### PR DESCRIPTION
CiC now defaults to CIC_NUS_6102 behavior. This is mainly to improve end user experience for ROMS that would function under an existing CIC.
Error will still be produced under debugger with the CRC of the CiC that we do not understand/