### PR TITLE
Fix manifest file not being embedded into the Project64 executable

### DIFF
--- a/Source/Project64/Project64.exe.manifest
+++ b/Source/Project64/Project64.exe.manifest
@@ -1,22 +1,28 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-<assemblyIdentity
-   version="1.0.0.0"
-   processorArchitecture="x86"
-   name="Project64.XP"
-   type="win32"
-/>
-<description>Project64</description>
-<dependency>
-   <dependentAssembly>
-   <assemblyIdentity
-      type="win32"
-      name="Microsoft.Windows.Common-Controls"
-      version="6.0.0.0"
-      processorArchitecture="X86"
-      publicKeyToken="6595b64144ccf1df"
-      language="*"
-      />
-   </dependentAssembly>
-</dependency>
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+  <trustInfo xmlns='urn:schemas-microsoft-com:asm.v3'>
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level='asInvoker' uiAccess='false' />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <assemblyIdentity
+    version='2.1.0.1'
+    processorArchitecture='x86'
+    name='Project64'
+    type='win32'
+  />
+  <dependency>
+  <dependentAssembly>
+    <assemblyIdentity
+      type='win32'
+      name='Microsoft.Windows.Common-Controls'
+      version='6.0.0.0'
+      processorArchitecture='X86'
+      publicKeyToken='6595b64144ccf1df'
+      language='*'
+    />
+  </dependentAssembly>
+  </dependency>
 </assembly>

--- a/Source/Project64/Project64.vcxproj
+++ b/Source/Project64/Project64.vcxproj
@@ -34,12 +34,28 @@
   <PropertyGroup>
     <_ProjectFileVersion>12.0.21005.1</_ProjectFileVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <GenerateManifest>false</GenerateManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
       <DataExecutionPrevention>false</DataExecutionPrevention>
       <MinimumRequiredVersion Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
       <SubSystem Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Windows</SubSystem>
+      <ManifestFile Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <AllowIsolation Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <EnableUAC Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <UACExecutionLevel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <UACUIAccess Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <ManifestFile Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+      <AllowIsolation Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+      <EnableUAC Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+      <UACExecutionLevel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+      <UACUIAccess Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Project64/User Interface/UI Resources.rc
+++ b/Source/Project64/User Interface/UI Resources.rc
@@ -17,6 +17,8 @@
 /////////////////////////////////////////////////////////////////////////////
 // English (U.S.) resources
 
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "..\Project64.exe.manifest"
+
 #if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
 #ifdef _WIN32
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US


### PR DESCRIPTION
The Project64.exe.manifest file wasn't being embedded into the main executable, instead Visual Studio was generating a generic one that didn't include Common Controls 6. This commit updates the project so it uses the appropriate file instead which also fixes windows theming in versions from Windows XP and above. Also updated the manifest file with new info such as UAC access level for better compatibility with Windows Vista and above.