### PR TITLE
Fix RomClosed() issue for RSP #1.1 plugins

### DIFF
--- a/Source/Project64/Plugins/Plugin Base.cpp
+++ b/Source/Project64/Plugins/Plugin Base.cpp
@@ -124,11 +124,13 @@ bool CPlugin::Load (const char * FileName)
 
 void CPlugin::RomOpened()
 {
-	if (m_RomOpen || RomOpen == NULL)
+	if (m_RomOpen)
 		return;
 
 	WriteTraceF(PluginTraceType(),__FUNCTION__ "(%s): Before Rom Open",PluginType());
-	RomOpen();
+	if(RomOpen != NULL){
+		RomOpen();
+	}
 	m_RomOpen = true;
 	WriteTraceF(PluginTraceType(),__FUNCTION__ "(%s): After Rom Open",PluginType());
 }

--- a/Source/Project64/Plugins/Plugin Base.cpp
+++ b/Source/Project64/Plugins/Plugin Base.cpp
@@ -127,12 +127,12 @@ void CPlugin::RomOpened()
 	if (m_RomOpen)
 		return;
 
-	WriteTraceF(PluginTraceType(),__FUNCTION__ "(%s): Before Rom Open",PluginType());
 	if(RomOpen != NULL){
+		WriteTraceF(PluginTraceType(),__FUNCTION__ "(%s): Before Rom Open",PluginType());
 		RomOpen();
+		WriteTraceF(PluginTraceType(),__FUNCTION__ "(%s): After Rom Open",PluginType());
 	}
 	m_RomOpen = true;
-	WriteTraceF(PluginTraceType(),__FUNCTION__ "(%s): After Rom Open",PluginType());
 }
 
 void CPlugin::RomClose()


### PR DESCRIPTION
RSP #1.1 does not have RomOpened() so m_RomOpen is never true. Since
m_RomOpen is never true, RomClosed() never gets called.