### PR TITLE
Instantiate fixed-size standard int types to RSP module.

### DIFF
--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -64,7 +64,7 @@ void RSP_Opcode_JAL ( void ) {
 void RSP_Opcode_BEQ ( void ) {
 	RSP_NextInstruction = DELAY_SLOT;
 	if (RSP_GPR[RSPOpC.rs].W == RSP_GPR[RSPOpC.rt].W) {
-		RSP_JumpTo = ( *PrgCount + ((short)RSPOpC.offset << 2) + 4 ) & 0xFFC;
+		RSP_JumpTo = ( *PrgCount + (RSPOpC.offset << 2) + 4 ) & 0xFFC;
 	} else  {
 		RSP_JumpTo = ( *PrgCount + 8 ) & 0xFFC;
 	}
@@ -73,7 +73,7 @@ void RSP_Opcode_BEQ ( void ) {
 void RSP_Opcode_BNE ( void ) {
 	RSP_NextInstruction = DELAY_SLOT;
 	if (RSP_GPR[RSPOpC.rs].W != RSP_GPR[RSPOpC.rt].W) {
-		RSP_JumpTo = ( *PrgCount + ((short)RSPOpC.offset << 2) + 4 ) & 0xFFC;
+		RSP_JumpTo = ( *PrgCount + (RSPOpC.offset << 2) + 4 ) & 0xFFC;
 	} else  {
 		RSP_JumpTo = ( *PrgCount + 8 ) & 0xFFC;
 	}
@@ -82,7 +82,7 @@ void RSP_Opcode_BNE ( void ) {
 void RSP_Opcode_BLEZ ( void ) {
 	RSP_NextInstruction = DELAY_SLOT;
 	if (RSP_GPR[RSPOpC.rs].W <= 0) {
-		RSP_JumpTo = ( *PrgCount + ((short)RSPOpC.offset << 2) + 4 ) & 0xFFC;
+		RSP_JumpTo = ( *PrgCount + (RSPOpC.offset << 2) + 4 ) & 0xFFC;
 	} else  {
 		RSP_JumpTo = ( *PrgCount + 8 ) & 0xFFC;
 	}
@@ -91,7 +91,7 @@ void RSP_Opcode_BLEZ ( void ) {
 void RSP_Opcode_BGTZ ( void ) {
 	RSP_NextInstruction = DELAY_SLOT;
 	if (RSP_GPR[RSPOpC.rs].W > 0) {
-		RSP_JumpTo = ( *PrgCount + ((short)RSPOpC.offset << 2) + 4 ) & 0xFFC;
+		RSP_JumpTo = ( *PrgCount + (RSPOpC.offset << 2) + 4 ) & 0xFFC;
 	} else  {
 		RSP_JumpTo = ( *PrgCount + 8 ) & 0xFFC;
 	}
@@ -147,7 +147,7 @@ void RSP_Opcode_XORI ( void ) {
 
 void RSP_Opcode_LUI (void) {
 	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = (short)RSPOpC.offset << 16;
+		RSP_GPR[RSPOpC.rt].W = RSPOpC.offset << 16;
 	}
 }
 
@@ -160,46 +160,46 @@ void RSP_Opcode_COP2 (void) {
 }
 
 void RSP_Opcode_LB ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
 	RSP_LB_DMEM( Address, &RSP_GPR[RSPOpC.rt].UB[0] );
 	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rt].B[0];
 }
 
 void RSP_Opcode_LH ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
 	RSP_LH_DMEM( Address, &RSP_GPR[RSPOpC.rt].UHW[0] );
 	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rt].HW[0];
 }
 
 void RSP_Opcode_LW ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
 	RSP_LW_DMEM( Address, &RSP_GPR[RSPOpC.rt].UW );
 }
 
 void RSP_Opcode_LBU ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
 	RSP_LB_DMEM( Address, &RSP_GPR[RSPOpC.rt].UB[0] );
 	RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rt].UB[0];
 }
 
 void RSP_Opcode_LHU ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
 	RSP_LH_DMEM( Address, &RSP_GPR[RSPOpC.rt].UHW[0] );
 	RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rt].UHW[0];
 }
 
 void RSP_Opcode_SB ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
 	RSP_SB_DMEM( Address, RSP_GPR[RSPOpC.rt].UB[0] );
 }
 
 void RSP_Opcode_SH ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
 	RSP_SH_DMEM( Address, RSP_GPR[RSPOpC.rt].UHW[0] );
 }
 
 void RSP_Opcode_SW ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
 	RSP_SW_DMEM( Address, RSP_GPR[RSPOpC.rt].UW );
 }
 
