### PR TITLE
Default setup directory fix.

### DIFF
--- a/Source/Installer/Installer.iss
+++ b/Source/Installer/Installer.iss
@@ -4,6 +4,7 @@
 #include BaseDir+"\Source\Installer\binno\binno.iss"
 
 [Setup]
+AppId={{BEB5FB69-4080-466F-96C4-F15DF271718B}
 AppName=Project 64
 AppVersion={#AppVersion}
 DefaultDirName={pf}\Project64 2.2


### PR DESCRIPTION
Without a unique AppId, 2.2 setup will use the previous 2.1 install directory as default, instead of Program Files\Project64 2.2.