### PR TITLE
We need to set the id for XInput controllers separate from the controlle...

### DIFF
--- a/Source/nragev20/NRagePluginV2.cpp
+++ b/Source/nragev20/NRagePluginV2.cpp
@@ -343,6 +343,9 @@ EXPORT void CALL InitiateControllers (CONTROL_INFO * ControlInfo)
 		}
 	}
 
+	//To handle XInput controllers better, we need to set id to 0
+	iXinputControlId = 0;
+
 	int iDevice;
 
 	EnterCriticalSection( &g_critical );
@@ -369,25 +372,19 @@ EXPORT void CALL InitiateControllers (CONTROL_INFO * ControlInfo)
 		LoadShortcutsFromResource(false);
 	}
 
-	for( int i = 0; i < 4; i++)	// initiate xinput controller and plug then if connected --tecnicors
-	{
-		InitiateXInputController( &g_pcControllers[i].xiController, i );
-		if( g_pcControllers[i].xiController.bConnected )
-		{
-			g_pcControllers[i].fPlugged = true;
-			g_pcControllers[i].fGamePad = true;
-		}
-	}	// END
-
 	// Init: Find force-feedback devices and init 
-	for( int i = 3; i >= 0; i-- )
+	for( int i = 0; i < 4; i++ )
 	{
 		DebugWriteA("Controller %d: ", i+1);
-		if( g_pcControllers[i].xiController.bConnected && g_pcControllers[i].fXInput)	// if xinput connected, we don't need other config --tecnicors
-			continue;
 
 		if( g_pcControllers[i].fPlugged )
 		{
+			if (g_pcControllers[i].fXInput)
+			{
+				InitiateXInputController(&g_pcControllers[i].xiController, i);
+				continue;
+			}
+
 			// Search for right Controller
 			iDevice = FindDeviceinList( g_pcControllers[i].guidFFDevice );
 			if( iDevice != -1 && g_devList[iDevice].bEffType )
@@ -526,7 +523,7 @@ EXPORT void CALL GetKeys(int Control, BUTTONS * Keys )
 				GetDeviceDatas();
 				CheckShortcuts();
 			}
-			if( g_pcControllers[Control].xiController.bConnected && g_pcControllers[Control].fXInput )	// reads the xinput controller keys, if connected --tecnicors
+			if( g_pcControllers[Control].fXInput )	// reads the xinput controller keys, if connected --tecnicors
 				GetXInputControllerKeys( Control, &Keys->Value );
 			else
 				GetNControllerInput( Control, &Keys->Value );
@@ -664,7 +661,7 @@ EXPORT void CALL ReadController( int Control, BYTE * Command )
 				GetDeviceDatas();
 				CheckShortcuts();
 			}
-			if( g_pcControllers[Control].xiController.bConnected && g_pcControllers[Control].fXInput )	// reads xinput controller kesy, if connected --tecnicors
+			if( g_pcControllers[Control].fXInput )	// reads xinput controller kesy, if connected --tecnicors
 				GetXInputControllerKeys( Control, (LPDWORD)&Command[3] );
 			else
 				GetNControllerInput( Control, (DWORD*)&Command[3] );

--- a/Source/nragev20/PakIO.cpp
+++ b/Source/nragev20/PakIO.cpp
@@ -210,7 +210,7 @@ bool InitControllerPak( const int iControl )
 //			rPak->bRumbleTyp = g_pcControllers[iControl].bRumbleTyp;
 //			rPak->bRumbleStrength = g_pcControllers[iControl].bRumbleStrength;
 //			rPak->fVisualRumble = g_pcControllers[iControl].fVisualRumble;
-			if( !g_pcControllers[iControl].xiController.bConnected )	//used to make sure only xinput cotroller rumbles --tecnicors
+			if( !g_pcControllers[iControl].fXInput )	//used to make sure only xinput cotroller rumbles --tecnicors
 				CreateEffectHandle( iControl, g_pcControllers[iControl].bRumbleTyp, g_pcControllers[iControl].bRumbleStrength );
 			bReturn = true;
 		}