@@ -336,7 +336,7 @@ void RSP_Special_SLTU (void) {
 void RSP_Opcode_BLTZ ( void ) {
 	RSP_NextInstruction = DELAY_SLOT;
 	if (RSP_GPR[RSPOpC.rs].W < 0) {
-		RSP_JumpTo = ( *PrgCount + ((short)RSPOpC.offset << 2) + 4 ) & 0xFFC;
+		RSP_JumpTo = ( *PrgCount + (RSPOpC.offset << 2) + 4 ) & 0xFFC;
 	} else  {
 		RSP_JumpTo = ( *PrgCount + 8 ) & 0xFFC;
 	}
@@ -345,7 +345,7 @@ void RSP_Opcode_BLTZ ( void ) {
 void RSP_Opcode_BGEZ ( void ) {
 	RSP_NextInstruction = DELAY_SLOT;
 	if (RSP_GPR[RSPOpC.rs].W >= 0) {
-		RSP_JumpTo = ( *PrgCount + ((short)RSPOpC.offset << 2) + 4 ) & 0xFFC;
+		RSP_JumpTo = ( *PrgCount + (RSPOpC.offset << 2) + 4 ) & 0xFFC;
 	} else  {
 		RSP_JumpTo = ( *PrgCount + 8 ) & 0xFFC;
 	}
@@ -355,7 +355,7 @@ void RSP_Opcode_BLTZAL ( void ) {
 	RSP_NextInstruction = DELAY_SLOT;
 	RSP_GPR[31].UW = ( *PrgCount + 8 ) & 0xFFC;
 	if (RSP_GPR[RSPOpC.rs].W < 0) {
-		RSP_JumpTo = ( *PrgCount + ((short)RSPOpC.offset << 2) + 4 ) & 0xFFC;
+		RSP_JumpTo = ( *PrgCount + (RSPOpC.offset << 2) + 4 ) & 0xFFC;
 	} else  {
 		RSP_JumpTo = ( *PrgCount + 8 ) & 0xFFC;
 	}
@@ -365,7 +365,7 @@ void RSP_Opcode_BGEZAL ( void ) {
 	RSP_NextInstruction = DELAY_SLOT;
 	RSP_GPR[31].UW = ( *PrgCount + 8 ) & 0xFFC;
 	if (RSP_GPR[RSPOpC.rs].W >= 0) {
-		RSP_JumpTo = ( *PrgCount + ((short)RSPOpC.offset << 2) + 4 ) & 0xFFC;
+		RSP_JumpTo = ( *PrgCount + (RSPOpC.offset << 2) + 4 ) & 0xFFC;
 	} else  {
 		RSP_JumpTo = ( *PrgCount + 8 ) & 0xFFC;
 	}

--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -99,19 +99,19 @@ void RSP_Opcode_BGTZ ( void ) {
 
 void RSP_Opcode_ADDI ( void ) {
 	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W + (short)RSPOpC.immediate;
+		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W + (int16_t)RSPOpC.immediate;
 	}
 }
 
 void RSP_Opcode_ADDIU ( void ) {
 	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rs].UW + (DWORD)((short)RSPOpC.immediate);
+		RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rs].UW + (uint32_t)((int16_t)RSPOpC.immediate);
 	}
 }
 
 void RSP_Opcode_SLTI (void) {
 	if (RSPOpC.rt == 0) { return; }
-	if (RSP_GPR[RSPOpC.rs].W < (short)RSPOpC.immediate) {
+	if (RSP_GPR[RSPOpC.rs].W < (int16_t)RSPOpC.immediate) {
 		RSP_GPR[RSPOpC.rt].W = 1;
 	} else {
 		RSP_GPR[RSPOpC.rt].W = 0;
@@ -120,7 +120,7 @@ void RSP_Opcode_SLTI (void) {
 
 void RSP_Opcode_SLTIU (void) {
 	if (RSPOpC.rt == 0) { return; }
-	if (RSP_GPR[RSPOpC.rs].UW < (DWORD)(short)RSPOpC.immediate) {
+	if (RSP_GPR[RSPOpC.rs].UW < (uint32_t)(int16_t)RSPOpC.immediate) {
 		RSP_GPR[RSPOpC.rt].W = 1;
 	} else {
 		RSP_GPR[RSPOpC.rt].W = 0;
@@ -129,19 +129,19 @@ void RSP_Opcode_SLTIU (void) {
 
 void RSP_Opcode_ANDI ( void ) {
 	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W & RSPOpC.immediate;
+		RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rs].UW & RSPOpC.immediate;
 	}
 }
 
 void RSP_Opcode_ORI ( void ) {
 	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W | RSPOpC.immediate;
+		RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rs].UW | RSPOpC.immediate;
 	}
 }
 
 void RSP_Opcode_XORI ( void ) {
 	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W ^ RSPOpC.immediate;
+		RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rs].UW ^ RSPOpC.immediate;
 	}
 }
 
@@ -160,46 +160,62 @@ void RSP_Opcode_COP2 (void) {
 }
 
 void RSP_Opcode_LB ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + RSPOpC.offset) & 0xFFF;
 	RSP_LB_DMEM( Address, &RSP_GPR[RSPOpC.rt].UB[0] );
 	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rt].B[0];
 }
 
 void RSP_Opcode_LH ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + RSPOpC.offset) & 0xFFF;
 	RSP_LH_DMEM( Address, &RSP_GPR[RSPOpC.rt].UHW[0] );
 	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rt].HW[0];
 }
 
 void RSP_Opcode_LW ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + RSPOpC.offset) & 0xFFF;
 	RSP_LW_DMEM( Address, &RSP_GPR[RSPOpC.rt].UW );
 }
 
 void RSP_Opcode_LBU ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + RSPOpC.offset) & 0xFFF;
 	RSP_LB_DMEM( Address, &RSP_GPR[RSPOpC.rt].UB[0] );
 	RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rt].UB[0];
 }
 
 void RSP_Opcode_LHU ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + RSPOpC.offset) & 0xFFF;
 	RSP_LH_DMEM( Address, &RSP_GPR[RSPOpC.rt].UHW[0] );
 	RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rt].UHW[0];
 }
 
 void RSP_Opcode_SB ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + RSPOpC.offset) & 0xFFF;
 	RSP_SB_DMEM( Address, RSP_GPR[RSPOpC.rt].UB[0] );
 }
 
 void RSP_Opcode_SH ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + RSPOpC.offset) & 0xFFF;
 	RSP_SH_DMEM( Address, RSP_GPR[RSPOpC.rt].UHW[0] );
 }
 
 void RSP_Opcode_SW ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + RSPOpC.offset) & 0xFFF;
 	RSP_SW_DMEM( Address, RSP_GPR[RSPOpC.rt].UW );
 }
 
@@ -210,10 +226,11 @@ void RSP_Opcode_LC2 (void) {
 void RSP_Opcode_SC2 (void) {
 	RSP_Sc2 [ RSPOpC.rd ]();
 }
+
 /********************** R4300i OpCodes: Special **********************/
 void RSP_Special_SLL ( void ) {
 	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W << RSPOpC.sa;
+		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rt].UW << RSPOpC.sa;
 	}
 }
 
@@ -231,31 +248,31 @@ void RSP_Special_SRA ( void ) {
 
 void RSP_Special_SLLV (void) {
 	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W << (RSP_GPR[RSPOpC.rs].W & 0x1F);
+		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rt].UW << (RSP_GPR[RSPOpC.rs].UW & 0x1F);
 	}
 }
 
 void RSP_Special_SRLV (void) {
 	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rt].UW >> (RSP_GPR[RSPOpC.rs].W & 0x1F);
+		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rt].UW >> (RSP_GPR[RSPOpC.rs].UW & 0x1F);
 	}
 }
 
 void RSP_Special_SRAV (void) {
 	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W >> (RSP_GPR[RSPOpC.rs].W & 0x1F);
+		RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W >> (RSP_GPR[RSPOpC.rs].UW & 0x1F);
 	}
 }
 
 void RSP_Special_JR (void) {
 	RSP_NextInstruction = DELAY_SLOT;
-	RSP_JumpTo = (RSP_GPR[RSPOpC.rs].W & 0xFFC);
+	RSP_JumpTo = (RSP_GPR[RSPOpC.rs].UW & 0xFFC);
 }
 
 void RSP_Special_JALR (void) {
 	RSP_NextInstruction = DELAY_SLOT;
-	RSP_GPR[RSPOpC.rd].W = (*PrgCount + 8) & 0xFFC;
-	RSP_JumpTo = (RSP_GPR[RSPOpC.rs].W & 0xFFC);
+	RSP_GPR[RSPOpC.rd].UW = (*PrgCount + 8) & 0xFFC;
+	RSP_JumpTo = (RSP_GPR[RSPOpC.rs].UW & 0xFFC);
 }
 
 void RSP_Special_BREAK ( void ) {
@@ -332,6 +349,7 @@ void RSP_Special_SLTU (void) {
 		RSP_GPR[RSPOpC.rd].UW = 0;
 	}
 }
+
 /********************** R4300i OpCodes: RegImm **********************/
 void RSP_Opcode_BLTZ ( void ) {
 	RSP_NextInstruction = DELAY_SLOT;
@@ -370,6 +388,7 @@ void RSP_Opcode_BGEZAL ( void ) {
 		RSP_JumpTo = ( *PrgCount + 8 ) & 0xFFC;
 	}
 }
