### PR TITLE
fixed VS2013 linker warning MSB8030

### DIFF
--- a/Source/Project64/Project64.vcxproj
+++ b/Source/Project64/Project64.vcxproj
@@ -47,6 +47,7 @@
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <DataExecutionPrevention>false</DataExecutionPrevention>
       <MinimumRequiredVersion Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Beta Release|Win32'">


### PR DESCRIPTION
`Warning	1	warning MSB8030: The linker switch "Minimum Required Version" requires "SubSystem" to be set.  Without "SubSystem", the "Minimum Required Version" would not be passed to linker and could prevent to the output binary from running on older Operating Systems.	C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\Microsoft.CppBuild.targets	1197	5	Project64`

For some reason, the VS2013 makefile treats the Project64 module to have a Subsystem version of `5.01`, which in my experience happens to also be the oldest version of Windows that you can link with when using VS2013, even with the XP-compatible toolchain.  I guess this was done because otherwise it would have defaulted to `6.00` and could require something like Windows Vista unless it was linked by MSVC 2008.

The problem with this is that it fails to set the version number to 5.01 correctly, according to my results in Dependency Walker.  VS2013 warns that the build occurred while setting a SubSystem version, without a type.  So I set this to `Windows (/SUBSYSTEM:WINDOWS)`, which was already the default value it was getting linked with anyway, which solved the linker warning and correctly links in the 5.01 version number.