### PR TITLE
Disassemble memory offsets as signed integers.

### DIFF
--- a/Source/Project64/N64 System/C Core/r4300i Commands.cpp
+++ b/Source/Project64/N64 System/C Core/r4300i Commands.cpp
@@ -628,82 +628,82 @@ char * R4300iOpcodeName ( DWORD OpCode, DWORD PC ) {
 		sprintf(CommandName,"daddiu\t%s, %s, 0x%X",CRegName::GPR[command.rt], CRegName::GPR[command.rs],command.immediate);
 		break;
 	case R4300i_LDL:
-		sprintf(CommandName,"ldl\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"ldl\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LDR:
-		sprintf(CommandName,"ldr\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"ldr\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LB:
-		sprintf(CommandName,"lb\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"lb\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LH:
-		sprintf(CommandName,"lh\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"lh\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LWL:
-		sprintf(CommandName,"lwl\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"lwl\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LW:
-		sprintf(CommandName,"lw\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"lw\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LBU:
-		sprintf(CommandName,"lbu\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"lbu\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LHU:
-		sprintf(CommandName,"lhu\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"lhu\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LWR:
-		sprintf(CommandName,"lwr\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"lwr\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LWU:
-		sprintf(CommandName,"lwu\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"lwu\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SB:
-		sprintf(CommandName,"sb\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"sb\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SH:
-		sprintf(CommandName,"sh\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"sh\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SWL:
-		sprintf(CommandName,"swl\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"swl\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SW:
-		sprintf(CommandName,"sw\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"sw\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SDL:
-		sprintf(CommandName,"sdl\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"sdl\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SDR:
-		sprintf(CommandName,"sdr\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"sdr\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SWR:
-		sprintf(CommandName,"swr\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"swr\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_CACHE:
-		sprintf(CommandName,"cache\t%d, 0x%X (%s)",command.rt, command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"cache\t%d, %i(%s)",command.rt, (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LL:
-		sprintf(CommandName,"ll\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"ll\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LWC1:
-		sprintf(CommandName,"lwc1\t%s, 0x%X (%s)",CRegName::FPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"lwc1\t%s, %i(%s)",CRegName::FPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LDC1:
-		sprintf(CommandName,"ldc1\t%s, 0x%X (%s)",CRegName::FPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"ldc1\t%s, %i(%s)",CRegName::FPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LD:
-		sprintf(CommandName,"ld\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"ld\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SC:
-		sprintf(CommandName,"sc\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"sc\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SWC1:
-		sprintf(CommandName,"swc1\t%s, 0x%X (%s)",CRegName::FPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"swc1\t%s, %i(%s)",CRegName::FPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SDC1:
-		sprintf(CommandName,"sdc1\t%s, 0x%X (%s)",CRegName::FPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"sdc1\t%s, %i(%s)",CRegName::FPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SD:
-		sprintf(CommandName,"sd\t%s, 0x%X (%s)",CRegName::GPR[command.rt], command.offset, CRegName::GPR[command.base]);
+		sprintf(CommandName,"sd\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
 		break;
 	default:	
 		sprintf(CommandName,"Unknown\t%02X %02X %02X %02X",

--- a/Source/Project64/N64 System/C Core/r4300i Commands.cpp
+++ b/Source/Project64/N64 System/C Core/r4300i Commands.cpp
@@ -501,8 +501,11 @@ char * R4300iCop1Name ( DWORD OpCode, DWORD PC ) {
 
 char * R4300iOpcodeName ( DWORD OpCode, DWORD PC ) {
 	OPCODE command;
+	char sign_offset[2];
+	int abs_offset;
+
 	command.Hex = OpCode;
-		
+
 	switch (command.op) {
 	case R4300i_SPECIAL:
 		return R4300iSpecialName ( OpCode, PC );
@@ -628,82 +631,108 @@ char * R4300iOpcodeName ( DWORD OpCode, DWORD PC ) {
 		sprintf(CommandName,"daddiu\t%s, %s, 0x%X",CRegName::GPR[command.rt], CRegName::GPR[command.rs],command.immediate);
 		break;
 	case R4300i_LDL:
-		sprintf(CommandName,"ldl\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"ldl\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LDR:
-		sprintf(CommandName,"ldr\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"ldr\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LB:
-		sprintf(CommandName,"lb\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"lb\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LH:
-		sprintf(CommandName,"lh\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"lh\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LWL:
-		sprintf(CommandName,"lwl\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"lwl\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LW:
-		sprintf(CommandName,"lw\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"lw\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LBU:
-		sprintf(CommandName,"lbu\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"lbu\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LHU:
-		sprintf(CommandName,"lhu\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"lhu\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LWR:
-		sprintf(CommandName,"lwr\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"lwr\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LWU:
-		sprintf(CommandName,"lwu\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"lwu\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SB:
-		sprintf(CommandName,"sb\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"sb\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SH:
-		sprintf(CommandName,"sh\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"sh\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SWL:
-		sprintf(CommandName,"swl\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"swl\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SW:
-		sprintf(CommandName,"sw\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"sw\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SDL:
-		sprintf(CommandName,"sdl\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"sdl\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SDR:
-		sprintf(CommandName,"sdr\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"sdr\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SWR:
-		sprintf(CommandName,"swr\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"swr\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_CACHE:
-		sprintf(CommandName,"cache\t%d, %i(%s)",command.rt, (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"cache\t%d, %s0x%X(%s)",command.rt, sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LL:
-		sprintf(CommandName,"ll\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"ll\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LWC1:
-		sprintf(CommandName,"lwc1\t%s, %i(%s)",CRegName::FPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"lwc1\t%s, %s0x%X(%s)",CRegName::FPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LDC1:
-		sprintf(CommandName,"ldc1\t%s, %i(%s)",CRegName::FPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"ldc1\t%s, %s0x%X(%s)",CRegName::FPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_LD:
-		sprintf(CommandName,"ld\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"ld\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SC:
-		sprintf(CommandName,"sc\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"sc\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SWC1:
-		sprintf(CommandName,"swc1\t%s, %i(%s)",CRegName::FPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"swc1\t%s, %s0x%X(%s)",CRegName::FPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SDC1:
-		sprintf(CommandName,"sdc1\t%s, %i(%s)",CRegName::FPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"sdc1\t%s, %s0x%X(%s)",CRegName::FPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	case R4300i_SD:
-		sprintf(CommandName,"sd\t%s, %i(%s)",CRegName::GPR[command.rt], (short)command.offset, CRegName::GPR[command.base]);
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"sd\t%s, %s0x%X(%s)",CRegName::GPR[command.rt], sign_offset, abs_offset, CRegName::GPR[command.base]);
 		break;
 	default:	
 		sprintf(CommandName,"Unknown\t%02X %02X %02X %02X",

--- a/Source/Project64/N64 System/C Core/r4300i Commands.h
+++ b/Source/Project64/N64 System/C Core/r4300i Commands.h
@@ -37,9 +37,9 @@ char * R4300iOpcodeName ( DWORD OpCode, DWORD PC );
  * natively let us convert to a hexadecimal with a sign prefix.
  */
 #define SPRINTF_FIX_SIGNED_HEX(offset) {               \
-	abs_offset     = (offset < 0) ? -offset : +offset; \
-	sign_offset[0] = (offset < 0) ?     '-' :    '\0'; \
-	sign_offset[1] = '\0';                             \
+    abs_offset     = (offset < 0) ? -offset : +offset; \
+    sign_offset[0] = (offset < 0) ?     '-' :    '\0'; \
+    sign_offset[1] = '\0';                             \
 }
 
 #ifdef __cplusplus

--- a/Source/Project64/N64 System/C Core/r4300i Commands.h
+++ b/Source/Project64/N64 System/C Core/r4300i Commands.h
@@ -30,6 +30,18 @@ extern BOOL InR4300iCommandsWindow;
 char * R4300iOpcodeName ( DWORD OpCode, DWORD PC );
 #endif
 
+/*
+ * for CPU memory loads and stores
+ *
+ * The `offset` immediate is sign-extended, but C standard `sprintf` does not
+ * natively let us convert to a hexadecimal with a sign prefix.
+ */
+#define SPRINTF_FIX_SIGNED_HEX(offset) {               \
+	abs_offset     = (offset < 0) ? -offset : +offset; \
+	sign_offset[0] = (offset < 0) ?     '-' :    '\0'; \
+	sign_offset[1] = '\0';                             \
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -1258,35 +1258,35 @@ char * RSPOpcodeName ( DWORD OpCode, DWORD PC ) {
 		return RSPCop2Name(OpCode,PC);
 		break;
 	case RSP_LB:
-		sprintf(CommandName,"LB\t%s, 0x%04X(%s)",GPR_Name(command.rt), command.offset,
+		sprintf(CommandName,"LB\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_LH:
-		sprintf(CommandName,"LH\t%s, 0x%04X(%s)",GPR_Name(command.rt), command.offset,
+		sprintf(CommandName,"LH\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_LW:
-		sprintf(CommandName,"LW\t%s, 0x%04X(%s)",GPR_Name(command.rt), command.offset,
+		sprintf(CommandName,"LW\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_LBU:
-		sprintf(CommandName,"LBU\t%s, 0x%04X(%s)",GPR_Name(command.rt), command.offset,
+		sprintf(CommandName,"LBU\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_LHU:
-		sprintf(CommandName,"LHU\t%s, 0x%04X(%s)",GPR_Name(command.rt), command.offset,
+		sprintf(CommandName,"LHU\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_SB:
-		sprintf(CommandName,"SB\t%s, 0x%04X(%s)",GPR_Name(command.rt), command.offset,
+		sprintf(CommandName,"SB\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_SH:
-		sprintf(CommandName,"SH\t%s, 0x%04X(%s)",GPR_Name(command.rt), command.offset,
+		sprintf(CommandName,"SH\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_SW:
-		sprintf(CommandName,"SW\t%s, 0x%04X(%s)",GPR_Name(command.rt), command.offset,
+		sprintf(CommandName,"SW\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_LC2:

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -1184,8 +1184,11 @@ char * RSPSc2Name ( DWORD OpCode, DWORD PC ) {
 
 char * RSPOpcodeName ( DWORD OpCode, DWORD PC ) {
 	OPCODE command;
+	char sign_offset[2];
+	int abs_offset;
+
 	command.Hex = OpCode;
-		
+
 	switch (command.op) {
 	case RSP_SPECIAL:
 		return RSPSpecialName(OpCode,PC);
@@ -1258,35 +1261,43 @@ char * RSPOpcodeName ( DWORD OpCode, DWORD PC ) {
 		return RSPCop2Name(OpCode,PC);
 		break;
 	case RSP_LB:
-		sprintf(CommandName,"LB\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"LB\t%s, %s0x%X(%s)",GPR_Name(command.rt), sign_offset, abs_offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_LH:
-		sprintf(CommandName,"LH\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"LH\t%s, %s0x%X(%s)",GPR_Name(command.rt), sign_offset, abs_offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_LW:
-		sprintf(CommandName,"LW\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"LW\t%s, %s0x%X(%s)",GPR_Name(command.rt), sign_offset, abs_offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_LBU:
-		sprintf(CommandName,"LBU\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"LBU\t%s, %s0x%X(%s)",GPR_Name(command.rt), sign_offset, abs_offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_LHU:
-		sprintf(CommandName,"LHU\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"LHU\t%s, %s0x%X(%s)",GPR_Name(command.rt), sign_offset, abs_offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_SB:
-		sprintf(CommandName,"SB\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"SB\t%s, %s0x%X(%s)",GPR_Name(command.rt), sign_offset, abs_offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_SH:
-		sprintf(CommandName,"SH\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"SH\t%s, %s0x%X(%s)",GPR_Name(command.rt), sign_offset, abs_offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_SW:
-		sprintf(CommandName,"SW\t%s, %i(%s)",GPR_Name(command.rt), (short)command.offset,
+		SPRINTF_FIX_SIGNED_HEX((short)command.offset);
+		sprintf(CommandName,"SW\t%s, %s0x%X(%s)",GPR_Name(command.rt), sign_offset, abs_offset,
 			GPR_Name(command.base));
 		break;
 	case RSP_LC2:

--- a/Source/RSP/RSP Command.h
+++ b/Source/RSP/RSP Command.h
@@ -46,7 +46,7 @@ extern BOOL InRSPCommandsWindow;
  * natively let us convert to a hexadecimal with a sign prefix.
  */
 #define SPRINTF_FIX_SIGNED_HEX(offset) {               \
-	abs_offset     = (offset < 0) ? -offset : +offset; \
-	sign_offset[0] = (offset < 0) ?     '-' :    '\0'; \
-	sign_offset[1] = '\0';                             \
+    abs_offset     = (offset < 0) ? -offset : +offset; \
+    sign_offset[0] = (offset < 0) ?     '-' :    '\0'; \
+    sign_offset[1] = '\0';                             \
 }

--- a/Source/RSP/RSP Command.h
+++ b/Source/RSP/RSP Command.h
@@ -38,3 +38,15 @@ void SetRSPCommandViewto ( UINT NewLocation );
 
 extern DWORD Stepping_Commands, WaitingForStep;
 extern BOOL InRSPCommandsWindow;
+
+/*
+ * for CPU memory loads and stores
+ *
+ * The `offset` immediate is sign-extended, but C standard `sprintf` does not
+ * natively let us convert to a hexadecimal with a sign prefix.
+ */
+#define SPRINTF_FIX_SIGNED_HEX(offset) {               \
+	abs_offset     = (offset < 0) ? -offset : +offset; \
+	sign_offset[0] = (offset < 0) ?     '-' :    '\0'; \
+	sign_offset[1] = '\0';                             \
+}


### PR DESCRIPTION
The commands stepper and debugging units of the RSP and VR4300 components to Project64 were using `sprintf` formatting to get the memory load or store offset as a hexadecimal string.  This is rather unintuitive because the offset is always, in the MIPS architecture, a sign-extended immediate operand (as opposed to the "immediate" name given to its counterpart), but that is a pull request for later.

I can give plenty of official examples where programmers have written something more like this:
```asm
LW      $at, -8($t0)
```
It's just more intuitive and more used in practice by N64 developers.  We desire the 32-bit content of memory address *(T0 - 8), not this weird zero-extended hexadecimal that Project64 would always output:
```asm
LW      AT, 0xFFF8(T0)
```
First, FFF8_16 is not a valid offset.  Memory offsets are always in the range { -32768 <= x <= +32767 }.  The correct hexadecimal output would be -0x8(T0), however decimals are probably better in practice due to the scalar arithmetic nature of the offset which is either added or subtracted.  Hexadecimals are better for bit-sensitive operations, absolute addresses or unsigned memory things.