+
 /************************** Cop0 functions *************************/
 void RSP_Cop0_MF (void) {
 	if (LogRDP && CPUCore == InterpreterCPU)
@@ -529,6 +548,7 @@ void RSP_Cop2_CT (void) {
 void RSP_COP2_VECTOR (void) {
 	RSP_Vector[ RSPOpC.funct ]();
 }
+
 /************************** Vect functions **************************/
 void RSP_Vector_VMULF (void) {
 	int el, del;
@@ -1648,120 +1668,167 @@ void RSP_Vector_VRSQH (void) {
 }
 
 void RSP_Vector_VNOOP (void) {}
+
 /************************** lc2 functions **************************/
 void RSP_Opcode_LBV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 0)) & 0xFFF;
 	RSP_LBV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LSV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 1)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 1)) & 0xFFF;
 	RSP_LSV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LLV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 2)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 2)) & 0xFFF;
 	RSP_LLV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LDV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_LDV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LQV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LQV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LRV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LRV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LPV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_LPV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LUV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_LUV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LHV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LHV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LFV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LFV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LTV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LTV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 /************************** sc2 functions **************************/
 void RSP_Opcode_SBV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 0)) & 0xFFF;
 	RSP_SBV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SSV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 1)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 1)) & 0xFFF;
 	RSP_SSV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SLV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 2)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 2)) & 0xFFF;
 	RSP_SLV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SDV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_SDV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SQV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SQV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SRV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SRV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SPV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_SPV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SUV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_SUV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SHV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SHV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SFV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SFV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_STV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_STV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SWV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SWV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 