@@ -339,7 +339,7 @@ BYTE ReadControllerPak( const int iControl, LPBYTE Command )
 			else
 				ZeroMemory( Data, 32 );
 			
-			if( g_pcControllers[iControl].xiController.bConnected && g_pcControllers[iControl].fXInput )	// xinput controller rumble --tecnicors
+			if( g_pcControllers[iControl].fXInput )	// xinput controller rumble --tecnicors
 				VibrateXInputController( g_pcControllers[iControl].xiController.nControl, 0, 0);
 			else if (g_apFFDevice[iControl])
 				g_apFFDevice[iControl]->Acquire();
@@ -496,7 +496,7 @@ BYTE WriteControllerPak( const int iControl, LPBYTE Command )
 	case PAK_RUMBLE:
 		if( dwAddress == PAK_IO_RUMBLE )
 		{
-			if( g_pcControllers[iControl].xiController.bConnected  && g_pcControllers[iControl].fXInput )	// xinput controller rumble --tecnicors
+			if( g_pcControllers[iControl].fXInput )	// xinput controller rumble --tecnicors
 			{
 				if( *Data )
 					VibrateXInputController( g_pcControllers[iControl].xiController.nControl );

--- a/Source/nragev20/XInputController.cpp
+++ b/Source/nragev20/XInputController.cpp
@@ -26,6 +26,9 @@
 #include "resource.h"
 #include <stdio.h>
 
+//We need to keep track of XInput control id's
+int iXinputControlId = 0;
+
 BOOL IsXInputDevice( const GUID* pGuidProductFromDirectInput )
 {
     IWbemLocator*           pIWbemLocator  = NULL;
@@ -344,18 +347,13 @@ bool InitiateXInputController( LPXCONTROLLER gController, int nControl )
 	{
 		return false;
 	}
-
-	DWORD result;
-	XINPUT_STATE state;
-	ZeroMemory( &state, sizeof( XINPUT_STATE ) );
-	result = fnXInputGetState(nControl, &state);
-
-	gController->bConnected = result == ERROR_SUCCESS;
-	gController->nControl = nControl;
 	
+	gController->nControl = iXinputControlId;
+	iXinputControlId++;
+
 	TCHAR buffer[MAX_PATH];
 	GetDirectory( buffer, DIRECTORY_CONFIG );
-	_stprintf_s( buffer, _T("%sXInput Controller %d Config.xcc"), buffer, gController->nControl + 1 );
+	_stprintf_s( buffer, _T("%sXInput Controller %d Config.xcc"), buffer, nControl + 1 );
 	FILE *file = _tfopen( buffer, _T("rS") );
 	if( file )
 	{
@@ -366,7 +364,7 @@ bool InitiateXInputController( LPXCONTROLLER gController, int nControl )
 	if( !gController->bConfigured )
 		DefaultXInputControllerKeys( gController );
 
-	return gController->bConnected;
+	return true;
 }
 
 TCHAR * GetN64ButtonNameFromButtonCode( int Button )

--- a/Source/nragev20/XInputController.h
+++ b/Source/nragev20/XInputController.h
@@ -82,7 +82,6 @@ namespace N64_BUTTONS
 typedef struct _XCONTROLLER		// XInput controller struct
 {
 	int nControl;
-	bool bConnected;
 	bool bConfigured;
 
 	struct _N64_BUTTONS			// For button configurations
@@ -104,6 +103,8 @@ typedef struct _XCONTROLLER		// XInput controller struct
 }XCONTROLLER;
 
 typedef XCONTROLLER *LPXCONTROLLER;
+
+extern int iXinputControlId;
 
 //Initiates XInput library
 bool InitXinput();


### PR DESCRIPTION
...r number where handed.

This is to stop XInput controller one from having to be used in first player.

Also remove the need for the bconnected variable, allows controllers that are connected at game start to be disconnected and reconnected for XInput.