### PR TITLE
Fix linker warning MSB8012 in VS2013 for RSP module.

### DIFF
--- a/Source/RSP/RSP.vcxproj
+++ b/Source/RSP/RSP.vcxproj
@@ -42,6 +42,10 @@
     <TargetName>RSP_d 1.7</TargetName>
     <OutDir>$(SolutionDir)Plugin\RSP\</OutDir>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)Plugin\RSP\</OutDir>
+    <TargetName>RSP 1.7</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader />
@@ -55,9 +59,7 @@
     <ClCompile>
       <PrecompiledHeader />
     </ClCompile>
-    <Link>
-      <OutputFile>$(Root)Plugin/RSP/RSP 1.7.dll</OutputFile>
-    </Link>
+    <Link />
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="breakpoint.c" />


### PR DESCRIPTION
I have no idea where this came from or who did this, but for some reason the **Release** config for the RSP component is inconsistent with the config for the Debug config of the RSP component, the Release config for the PJGlide64 component, and the Debug component of the PJGlide64 component.

PJGlide64 Release, PJGlide64 Debug, and RSP Debug all do this in `RSP.vcxproj` or `Glide64.vcxproj`:
```
General, Output Directory:  $(SolutionDir)Plugin\$(either RSP or GFX goes here)\
General, Target Name:  $(either RSP or PJ64Glide64)[_d] [1.7]
Linker, Output File:  $(OutDir)$(TargetName)$(TargetExt) # This is the default.
```
[And N-Rage Input doesn't seem to be anywhere in this solution from the branch I am sending this pull request, to which I say thank goodness anyway.  So I only have RSP and graphics plugin to compare.]

The odd one out is this config for RSP Release mode, but not Debug, which does:
```
General, Output Directory:  $(SolutionDir)bin\$(Configuration)\ # This is the default.
General, Target Name:  $(ProjectName) # This is the default.
Linker, Output File:  $(Root)Plugin/RSP/RSP 1.7.dll # This is **NOT** the default.
```

Luckily for us, the conflict caused by this didn't amount to the RSP plugin being built in the incorrect directory.  However, we received the following two warnings, which have been fixed in this pull request.
```
warning MSB8012: TargetPath(C:\Users\RJ\project64\bin\Release\RSP.dll) does not match the Linker's OutputFile property value (C:\Users\RJ\project64\Plugin\RSP\RSP 1.7.dll). This may cause your project to build incorrectly. To correct this, please make sure that $(OutDir), $(TargetName) and $(TargetExt) property values match the value specified in %(Link.OutputFile).
warning MSB8012: TargetName(RSP) does not match the Linker's OutputFile property value (RSP 1.7). This may cause your project to build incorrectly. To correct this, please make sure that $(OutDir), $(TargetName) and $(TargetExt) property values match the value specified in %(Link.OutputFile).
```