--- a/Source/RSP/OpCode.h
+++ b/Source/RSP/OpCode.h
@@ -41,7 +41,7 @@ typedef union tagOPCODE {
 	};
 
 	struct {
-		unsigned offset : 16;
+		signed offset : 16;
 		unsigned : 5;
 		unsigned base : 5;
 		unsigned : 6;

--- a/Source/RSP/OpCode.h
+++ b/Source/RSP/OpCode.h
@@ -30,7 +30,7 @@
 #pragma warning(disable : 4201) // nonstandard extension used : nameless struct/union
 
 typedef union tagOPCODE {
-	unsigned long Hex;
+	uint32_t Hex;
 	unsigned char Ascii[4];
 
 	struct {

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -119,7 +119,8 @@ void Disable_RSP_Commands_Window ( void ) {
 }
 
 int DisplayRSPCommand (DWORD location, int InsertPos) {
-	DWORD OpCode, LinesUsed = 1, status;
+	uint32_t OpCode;
+	DWORD LinesUsed = 1, status;
 	BOOL Redraw = FALSE;	
 
 	RSP_LW_IMEM(location, &OpCode);
@@ -149,7 +150,8 @@ int DisplayRSPCommand (DWORD location, int InsertPos) {
 
 void DumpRSPCode (void) {
 	char string[100], LogFileName[255], *p ;
-	DWORD location, OpCode, dwWritten;
+	uint32_t OpCode;
+	DWORD location, dwWritten;
 	HANDLE hLogFile = NULL;
 
 	strcpy(LogFileName,GetCommandLine() + 1);
@@ -185,7 +187,8 @@ void DumpRSPCode (void) {
 
 void DumpRSPData (void) {
 	char string[100], LogFileName[255], *p ;
-	DWORD location, value, dwWritten;
+	uint32_t value;
+	DWORD location, dwWritten;
 	HANDLE hLogFile = NULL;
 
 	strcpy(LogFileName,GetCommandLine() + 1);

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -803,22 +803,22 @@ char * RSPRegimmName ( DWORD OpCode, DWORD PC ) {
 	switch (command.rt) {
 	case RSP_REGIMM_BLTZ:
 		sprintf(CommandName,"BLTZ\t%s, 0x%03X",GPR_Name(command.rs),
-			(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+			(PC + (command.offset << 2) + 4) & 0xFFC);
 		break;
 	case RSP_REGIMM_BGEZ:
 		sprintf(CommandName,"BGEZ\t%s, 0x%03X",GPR_Name(command.rs),
-			(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+			(PC + (command.offset << 2) + 4) & 0xFFC);
 		break;
 	case RSP_REGIMM_BLTZAL:
 		sprintf(CommandName,"BLTZAL\t%s, 0x%03X",GPR_Name(command.rs),
-			(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+			(PC + (command.offset << 2) + 4) & 0xFFC);
 		break;
 	case RSP_REGIMM_BGEZAL:
 		if (command.rs == 0) {
-			sprintf(CommandName,"BAL\t0x%03X",(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+			sprintf(CommandName,"BAL\t0x%03X",(PC + (command.offset << 2) + 4) & 0xFFC);
 		} else {
 			sprintf(CommandName,"BGEZAL\t%s, 0x%03X",GPR_Name(command.rs),
-				(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+				(PC + (command.offset << 2) + 4) & 0xFFC);
 		}	
 		break;
 	default:
@@ -1204,24 +1204,24 @@ char * RSPOpcodeName ( DWORD OpCode, DWORD PC ) {
 		break;
 	case RSP_BEQ:
 		if (command.rs == 0 && command.rt == 0) {
-			sprintf(CommandName,"B\t0x%03X",(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+			sprintf(CommandName,"B\t0x%03X",(PC + (command.offset << 2) + 4) & 0xFFC);
 		} else if (command.rs == 0 || command.rt == 0){
 			sprintf(CommandName,"BEQZ\t%s, 0x%03X",GPR_Name(command.rs == 0 ? command.rt : command.rs),
-				(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+				(PC + (command.offset << 2) + 4) & 0xFFC);
 		} else {
 			sprintf(CommandName,"BEQ\t%s, %s, 0x%03X",GPR_Name(command.rs),GPR_Name(command.rt),
-				(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+				(PC + (command.offset << 2) + 4) & 0xFFC);
 		}
 		break;
 	case RSP_BNE:
 		sprintf(CommandName,"BNE\t%s, %s, 0x%03X",GPR_Name(command.rs),GPR_Name(command.rt),
-			(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+			(PC + (command.offset << 2) + 4) & 0xFFC);
 		break;
 	case RSP_BLEZ:
-		sprintf(CommandName,"BLEZ\t%s, 0x%03X",GPR_Name(command.rs),(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+		sprintf(CommandName,"BLEZ\t%s, 0x%03X",GPR_Name(command.rs),(PC + (command.offset << 2) + 4) & 0xFFC);
 		break;
 	case RSP_BGTZ:
-		sprintf(CommandName,"BGTZ\t%s, 0x%03X",GPR_Name(command.rs),(PC + ((short)command.offset << 2) + 4) & 0xFFC);
+		sprintf(CommandName,"BGTZ\t%s, 0x%03X",GPR_Name(command.rs),(PC + (command.offset << 2) + 4) & 0xFFC);
 		break;
 	case RSP_ADDI:
 		sprintf(CommandName,"ADDI\t%s, %s, 0x%04X",GPR_Name(command.rt), GPR_Name(command.rs),

--- a/Source/RSP/Recompiler Analysis.c
+++ b/Source/RSP/Recompiler Analysis.c
@@ -213,7 +213,7 @@ DWORD WriteToAccum2 (int Location, int PC, BOOL RecursiveCall) {
 		case RSP_BNE:
 		case RSP_BLEZ:
 		case RSP_BGTZ:			
-			BranchImmed = (short)RspOp.offset;
+			BranchImmed = RspOp.offset;
 			if (Compiler.bAudioUcode) {
 				OPCODE NextOp;
 
@@ -222,13 +222,13 @@ DWORD WriteToAccum2 (int Location, int PC, BOOL RecursiveCall) {
 					break;
 				}
 				/* if the opcode 8 bytes before the dest is a J backward than ignore this */
-				BranchImmed = (PC + ((short)RspOp.offset << 2) + 4) & 0xFFC;
+				BranchImmed = (PC + (RspOp.offset << 2) + 4) & 0xFFC;
 				RSP_LW_IMEM(BranchImmed - 8, &NextOp.Hex);
 				if (RspOp.op == RSP_J && (int)(RspOp.target << 2) < PC) {
 					break;
 				}
 			}
-			BranchTarget = (PC + ((short)RspOp.offset << 2) + 4) & 0xFFC;
+			BranchTarget = (PC + (RspOp.offset << 2) + 4) & 0xFFC;
 			Instruction_State = DO_DELAY_SLOT;
 			break;
 		case RSP_ADDI:
@@ -518,7 +518,7 @@ BOOL WriteToVectorDest2 (DWORD DestReg, int PC, BOOL RecursiveCall) {
 		case RSP_BNE:
 		case RSP_BLEZ:
 		case RSP_BGTZ:			
-			BranchImmed = (short)RspOp.offset;
+			BranchImmed = RspOp.offset;
 			if (Compiler.bAudioUcode) {
 				OPCODE NextOp;
 
@@ -527,13 +527,13 @@ BOOL WriteToVectorDest2 (DWORD DestReg, int PC, BOOL RecursiveCall) {
 					break;
 				}
 				/* if the opcode 8 bytes before the dest is a J backward than ignore this */
-				BranchImmed = (PC + ((short)RspOp.offset << 2) + 4) & 0xFFC;
+				BranchImmed = (PC + (RspOp.offset << 2) + 4) & 0xFFC;
 				RSP_LW_IMEM(BranchImmed - 8, &NextOp.Hex);
 				if (RspOp.op == RSP_J && (int)(RspOp.target << 2) < PC) {
 					break;
 				}
 			}
-			BranchTarget = (PC + ((short)RspOp.offset << 2) + 4) & 0xFFC;
+			BranchTarget = (PC + (RspOp.offset << 2) + 4) & 0xFFC;
 			Instruction_State = DO_DELAY_SLOT;
 			break;
 		case RSP_ADDI:
@@ -1066,7 +1066,7 @@ BOOL IsRegisterConstant (DWORD Reg, DWORD * Constant) {
 		case RSP_LUI:
 			if (RspOp.rt == Reg) {
 				if (References > 0) { return FALSE; }
-				Const = (short)RspOp.offset << 16;
+				Const = RspOp.offset << 16;
 				References++;
 			}
 			break;

--- a/Source/RSP/Recompiler CPU.c
+++ b/Source/RSP/Recompiler CPU.c
@@ -712,7 +712,7 @@ void BuildBranchLabels(void) {
 				CPU_Message("[%02i] Added branch at %X to %X", RspCode.LabelCount, i, Dest);
 #endif
 			} else {
-				Dest = (i + ((short)RspOp.offset << 2) + 4) & 0xFFC;
+				Dest = (i + (RspOp.offset << 2) + 4) & 0xFFC;
 				RspCode.BranchLabels[RspCode.LabelCount] = Dest;
 				RspCode.LabelCount += 1;
 #ifdef BUILD_BRANCHLABELS_VERBOSE

--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -250,7 +250,7 @@ void Compile_BEQ ( void ) {
 		SetzVariable(&BranchCompare, "BranchCompare");
 		NextInstruction = DO_DELAY_SLOT;	
 	} else if ( NextInstruction == DELAY_SLOT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		
 		if (RSPOpC.rs == 0 && RSPOpC.rt == 0) {
 			JmpLabel32 ( "BranchToJump", 0 );
@@ -276,7 +276,7 @@ void Compile_BEQ ( void ) {
 		Branch_AddRef(Target, (DWORD*)(RecompPos - 4));
 		NextInstruction = FINISH_SUB_BLOCK;
 	} else if ( NextInstruction == DELAY_SLOT_EXIT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		CompileBranchExit(Target, CompilePC + 8);
 	} else {
 		CompilerWarning("BEQ error\nWeird Delay Slot.\n\nNextInstruction = %X\nEmulation will now stop", NextInstruction);
@@ -310,7 +310,7 @@ void Compile_BNE ( void ) {
 		SetnzVariable(&BranchCompare, "BranchCompare");
 		NextInstruction = DO_DELAY_SLOT;	
 	} else if ( NextInstruction == DELAY_SLOT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		
 		if (RSPOpC.rs == 0 && RSPOpC.rt == 0) {			
 			NextInstruction = FINISH_SUB_BLOCK;
@@ -335,7 +335,7 @@ void Compile_BNE ( void ) {
 		Branch_AddRef(Target, (DWORD*)(RecompPos - 4));
 		NextInstruction = FINISH_SUB_BLOCK;
 	} else if ( NextInstruction == DELAY_SLOT_EXIT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		CompileBranchExit(Target, CompilePC + 8);
 	} else {
 		CompilerWarning("BNE error\nWeird Delay Slot.\n\nNextInstruction = %X\nEmulation will now stop", NextInstruction);
@@ -361,7 +361,7 @@ void Compile_BLEZ ( void ) {
 		SetleVariable(&BranchCompare, "BranchCompare");
 		NextInstruction = DO_DELAY_SLOT;	
 	} else if ( NextInstruction == DELAY_SLOT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		
 		if (RSPOpC.rs == 0) {
 			JmpLabel32 ( "BranchToJump", 0 );
@@ -381,7 +381,7 @@ void Compile_BLEZ ( void ) {
 		Branch_AddRef(Target, (DWORD*)(RecompPos - 4));
 		NextInstruction = FINISH_SUB_BLOCK;
 	} else if ( NextInstruction == DELAY_SLOT_EXIT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		CompileBranchExit(Target, CompilePC + 8);
 	} else {
 		CompilerWarning("BLEZ error\nWeird Delay Slot.\n\nNextInstruction = %X\nEmulation will now stop", NextInstruction);
@@ -407,7 +407,7 @@ void Compile_BGTZ ( void ) {
 		SetgVariable(&BranchCompare, "BranchCompare");
 		NextInstruction = DO_DELAY_SLOT;	
 	} else if ( NextInstruction == DELAY_SLOT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		
 		if (RSPOpC.rs == 0) {			
 			NextInstruction = FINISH_SUB_BLOCK;
@@ -424,7 +424,7 @@ void Compile_BGTZ ( void ) {
 		Branch_AddRef(Target, (DWORD*)(RecompPos - 4));
 		NextInstruction = FINISH_SUB_BLOCK;
 	} else if ( NextInstruction == DELAY_SLOT_EXIT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		CompileBranchExit(Target, CompilePC + 8);
 	} else {
 		CompilerWarning("BGTZ error\nWeird Delay Slot.\n\nNextInstruction = %X\nEmulation will now stop", NextInstruction);
@@ -561,7 +561,7 @@ void Compile_XORI ( void ) {
 }
 
 void Compile_LUI ( void ) {
-	int constant = (short)RSPOpC.offset << 16;
+	int constant = RSPOpC.offset << 16;
 
 	#ifndef Compile_Immediates
 	Cheat_r4300iOpcode(RSP_Opcode_LUI,"RSP_Opcode_LUI"); return;
@@ -582,7 +582,7 @@ void Compile_COP2 (void) {
 }
 
 void Compile_LB ( void ) {
-	int Offset = (short)RSPOpC.offset;
+	int Offset = RSPOpC.offset;
 
 	#ifndef Compile_GPRLoads
 	Cheat_r4300iOpcode(RSP_Opcode_LB,"RSP_Opcode_LB"); return;
@@ -600,7 +600,7 @@ void Compile_LB ( void ) {
 }
 
 void Compile_LH ( void ) {
-	int Offset = (short)RSPOpC.offset;
+	int Offset = RSPOpC.offset;
 	BYTE * Jump[2];
 
 	#ifndef Compile_GPRLoads
@@ -655,7 +655,7 @@ void Compile_LH ( void ) {
 }
 
 void Compile_LW ( void ) {
-	int Offset = (short)RSPOpC.offset;
+	int Offset = RSPOpC.offset;
 	BYTE * Jump[2];
 
 	#ifndef Compile_GPRLoads
@@ -722,7 +722,7 @@ void Compile_LW ( void ) {
 }
 
 void Compile_LBU ( void ) {
-	int Offset = (short)RSPOpC.offset;
+	int Offset = RSPOpC.offset;
 
 	#ifndef Compile_GPRLoads
 	Cheat_r4300iOpcode(RSP_Opcode_LBU,"RSP_Opcode_LBU"); return;
@@ -742,7 +742,7 @@ void Compile_LBU ( void ) {
 }
 
 void Compile_LHU ( void ) {
-	int Offset = (short)RSPOpC.offset;
+	int Offset = RSPOpC.offset;
 	BYTE * Jump[2];
 
 	#ifndef Compile_GPRLoads
@@ -797,7 +797,7 @@ void Compile_LHU ( void ) {
 }
 
 void Compile_SB ( void ) {
-	int Offset = (short)RSPOpC.offset;
+	int Offset = RSPOpC.offset;
 
 	#ifndef Compile_GPRStores
 	Cheat_r4300iOpcode(RSP_Opcode_SB,"RSP_Opcode_SB"); return;
@@ -816,7 +816,7 @@ void Compile_SB ( void ) {
 }
 
 void Compile_SH ( void ) {
-	int Offset = (short)RSPOpC.offset;
+	int Offset = RSPOpC.offset;
 	BYTE * Jump[2];
 
 	#ifndef Compile_GPRStores
@@ -871,7 +871,7 @@ void Compile_SH ( void ) {
 }
 
 void Compile_SW ( void ) {
-	int Offset = (short)RSPOpC.offset;
+	int Offset = RSPOpC.offset;
 	BYTE * Jump[2];
 
 	#ifndef Compile_GPRStores
@@ -1373,7 +1373,7 @@ void Compile_RegImm_BLTZ ( void ) {
 		SetlVariable(&BranchCompare, "BranchCompare");
 		NextInstruction = DO_DELAY_SLOT;	
 	} else if ( NextInstruction == DELAY_SLOT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		
 		if (RSPOpC.rs == 0) {
 			NextInstruction = FINISH_SUB_BLOCK;
@@ -1390,7 +1390,7 @@ void Compile_RegImm_BLTZ ( void ) {
 		Branch_AddRef(Target, (DWORD*)(RecompPos - 4));
 		NextInstruction = FINISH_SUB_BLOCK;
 	} else if ( NextInstruction == DELAY_SLOT_EXIT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		CompileBranchExit(Target, CompilePC + 8);
 	} else {
 		CompilerWarning("BLTZ error\nWeird Delay Slot.\n\nNextInstruction = %X\nPC = %X\nEmulation will now stop", NextInstruction, CompilePC);
@@ -1416,7 +1416,7 @@ void Compile_RegImm_BGEZ ( void ) {
 		SetgeVariable(&BranchCompare, "BranchCompare");
 		NextInstruction = DO_DELAY_SLOT;	
 	} else if ( NextInstruction == DELAY_SLOT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		
 		if (RSPOpC.rs == 0) {			
 			JmpLabel32 ( "BranchToJump", 0 );
@@ -1435,7 +1435,7 @@ void Compile_RegImm_BGEZ ( void ) {
 		Branch_AddRef(Target, (DWORD*)(RecompPos - 4));
 		NextInstruction = FINISH_SUB_BLOCK;
 	} else if ( NextInstruction == DELAY_SLOT_EXIT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		CompileBranchExit(Target, CompilePC + 8);
 	} else {
 		CompilerWarning("BGEZ error\nWeird Delay Slot.\n\nNextInstruction = %X\nEmulation will now stop", NextInstruction);
@@ -1455,7 +1455,7 @@ void Compile_RegImm_BLTZAL ( void ) {
 		SetlVariable(&BranchCompare, "BranchCompare");
 		NextInstruction = DO_DELAY_SLOT;	
 	} else if ( NextInstruction == DELAY_SLOT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		
 		if (RSPOpC.rs == 0) {
 			NextInstruction = FINISH_SUB_BLOCK;
@@ -1468,7 +1468,7 @@ void Compile_RegImm_BLTZAL ( void ) {
 		Branch_AddRef(Target, (DWORD*)(RecompPos - 4));
 		NextInstruction = FINISH_SUB_BLOCK;
 	} else if ( NextInstruction == DELAY_SLOT_EXIT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		CompileBranchExit(Target, CompilePC + 8);
 	} else {
 		CompilerWarning("BLTZAL error\nWeird Delay Slot.\n\nNextInstruction = %X\nEmulation will now stop", NextInstruction);
@@ -1495,7 +1495,7 @@ void Compile_RegImm_BGEZAL ( void ) {
 		SetgeVariable(&BranchCompare, "BranchCompare");
 		NextInstruction = DO_DELAY_SLOT;	
 	} else if ( NextInstruction == DELAY_SLOT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		
 		if (RSPOpC.rs == 0) {			
 			JmpLabel32 ( "BranchToJump", 0 );
@@ -1514,7 +1514,7 @@ void Compile_RegImm_BGEZAL ( void ) {
 		Branch_AddRef(Target, (DWORD*)(RecompPos - 4));
 		NextInstruction = FINISH_SUB_BLOCK;
 	} else if ( NextInstruction == DELAY_SLOT_EXIT_DONE ) {
-		DWORD Target = (CompilePC + ((short)RSPOpC.offset << 2) + 4) & 0xFFC;
+		DWORD Target = (CompilePC + (RSPOpC.offset << 2) + 4) & 0xFFC;
 		CompileBranchExit(Target, CompilePC + 8);
 	} else {
 		CompilerWarning("BGEZAL error\nWeird Delay Slot.\n\nNextInstruction = %X\nEmulation will now stop", NextInstruction);

--- a/Source/RSP/Types.h
+++ b/Source/RSP/Types.h
@@ -24,8 +24,26 @@
  *
  */
 
-#ifndef __Types_h 
-#define __Types_h 
+#ifndef __Types_h
+#define __Types_h
+
+/*
+ * Some versions of Microsoft Visual C/++ compilers before Visual Studio 2010
+ * have <stdint.h> removed in favor of these nonstandard built-in types:
+ */
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+typedef signed __int8           int8_t;
+typedef signed __int16          int16_t;
+typedef signed __int32          int32_t;
+typedef signed __int64          int64_t;
+
+typedef unsigned __int8         uint8_t;
+typedef unsigned __int16        uint16_t;
+typedef unsigned __int32        uint32_t;
+typedef unsigned __int64        uint64_t;
+#else
+#include <stdint.h>
+#endif
 
 /*
  * pointer to RSP operation code functions or "func"
@@ -34,39 +52,42 @@
 typedef void(*p_func)(void);
 
 typedef union tagUWORD {
-	long				W;
-	float				F;
-	unsigned long		UW;
-	short				HW[2];
-	unsigned short		UHW[2];
-	char				B[4];
-	unsigned char		UB[4];
+    int32_t     W;
+    uint32_t    UW;
+    int16_t     HW[2];
+    uint16_t    UHW[2];
+    int8_t      B[4];
+    uint8_t     UB[4];
+
+    float       F;
 } UWORD32;
 
 typedef union tagUDWORD {
-	double				D;
-	__int64				DW;
-	unsigned __int64	UDW;
-	long				W[2];
-	float				F[2];
-	unsigned long		UW[2];
-	short				HW[4];
-	unsigned short		UHW[4];
-	char				B[8];
-	unsigned char		UB[8];
+    int64_t     DW;
+    uint64_t    UDW;
+    int32_t     W[2];
+    uint32_t    UW[2];
+    int16_t     HW[4];
+    uint16_t    UHW[4];
+    int8_t      B[8];
+    uint8_t     UB[8];
+
+    double      D;
+    float       F[2];
 } UDWORD;
 
 typedef union tagVect {
-	double				FD[2];
-	__int64				DW[2];
-	unsigned __int64	UDW[2];
-	long				W[4];
-	float				FS[4];
-	unsigned long		UW[4];
-	short				HW[8];
-	unsigned short		UHW[8];
-	char				B[16];
-	unsigned char		UB[16];
+    int64_t     DW[2];
+    uint64_t    UDW[2];
+    int32_t     W[4];
+    uint32_t    UW[4];
+    int16_t     HW[8];
+    uint16_t    UHW[8];
+    int8_t      B[16];
+    uint8_t     UB[16];
+
+    double      FD[2];
+    float       FS[4];
 } VECTOR;
 
 #endif

--- a/Source/RSP/memory.c
+++ b/Source/RSP/memory.c
@@ -109,15 +109,15 @@ void SetJumpTable (DWORD End) {
 	NoOfMaps += 1;
 }
 
-void RSP_LB_DMEM ( DWORD Addr, BYTE * Value ) {
-	* Value = *(BYTE *)(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF)) ;
+void RSP_LB_DMEM ( uint32_t Addr, uint8_t * Value ) {
+	*Value = *(uint8_t *)(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF));
 }
 
-void RSP_LBV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LBV_DMEM ( uint32_t Addr, int vect, int element ) {
 	RSP_Vect[vect].B[15 - element] = *(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF));
 }
 
-void RSP_LDV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LDV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count;
 	
 	length = 8;
@@ -131,7 +131,7 @@ void RSP_LDV_DMEM ( DWORD Addr, int vect, int element ) {
 
 }
 
-void RSP_LFV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LFV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, count;
 	VECTOR Temp;
 
@@ -154,21 +154,21 @@ void RSP_LFV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_LH_DMEM ( DWORD Addr, WORD * Value ) {
+void RSP_LH_DMEM ( uint32_t Addr, uint16_t * Value ) {
 	if ((Addr & 0x1) != 0) {
 		if (Addr > 0xFFE) {
 			DisplayError("hmmmm.... Problem with:\nRSP_LH_DMEM");
 			return;
 		}
 		Addr &= 0xFFF;
-		*Value = *(BYTE *)(RSPInfo.DMEM + (Addr^ 3)) << 8;		
-		*Value += *(BYTE *)(RSPInfo.DMEM + ((Addr + 1)^ 3));
+		*Value  = *(uint8_t *)(RSPInfo.DMEM + ((Addr + 0) ^ 3)) << 8;
+		*Value += *(uint8_t *)(RSPInfo.DMEM + ((Addr + 1) ^ 3)) << 0;
 		return;
 	}
-	* Value = *(WORD *)(RSPInfo.DMEM + ((Addr ^ 2 ) & 0xFFF));	
+	*Value = *(uint16_t *)(RSPInfo.DMEM + ((Addr ^ 2) & 0xFFF));
 }
 
-void RSP_LHV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_LHV_DMEM ( uint32_t Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[7] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element) & 0xF) ^3) & 0xFFF)) << 7;
 	RSP_Vect[vect].HW[6] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 2) & 0xF) ^3) & 0xFFF)) << 7;
 	RSP_Vect[vect].HW[5] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 4) & 0xF) ^3) & 0xFFF)) << 7;
@@ -179,7 +179,7 @@ void RSP_LHV_DMEM ( DWORD Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[0] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 14) & 0xF) ^3) & 0xFFF)) << 7;
 }
 
-void RSP_LLV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LLV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count;
 	
 	length = 4;
@@ -193,7 +193,7 @@ void RSP_LLV_DMEM ( DWORD Addr, int vect, int element ) {
 
 }
 
-void RSP_LPV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_LPV_DMEM ( uint32_t Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[7] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element) & 0xF)^3) & 0xFFF)) << 8;
 	RSP_Vect[vect].HW[6] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 1) & 0xF)^3) & 0xFFF)) << 8;
 	RSP_Vect[vect].HW[5] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 2) & 0xF)^3) & 0xFFF)) << 8;
@@ -204,7 +204,7 @@ void RSP_LPV_DMEM ( DWORD Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[0] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 7) & 0xF)^3) & 0xFFF)) << 8;
 }
 
-void RSP_LRV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_LRV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count, offset;
 
 	offset = (Addr & 0xF) - 1;
@@ -217,7 +217,7 @@ void RSP_LRV_DMEM ( DWORD Addr, int vect, int element ) {
 
 }
 
-void RSP_LQV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LQV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count;
 	
 	length = ((Addr + 0x10) & ~0xF) - Addr;
@@ -231,7 +231,7 @@ void RSP_LQV_DMEM ( DWORD Addr, int vect, int element ) {
 
 }
 
-void RSP_LSV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LSV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count;
 	
 	length = 2;
@@ -244,7 +244,7 @@ void RSP_LSV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_LTV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LTV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int del, count, length;
 	
 	length = 8;
@@ -261,7 +261,7 @@ void RSP_LTV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_LUV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_LUV_DMEM ( uint32_t Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[7] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element) & 0xF)^3) & 0xFFF)) << 7;
 	RSP_Vect[vect].HW[6] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 1) & 0xF)^3) & 0xFFF)) << 7;
 	RSP_Vect[vect].HW[5] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 2) & 0xF)^3) & 0xFFF)) << 7;
@@ -272,38 +272,38 @@ void RSP_LUV_DMEM ( DWORD Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[0] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 7) & 0xF)^3) & 0xFFF)) << 7;
 }
 
-void RSP_LW_DMEM ( DWORD Addr, DWORD * Value ) {
+void RSP_LW_DMEM ( uint32_t Addr, uint32_t * Value ) {
 	if ((Addr & 0x3) != 0) {
 		Addr &= 0xFFF;
 		if (Addr > 0xFFC) {
 			DisplayError("hmmmm.... Problem with:\nRSP_LW_DMEM");
 			return;
 		}
-		*Value = *(BYTE *)(RSPInfo.DMEM + (Addr^ 3)) << 0x18;
-		*Value += *(BYTE *)(RSPInfo.DMEM + ((Addr + 1)^ 3)) << 0x10;
-		*Value += *(BYTE *)(RSPInfo.DMEM + ((Addr + 2)^ 3)) << 8;
-		*Value += *(BYTE *)(RSPInfo.DMEM + ((Addr + 3)^ 3));
+		*Value  = *(uint8_t *)(RSPInfo.DMEM + ((Addr + 0) ^ 3)) << 24;
+		*Value += *(uint8_t *)(RSPInfo.DMEM + ((Addr + 1) ^ 3)) << 16;
+		*Value += *(uint8_t *)(RSPInfo.DMEM + ((Addr + 2) ^ 3)) <<  8;
+		*Value += *(uint8_t *)(RSPInfo.DMEM + ((Addr + 3) ^ 3)) <<  0;
 		return;
 	}
-	* Value = *(DWORD *)(RSPInfo.DMEM + (Addr & 0xFFF));	
+	*Value = *(uint32_t *)(RSPInfo.DMEM + (Addr & 0xFFF));
 }
 
-void RSP_LW_IMEM ( DWORD Addr, DWORD * Value ) {
+void RSP_LW_IMEM ( uint32_t Addr, uint32_t * Value ) {
 	if ((Addr & 0x3) != 0) {
 		DisplayError("Unaligned RSP_LW_IMEM");
 	}
-	* Value = *(DWORD *)(RSPInfo.IMEM + (Addr & 0xFFF));	
+	*Value = *(uint32_t *)(RSPInfo.IMEM + (Addr & 0xFFF));
 }
 
-void RSP_SB_DMEM ( DWORD Addr, BYTE Value ) {
-	*(BYTE *)(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF)) = Value;
+void RSP_SB_DMEM ( uint32_t Addr, uint8_t Value ) {
+	*(uint8_t *)(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF)) = Value;
 }
 
-void RSP_SBV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SBV_DMEM ( uint32_t Addr, int vect, int element ) {
 	*(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF)) = RSP_Vect[vect].B[15 - element];
 }
 
-void RSP_SDV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SDV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count;
 
 	for (Count = element; Count < (8 + element); Count ++ ){
@@ -312,22 +312,22 @@ void RSP_SDV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SFV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_SFV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int offset = Addr & 0xF;
 	Addr &= 0xFF0;
 
 	switch (element) {
 	case 0:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[7] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[6] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[5] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[4] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[7] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[6] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[5] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[4] >> 7) & 0xFF;
 		break;
 	case 1:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[1] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[0] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[3] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[2] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[1] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[0] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[3] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[2] >> 7) & 0xFF;
 		break;
 	case 2:
 		*(RSPInfo.DMEM + ((Addr + offset)^3)) = 0;
@@ -342,16 +342,16 @@ void RSP_SFV_DMEM ( DWORD Addr, int vect, int element ) {
 		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF)^3))) = 0;
 		break;
 	case 4:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[6] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[5] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[4] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[7] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[6] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[5] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[4] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[7] >> 7) & 0xFF;
 		break;
 	case 5:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[0] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[3] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[2] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[1] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[0] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[3] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[2] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[1] >> 7) & 0xFF;
 		break;
 	case 6:
 		*(RSPInfo.DMEM + ((Addr + offset)^3)) = 0;
@@ -366,10 +366,10 @@ void RSP_SFV_DMEM ( DWORD Addr, int vect, int element ) {
 		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = 0;
 		break;
 	case 8:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[3] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[2] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[1] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[0] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[3] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[2] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[1] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[0] >> 7) & 0xFF;
 		break;
 	case 9:
 		*(RSPInfo.DMEM + ((Addr + offset)^3)) = 0;
@@ -384,16 +384,16 @@ void RSP_SFV_DMEM ( DWORD Addr, int vect, int element ) {
 		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = 0;
 		break;
 	case 11:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[4] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[7] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[6] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[5] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[4] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[7] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[6] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[5] >> 7) & 0xFF;
 		break;
 	case 12:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[2] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[1] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[0] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[3] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[2] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[1] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[0] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[3] >> 7) & 0xFF;
 		break;
 	case 13:
 		*(RSPInfo.DMEM + ((Addr + offset)^3)) = 0;
@@ -408,23 +408,23 @@ void RSP_SFV_DMEM ( DWORD Addr, int vect, int element ) {
 		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = 0;
 		break;
 	case 15:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[7] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[6] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[5] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[4] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[7] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[6] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[5] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[4] >> 7) & 0xFF;
 		break;
 	}
 }
 
-void RSP_SH_DMEM ( DWORD Addr, WORD Value ) {
+void RSP_SH_DMEM ( uint32_t Addr, uint16_t Value ) {
 	if ((Addr & 0x1) != 0) {
 		DisplayError("Unaligned RSP_SH_DMEM");
 		return;
 	}
-	*(WORD *)(RSPInfo.DMEM + ((Addr ^ 2) & 0xFFF)) = Value;
+	*(uint16_t *)(RSPInfo.DMEM + ((Addr ^ 2) & 0xFFF)) = Value;
 }
 
-void RSP_SHV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_SHV_DMEM ( uint32_t Addr, int vect, int element ) {
 	*(RSPInfo.DMEM + ((Addr^3) & 0xFFF)) = (RSP_Vect[vect].UB[(15 - element) & 0xF] << 1) + 
 		(RSP_Vect[vect].UB[(14 - element) & 0xF] >> 7);
 	*(RSPInfo.DMEM + (((Addr + 2)^3) & 0xFFF)) = (RSP_Vect[vect].UB[(13 - element) & 0xF] << 1) + 
@@ -443,7 +443,7 @@ void RSP_SHV_DMEM ( DWORD Addr, int vect, int element ) {
 		(RSP_Vect[vect].UB[(0 - element) & 0xF] >> 7);
 }
 
-void RSP_SLV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SLV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count;
 
 	for (Count = element; Count < (4 + element); Count ++ ){
@@ -452,7 +452,7 @@ void RSP_SLV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SPV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SPV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count;
 
 	for (Count = element; Count < (8 + element); Count ++ ){
@@ -466,7 +466,7 @@ void RSP_SPV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SQV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SQV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count;
 	
 	length = ((Addr + 0x10) & ~0xF) - Addr;
@@ -476,7 +476,7 @@ void RSP_SQV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SRV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SRV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count, offset;
 
 	length = (Addr & 0xF);
@@ -488,7 +488,7 @@ void RSP_SRV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SSV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SSV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count;
 
 	for (Count = element; Count < (2 + element); Count ++ ){
@@ -497,7 +497,7 @@ void RSP_SSV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_STV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_STV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int del, count, length;
 	
 	length = 8;
@@ -514,7 +514,7 @@ void RSP_STV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SUV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SUV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count;
 
 	for (Count = element; Count < (8 + element); Count ++ ){
@@ -528,23 +528,23 @@ void RSP_SUV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SW_DMEM ( DWORD Addr, DWORD Value ) {
+void RSP_SW_DMEM ( uint32_t Addr, uint32_t Value ) {
 	Addr &= 0xFFF;
 	if ((Addr & 0x3) != 0) {
 		if (Addr > 0xFFC) {
 			DisplayError("hmmmm.... Problem with:\nRSP_SW_DMEM");
 			return;
 		}
-		*(BYTE *)(RSPInfo.DMEM + (Addr ^ 3)) = (BYTE)((Value >> 0x18) & 0xFF);
-		*(BYTE *)(RSPInfo.DMEM + ((Addr + 1) ^ 3)) = (BYTE)((Value >> 0x10) & 0xFF);
-		*(BYTE *)(RSPInfo.DMEM + ((Addr + 2) ^ 3)) = (BYTE)((Value >> 0x8) & 0xFF);
-		*(BYTE *)(RSPInfo.DMEM + ((Addr + 3) ^ 3)) = (BYTE)(Value &0xFF);
+		*(uint8_t *)(RSPInfo.DMEM + ((Addr + 0) ^ 3)) = (Value >> 24) & 0xFF;
+		*(uint8_t *)(RSPInfo.DMEM + ((Addr + 1) ^ 3)) = (Value >> 16) & 0xFF;
+		*(uint8_t *)(RSPInfo.DMEM + ((Addr + 2) ^ 3)) = (Value >>  8) & 0xFF;
+		*(uint8_t *)(RSPInfo.DMEM + ((Addr + 3) ^ 3)) = (Value >>  0) & 0xFF;
 		return;
 	}
-	*(DWORD *)(RSPInfo.DMEM + Addr) = Value;
+	*(uint32_t *)(RSPInfo.DMEM + Addr) = Value;
 }
 
-void RSP_SWV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SWV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count, offset;
 
 	offset = Addr & 0xF;

--- a/Source/RSP/memory.h
+++ b/Source/RSP/memory.h
@@ -24,6 +24,9 @@
  *
  */
 
+#include <windows.h>
+#include "types.h"
+
 int  AllocateMemory ( void );
 void FreeMemory     ( void );
 void SetJumpTable   ( DWORD End );
@@ -32,33 +35,33 @@ extern BYTE * RecompCode, * RecompCodeSecondary, * RecompPos;
 extern void ** JumpTable;
 extern DWORD Table;
 
-void RSP_LB_DMEM  ( DWORD Addr, BYTE * Value );
-void RSP_LBV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LDV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LFV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LH_DMEM  ( DWORD Addr, WORD * Value );
-void RSP_LHV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LLV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LPV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LRV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LQV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LSV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LTV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LUV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LW_DMEM  ( DWORD Addr, DWORD * Value );
-void RSP_LW_IMEM  ( DWORD Addr, DWORD * Value );
-void RSP_SB_DMEM  ( DWORD Addr, BYTE Value );
-void RSP_SBV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SDV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SFV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SH_DMEM  ( DWORD Addr, WORD Value );
-void RSP_SHV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SLV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SPV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SQV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SRV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SSV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_STV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SUV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SW_DMEM  ( DWORD Addr, DWORD Value );
-void RSP_SWV_DMEM ( DWORD Addr, int vect, int element );
+void RSP_LB_DMEM  ( uint32_t Addr, uint8_t * Value );
+void RSP_LBV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LDV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LFV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LH_DMEM  ( uint32_t Addr, uint16_t * Value );
+void RSP_LHV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LLV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LPV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LRV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LQV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LSV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LTV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LUV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LW_DMEM  ( uint32_t Addr, uint32_t * Value );
+void RSP_LW_IMEM  ( uint32_t Addr, uint32_t * Value );
+void RSP_SB_DMEM  ( uint32_t Addr, uint8_t Value );
+void RSP_SBV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SDV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SFV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SH_DMEM  ( uint32_t Addr, uint16_t Value );
+void RSP_SHV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SLV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SPV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SQV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SRV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SSV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_STV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SUV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SW_DMEM  ( uint32_t Addr, uint32_t Value );
+void RSP_SWV_DMEM ( uint32_t Addr, int vect, int element );


### PR DESCRIPTION
I left the vector unit and the COP2 vector op-code functions alone, since this pull request started to get more and more complex and questionable with the total number of the changes, so here is what has been standardized to fixed-size portable C types, in chronological order of significance:
* RSP word, double-word, and `VECTOR` register union member types
* RSP memory loads and stores
* a few remaining RSP scalar instructions (those inherent from the MIPS R4000 superset) which had type signedness mixing, or the unnecessary use of sign-extended data types in some of the shift or bit-wise op-codes which could further impede non-2's-complement CPU portability

This PR isn't meant to be perfect or 100% complete; at times I had to hold Ctrl+Z and undo some final changes to happen in the future maybe, since things were getting a little too sizable.  I didn't exactly Ctrl+F, find/search for "(WORD)" or "(DWORD)" throughout the RSP solution; I just read through all the interpreter, debugger and recompiler stuff for emulation-relevant usage of them.  Anything that was tied to the Windows operating system or low-level calls to the OS, I left alone to continue to use types like `DWORD`.  I mostly only touched the types for the actual emulation of the RSP CPU to better document them and make them cross-platform; any Windows API stuff like memory protection, debugger windows and recompilers I left alone to continue to use Windows types.

I hope that this helps demonstrate basic type of changes that could be done to the other components outside of the RSP plugin.  Or maybe I can try to mirror what I did here for the main Project64 CPU component if it's that acceptable.