### PR TITLE
Redo pull request #92

### DIFF
--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -160,9 +160,7 @@ void RSP_Opcode_COP2 (void) {
 }
 
 void RSP_Opcode_LB ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_LB_DMEM( Address, &RSP_GPR[RSPOpC.rt].UB[0] );
 	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rt].B[0];
 }

--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -168,54 +168,40 @@ void RSP_Opcode_LB ( void ) {
 }
 
 void RSP_Opcode_LH ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_LH_DMEM( Address, &RSP_GPR[RSPOpC.rt].UHW[0] );
 	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rt].HW[0];
 }
 
 void RSP_Opcode_LW ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_LW_DMEM( Address, &RSP_GPR[RSPOpC.rt].UW );
 }
 
 void RSP_Opcode_LBU ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_LB_DMEM( Address, &RSP_GPR[RSPOpC.rt].UB[0] );
 	RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rt].UB[0];
 }
 
 void RSP_Opcode_LHU ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_LH_DMEM( Address, &RSP_GPR[RSPOpC.rt].UHW[0] );
 	RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rt].UHW[0];
 }
 
 void RSP_Opcode_SB ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_SB_DMEM( Address, RSP_GPR[RSPOpC.rt].UB[0] );
 }
 
 void RSP_Opcode_SH ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_SH_DMEM( Address, RSP_GPR[RSPOpC.rt].UHW[0] );
 }
 
 void RSP_Opcode_SW ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_SW_DMEM( Address, RSP_GPR[RSPOpC.rt].UW );
 }
 
@@ -1671,164 +1657,118 @@ void RSP_Vector_VNOOP (void) {}
 
 /************************** lc2 functions **************************/
 void RSP_Opcode_LBV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 0)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 0)) & 0xFFF;
 	RSP_LBV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LSV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 1)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 1)) & 0xFFF;
 	RSP_LSV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LLV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 2)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 2)) & 0xFFF;
 	RSP_LLV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LDV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_LDV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LQV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LQV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LRV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LRV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LPV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_LPV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LUV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_LUV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LHV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LHV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LFV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LFV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LTV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LTV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 /************************** sc2 functions **************************/
 void RSP_Opcode_SBV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 0)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 0)) & 0xFFF;
 	RSP_SBV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SSV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 1)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 1)) & 0xFFF;
 	RSP_SSV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SLV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 2)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 2)) & 0xFFF;
 	RSP_SLV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SDV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_SDV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SQV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SQV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SRV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SRV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SPV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_SPV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SUV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_SUV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SHV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SHV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SFV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SFV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_STV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_STV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SWV ( void ) {
-	uint32_t Address;
-
-	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
+	uint32_t Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SWV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 

--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -99,19 +99,19 @@ void RSP_Opcode_BGTZ ( void ) {
 
 void RSP_Opcode_ADDI ( void ) {
 	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W + (short)RSPOpC.immediate;
+		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W + (int16_t)RSPOpC.immediate;
 	}
 }
 
 void RSP_Opcode_ADDIU ( void ) {
 	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rs].UW + (DWORD)((short)RSPOpC.immediate);
+		RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rs].UW + (uint32_t)((int16_t)RSPOpC.immediate);
 	}
 }
 
 void RSP_Opcode_SLTI (void) {
 	if (RSPOpC.rt == 0) { return; }
-	if (RSP_GPR[RSPOpC.rs].W < (short)RSPOpC.immediate) {
+	if (RSP_GPR[RSPOpC.rs].W < (int16_t)RSPOpC.immediate) {
 		RSP_GPR[RSPOpC.rt].W = 1;
 	} else {
 		RSP_GPR[RSPOpC.rt].W = 0;
@@ -120,7 +120,7 @@ void RSP_Opcode_SLTI (void) {
 
 void RSP_Opcode_SLTIU (void) {
 	if (RSPOpC.rt == 0) { return; }
-	if (RSP_GPR[RSPOpC.rs].UW < (DWORD)(short)RSPOpC.immediate) {
+	if (RSP_GPR[RSPOpC.rs].UW < (uint32_t)(int16_t)RSPOpC.immediate) {
 		RSP_GPR[RSPOpC.rt].W = 1;
 	} else {
 		RSP_GPR[RSPOpC.rt].W = 0;
@@ -147,7 +147,7 @@ void RSP_Opcode_XORI ( void ) {
 
 void RSP_Opcode_LUI (void) {
 	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = (short)RSPOpC.offset << 16;
+		RSP_GPR[RSPOpC.rt].W = RSPOpC.immediate << 16;
 	}
 }
 
@@ -160,46 +160,62 @@ void RSP_Opcode_COP2 (void) {
 }
 
 void RSP_Opcode_LB ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_LB_DMEM( Address, &RSP_GPR[RSPOpC.rt].UB[0] );
 	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rt].B[0];
 }
 
 void RSP_Opcode_LH ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_LH_DMEM( Address, &RSP_GPR[RSPOpC.rt].UHW[0] );
 	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rt].HW[0];
 }
 
 void RSP_Opcode_LW ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_LW_DMEM( Address, &RSP_GPR[RSPOpC.rt].UW );
 }
 
 void RSP_Opcode_LBU ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_LB_DMEM( Address, &RSP_GPR[RSPOpC.rt].UB[0] );
 	RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rt].UB[0];
 }
 
 void RSP_Opcode_LHU ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_LH_DMEM( Address, &RSP_GPR[RSPOpC.rt].UHW[0] );
 	RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rt].UHW[0];
 }
 
 void RSP_Opcode_SB ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_SB_DMEM( Address, RSP_GPR[RSPOpC.rt].UB[0] );
 }
 
 void RSP_Opcode_SH ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_SH_DMEM( Address, RSP_GPR[RSPOpC.rt].UHW[0] );
 }
 
 void RSP_Opcode_SW ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (short)RSPOpC.offset) & 0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (short)RSPOpC.offset) & 0xFFF;
 	RSP_SW_DMEM( Address, RSP_GPR[RSPOpC.rt].UW );
 }
 
@@ -210,6 +226,7 @@ void RSP_Opcode_LC2 (void) {
 void RSP_Opcode_SC2 (void) {
 	RSP_Sc2 [ RSPOpC.rd ]();
 }
+
 /********************** R4300i OpCodes: Special **********************/
 void RSP_Special_SLL ( void ) {
 	if (RSPOpC.rd != 0) {
@@ -332,6 +349,7 @@ void RSP_Special_SLTU (void) {
 		RSP_GPR[RSPOpC.rd].UW = 0;
 	}
 }
+
 /********************** R4300i OpCodes: RegImm **********************/
 void RSP_Opcode_BLTZ ( void ) {
 	RSP_NextInstruction = DELAY_SLOT;
@@ -370,6 +388,7 @@ void RSP_Opcode_BGEZAL ( void ) {
 		RSP_JumpTo = ( *PrgCount + 8 ) & 0xFFC;
 	}
 }
+
 /************************** Cop0 functions *************************/
 void RSP_Cop0_MF (void) {
 	if (LogRDP && CPUCore == InterpreterCPU)
@@ -529,6 +548,7 @@ void RSP_Cop2_CT (void) {
 void RSP_COP2_VECTOR (void) {
 	RSP_Vector[ RSPOpC.funct ]();
 }
+
 /************************** Vect functions **************************/
 void RSP_Vector_VMULF (void) {
 	int el, del;
@@ -1648,120 +1668,167 @@ void RSP_Vector_VRSQH (void) {
 }
 
 void RSP_Vector_VNOOP (void) {}
+
 /************************** lc2 functions **************************/
 void RSP_Opcode_LBV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 0)) & 0xFFF;
 	RSP_LBV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LSV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 1)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 1)) & 0xFFF;
 	RSP_LSV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LLV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 2)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 2)) & 0xFFF;
 	RSP_LLV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LDV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_LDV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LQV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LQV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LRV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LRV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LPV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_LPV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LUV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_LUV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LHV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LHV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LFV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LFV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_LTV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_LTV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 /************************** sc2 functions **************************/
 void RSP_Opcode_SBV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 0)) & 0xFFF;
 	RSP_SBV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SSV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 1)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 1)) & 0xFFF;
 	RSP_SSV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SLV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 2)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 2)) & 0xFFF;
 	RSP_SLV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SDV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_SDV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SQV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SQV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SRV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SRV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SPV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_SPV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SUV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 3)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 3)) & 0xFFF;
 	RSP_SUV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SHV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SHV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SFV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SFV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_STV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_STV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 
 void RSP_Opcode_SWV ( void ) {
-	DWORD Address = ((RSP_GPR[RSPOpC.base].UW + (DWORD)(RSPOpC.voffset << 4)) &0xFFF);
+	uint32_t Address;
+
+	Address = (uint32_t)(RSP_GPR[RSPOpC.base].W + (RSPOpC.voffset << 4)) & 0xFFF;
 	RSP_SWV_DMEM( Address, RSPOpC.rt, RSPOpC.del);
 }
 

--- a/Source/RSP/OpCode.h
+++ b/Source/RSP/OpCode.h
@@ -30,7 +30,7 @@
 #pragma warning(disable : 4201) // nonstandard extension used : nameless struct/union
 
 typedef union tagOPCODE {
-	unsigned long Hex;
+	uint32_t Hex;
 	unsigned char Ascii[4];
 
 	struct {

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -119,7 +119,8 @@ void Disable_RSP_Commands_Window ( void ) {
 }
 
 int DisplayRSPCommand (DWORD location, int InsertPos) {
-	DWORD OpCode, LinesUsed = 1, status;
+	uint32_t OpCode;
+	DWORD LinesUsed = 1, status;
 	BOOL Redraw = FALSE;	
 
 	RSP_LW_IMEM(location, &OpCode);
@@ -149,7 +150,8 @@ int DisplayRSPCommand (DWORD location, int InsertPos) {
 
 void DumpRSPCode (void) {
 	char string[100], LogFileName[255], *p ;
-	DWORD location, OpCode, dwWritten;
+	uint32_t OpCode;
+	DWORD location, dwWritten;
 	HANDLE hLogFile = NULL;
 
 	strcpy(LogFileName,GetCommandLine() + 1);
@@ -185,7 +187,8 @@ void DumpRSPCode (void) {
 
 void DumpRSPData (void) {
 	char string[100], LogFileName[255], *p ;
-	DWORD location, value, dwWritten;
+	uint32_t value;
+	DWORD location, dwWritten;
 	HANDLE hLogFile = NULL;
 
 	strcpy(LogFileName,GetCommandLine() + 1);

--- a/Source/RSP/Types.h
+++ b/Source/RSP/Types.h
@@ -28,45 +28,66 @@
 #define __Types_h 
 
 /*
+ * Some versions of Microsoft Visual C/++ compilers before Visual Studio 2010
+ * have <stdint.h> removed in favor of these nonstandard built-in types:
+ */
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+typedef signed __int8           int8_t;
+typedef signed __int16          int16_t;
+typedef signed __int32          int32_t;
+typedef signed __int64          int64_t;
+
+typedef unsigned __int8         uint8_t;
+typedef unsigned __int16        uint16_t;
+typedef unsigned __int32        uint32_t;
+typedef unsigned __int64        uint64_t;
+#else
+#include <stdint.h>
+#endif
+
+/*
  * pointer to RSP operation code functions or "func"
  * This is the type of all RSP interpreter and recompiler functions.
  */
 typedef void(*p_func)(void);
 
 typedef union tagUWORD {
-	long				W;
-	float				F;
-	unsigned long		UW;
-	short				HW[2];
-	unsigned short		UHW[2];
-	char				B[4];
-	unsigned char		UB[4];
+    int32_t     W;
+    uint32_t    UW;
+    int16_t     HW[2];
+    uint16_t    UHW[2];
+    int8_t      B[4];
+    uint8_t     UB[4];
+
+    float       F;
 } UWORD32;
 
 typedef union tagUDWORD {
-	double				D;
-	__int64				DW;
-	unsigned __int64	UDW;
-	long				W[2];
-	float				F[2];
-	unsigned long		UW[2];
-	short				HW[4];
-	unsigned short		UHW[4];
-	char				B[8];
-	unsigned char		UB[8];
+    int64_t     DW;
+    uint64_t    UDW;
+    int32_t     W[2];
+    uint32_t    UW[2];
+    int16_t     HW[4];
+    uint16_t    UHW[4];
+    int8_t      B[8];
+    uint8_t     UB[8];
+
+    double      D;
+    float       F[2];
 } UDWORD;
 
 typedef union tagVect {
-	double				FD[2];
-	__int64				DW[2];
-	unsigned __int64	UDW[2];
-	long				W[4];
-	float				FS[4];
-	unsigned long		UW[4];
-	short				HW[8];
-	unsigned short		UHW[8];
-	char				B[16];
-	unsigned char		UB[16];
+    int64_t     DW[2];
+    uint64_t    UDW[2];
+    int32_t     W[4];
+    uint32_t    UW[4];
+    int16_t     HW[8];
+    uint16_t    UHW[8];
+    int8_t      B[16];
+    uint8_t     UB[16];
+
+    double      FD[2];
+    float       FS[4];
 } VECTOR;
 
 #endif

--- a/Source/RSP/memory.c
+++ b/Source/RSP/memory.c
@@ -109,15 +109,15 @@ void SetJumpTable (DWORD End) {
 	NoOfMaps += 1;
 }
 
-void RSP_LB_DMEM ( DWORD Addr, BYTE * Value ) {
-	* Value = *(BYTE *)(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF)) ;
+void RSP_LB_DMEM ( uint32_t Addr, uint8_t * Value ) {
+	*Value = *(uint8_t *)(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF));
 }
 
-void RSP_LBV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LBV_DMEM ( uint32_t Addr, int vect, int element ) {
 	RSP_Vect[vect].B[15 - element] = *(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF));
 }
 
-void RSP_LDV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LDV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count;
 	
 	length = 8;
@@ -131,7 +131,7 @@ void RSP_LDV_DMEM ( DWORD Addr, int vect, int element ) {
 
 }
 
-void RSP_LFV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LFV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, count;
 	VECTOR Temp;
 
@@ -154,21 +154,21 @@ void RSP_LFV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_LH_DMEM ( DWORD Addr, WORD * Value ) {
+void RSP_LH_DMEM ( uint32_t Addr, uint16_t * Value ) {
 	if ((Addr & 0x1) != 0) {
 		if (Addr > 0xFFE) {
 			DisplayError("hmmmm.... Problem with:\nRSP_LH_DMEM");
 			return;
 		}
 		Addr &= 0xFFF;
-		*Value = *(BYTE *)(RSPInfo.DMEM + (Addr^ 3)) << 8;		
-		*Value += *(BYTE *)(RSPInfo.DMEM + ((Addr + 1)^ 3));
+		*Value  = *(uint8_t *)(RSPInfo.DMEM + ((Addr + 0) ^ 3)) << 8;
+		*Value += *(uint8_t *)(RSPInfo.DMEM + ((Addr + 1) ^ 3)) << 0;
 		return;
 	}
-	* Value = *(WORD *)(RSPInfo.DMEM + ((Addr ^ 2 ) & 0xFFF));	
+	*Value = *(uint16_t *)(RSPInfo.DMEM + ((Addr ^ 2) & 0xFFF));
 }
 
-void RSP_LHV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_LHV_DMEM ( uint32_t Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[7] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element) & 0xF) ^3) & 0xFFF)) << 7;
 	RSP_Vect[vect].HW[6] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 2) & 0xF) ^3) & 0xFFF)) << 7;
 	RSP_Vect[vect].HW[5] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 4) & 0xF) ^3) & 0xFFF)) << 7;
@@ -179,7 +179,7 @@ void RSP_LHV_DMEM ( DWORD Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[0] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 14) & 0xF) ^3) & 0xFFF)) << 7;
 }
 
-void RSP_LLV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LLV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count;
 	
 	length = 4;
@@ -193,7 +193,7 @@ void RSP_LLV_DMEM ( DWORD Addr, int vect, int element ) {
 
 }
 
-void RSP_LPV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_LPV_DMEM ( uint32_t Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[7] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element) & 0xF)^3) & 0xFFF)) << 8;
 	RSP_Vect[vect].HW[6] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 1) & 0xF)^3) & 0xFFF)) << 8;
 	RSP_Vect[vect].HW[5] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 2) & 0xF)^3) & 0xFFF)) << 8;
@@ -204,7 +204,7 @@ void RSP_LPV_DMEM ( DWORD Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[0] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 7) & 0xF)^3) & 0xFFF)) << 8;
 }
 
-void RSP_LRV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_LRV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count, offset;
 
 	offset = (Addr & 0xF) - 1;
@@ -217,7 +217,7 @@ void RSP_LRV_DMEM ( DWORD Addr, int vect, int element ) {
 
 }
 
-void RSP_LQV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LQV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count;
 	
 	length = ((Addr + 0x10) & ~0xF) - Addr;
@@ -231,7 +231,7 @@ void RSP_LQV_DMEM ( DWORD Addr, int vect, int element ) {
 
 }
 
-void RSP_LSV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LSV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count;
 	
 	length = 2;
@@ -244,7 +244,7 @@ void RSP_LSV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_LTV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_LTV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int del, count, length;
 	
 	length = 8;
@@ -261,7 +261,7 @@ void RSP_LTV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_LUV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_LUV_DMEM ( uint32_t Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[7] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element) & 0xF)^3) & 0xFFF)) << 7;
 	RSP_Vect[vect].HW[6] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 1) & 0xF)^3) & 0xFFF)) << 7;
 	RSP_Vect[vect].HW[5] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 2) & 0xF)^3) & 0xFFF)) << 7;
@@ -272,38 +272,38 @@ void RSP_LUV_DMEM ( DWORD Addr, int vect, int element ) {
 	RSP_Vect[vect].HW[0] = *(RSPInfo.DMEM + ((Addr + ((0x10 - element + 7) & 0xF)^3) & 0xFFF)) << 7;
 }
 
-void RSP_LW_DMEM ( DWORD Addr, DWORD * Value ) {
+void RSP_LW_DMEM ( uint32_t Addr, uint32_t * Value ) {
 	if ((Addr & 0x3) != 0) {
 		Addr &= 0xFFF;
 		if (Addr > 0xFFC) {
 			DisplayError("hmmmm.... Problem with:\nRSP_LW_DMEM");
 			return;
 		}
-		*Value = *(BYTE *)(RSPInfo.DMEM + (Addr^ 3)) << 0x18;
-		*Value += *(BYTE *)(RSPInfo.DMEM + ((Addr + 1)^ 3)) << 0x10;
-		*Value += *(BYTE *)(RSPInfo.DMEM + ((Addr + 2)^ 3)) << 8;
-		*Value += *(BYTE *)(RSPInfo.DMEM + ((Addr + 3)^ 3));
+		*Value  = *(uint8_t *)(RSPInfo.DMEM + ((Addr + 0) ^ 3)) << 24;
+		*Value += *(uint8_t *)(RSPInfo.DMEM + ((Addr + 1) ^ 3)) << 16;
+		*Value += *(uint8_t *)(RSPInfo.DMEM + ((Addr + 2) ^ 3)) <<  8;
+		*Value += *(uint8_t *)(RSPInfo.DMEM + ((Addr + 3) ^ 3)) <<  0;
 		return;
 	}
-	* Value = *(DWORD *)(RSPInfo.DMEM + (Addr & 0xFFF));	
+	*Value = *(uint32_t *)(RSPInfo.DMEM + (Addr & 0xFFF));
 }
 
-void RSP_LW_IMEM ( DWORD Addr, DWORD * Value ) {
+void RSP_LW_IMEM ( uint32_t Addr, uint32_t * Value ) {
 	if ((Addr & 0x3) != 0) {
 		DisplayError("Unaligned RSP_LW_IMEM");
 	}
-	* Value = *(DWORD *)(RSPInfo.IMEM + (Addr & 0xFFF));	
+	*Value = *(uint32_t *)(RSPInfo.IMEM + (Addr & 0xFFF));
 }
 
-void RSP_SB_DMEM ( DWORD Addr, BYTE Value ) {
-	*(BYTE *)(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF)) = Value;
+void RSP_SB_DMEM ( uint32_t Addr, uint8_t Value ) {
+	*(uint8_t *)(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF)) = Value;
 }
 
-void RSP_SBV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SBV_DMEM ( uint32_t Addr, int vect, int element ) {
 	*(RSPInfo.DMEM + ((Addr ^ 3) & 0xFFF)) = RSP_Vect[vect].B[15 - element];
 }
 
-void RSP_SDV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SDV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count;
 
 	for (Count = element; Count < (8 + element); Count ++ ){
@@ -312,22 +312,22 @@ void RSP_SDV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SFV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_SFV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int offset = Addr & 0xF;
 	Addr &= 0xFF0;
 
 	switch (element) {
 	case 0:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[7] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[6] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[5] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[4] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[7] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[6] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[5] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[4] >> 7) & 0xFF;
 		break;
 	case 1:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[1] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[0] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[3] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[2] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[1] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[0] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[3] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[2] >> 7) & 0xFF;
 		break;
 	case 2:
 		*(RSPInfo.DMEM + ((Addr + offset)^3)) = 0;
@@ -342,16 +342,16 @@ void RSP_SFV_DMEM ( DWORD Addr, int vect, int element ) {
 		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF)^3))) = 0;
 		break;
 	case 4:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[6] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[5] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[4] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[7] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[6] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[5] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[4] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[7] >> 7) & 0xFF;
 		break;
 	case 5:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[0] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[3] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[2] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[1] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[0] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[3] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[2] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[1] >> 7) & 0xFF;
 		break;
 	case 6:
 		*(RSPInfo.DMEM + ((Addr + offset)^3)) = 0;
@@ -366,10 +366,10 @@ void RSP_SFV_DMEM ( DWORD Addr, int vect, int element ) {
 		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = 0;
 		break;
 	case 8:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[3] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[2] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[1] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[0] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[3] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[2] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[1] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[0] >> 7) & 0xFF;
 		break;
 	case 9:
 		*(RSPInfo.DMEM + ((Addr + offset)^3)) = 0;
@@ -384,16 +384,16 @@ void RSP_SFV_DMEM ( DWORD Addr, int vect, int element ) {
 		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = 0;
 		break;
 	case 11:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[4] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[7] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[6] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[5] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[4] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[7] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[6] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[5] >> 7) & 0xFF;
 		break;
 	case 12:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[2] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[1] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[0] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[3] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[2] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[1] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[0] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[3] >> 7) & 0xFF;
 		break;
 	case 13:
 		*(RSPInfo.DMEM + ((Addr + offset)^3)) = 0;
@@ -408,23 +408,23 @@ void RSP_SFV_DMEM ( DWORD Addr, int vect, int element ) {
 		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = 0;
 		break;
 	case 15:
-		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (BYTE)(RSP_Vect[vect].UHW[7] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[6] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[5] >> 7);
-		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (BYTE)(RSP_Vect[vect].UHW[4] >> 7);
+		*(RSPInfo.DMEM + ((Addr + offset)^3)) = (RSP_Vect[vect].UHW[7] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 4) & 0xF))^3)) = (RSP_Vect[vect].UHW[6] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 8) & 0xF))^3)) = (RSP_Vect[vect].UHW[5] >> 7) & 0xFF;
+		*(RSPInfo.DMEM + ((Addr + ((offset + 12) & 0xF))^3)) = (RSP_Vect[vect].UHW[4] >> 7) & 0xFF;
 		break;
 	}
 }
 
-void RSP_SH_DMEM ( DWORD Addr, WORD Value ) {
+void RSP_SH_DMEM ( uint32_t Addr, uint16_t Value ) {
 	if ((Addr & 0x1) != 0) {
 		DisplayError("Unaligned RSP_SH_DMEM");
 		return;
 	}
-	*(WORD *)(RSPInfo.DMEM + ((Addr ^ 2) & 0xFFF)) = Value;
+	*(uint16_t *)(RSPInfo.DMEM + ((Addr ^ 2) & 0xFFF)) = Value;
 }
 
-void RSP_SHV_DMEM ( DWORD Addr, int vect, int element ) {	
+void RSP_SHV_DMEM ( uint32_t Addr, int vect, int element ) {
 	*(RSPInfo.DMEM + ((Addr^3) & 0xFFF)) = (RSP_Vect[vect].UB[(15 - element) & 0xF] << 1) + 
 		(RSP_Vect[vect].UB[(14 - element) & 0xF] >> 7);
 	*(RSPInfo.DMEM + (((Addr + 2)^3) & 0xFFF)) = (RSP_Vect[vect].UB[(13 - element) & 0xF] << 1) + 
@@ -443,7 +443,7 @@ void RSP_SHV_DMEM ( DWORD Addr, int vect, int element ) {
 		(RSP_Vect[vect].UB[(0 - element) & 0xF] >> 7);
 }
 
-void RSP_SLV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SLV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count;
 
 	for (Count = element; Count < (4 + element); Count ++ ){
@@ -452,7 +452,7 @@ void RSP_SLV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SPV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SPV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count;
 
 	for (Count = element; Count < (8 + element); Count ++ ){
@@ -466,7 +466,7 @@ void RSP_SPV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SQV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SQV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count;
 	
 	length = ((Addr + 0x10) & ~0xF) - Addr;
@@ -476,7 +476,7 @@ void RSP_SQV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SRV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SRV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int length, Count, offset;
 
 	length = (Addr & 0xF);
@@ -488,7 +488,7 @@ void RSP_SRV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SSV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SSV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count;
 
 	for (Count = element; Count < (2 + element); Count ++ ){
@@ -497,7 +497,7 @@ void RSP_SSV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_STV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_STV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int del, count, length;
 	
 	length = 8;
@@ -514,7 +514,7 @@ void RSP_STV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SUV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SUV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count;
 
 	for (Count = element; Count < (8 + element); Count ++ ){
@@ -528,23 +528,23 @@ void RSP_SUV_DMEM ( DWORD Addr, int vect, int element ) {
 	}
 }
 
-void RSP_SW_DMEM ( DWORD Addr, DWORD Value ) {
+void RSP_SW_DMEM ( uint32_t Addr, uint32_t Value ) {
 	Addr &= 0xFFF;
 	if ((Addr & 0x3) != 0) {
 		if (Addr > 0xFFC) {
 			DisplayError("hmmmm.... Problem with:\nRSP_SW_DMEM");
 			return;
 		}
-		*(BYTE *)(RSPInfo.DMEM + (Addr ^ 3)) = (BYTE)((Value >> 0x18) & 0xFF);
-		*(BYTE *)(RSPInfo.DMEM + ((Addr + 1) ^ 3)) = (BYTE)((Value >> 0x10) & 0xFF);
-		*(BYTE *)(RSPInfo.DMEM + ((Addr + 2) ^ 3)) = (BYTE)((Value >> 0x8) & 0xFF);
-		*(BYTE *)(RSPInfo.DMEM + ((Addr + 3) ^ 3)) = (BYTE)(Value &0xFF);
+		*(uint8_t *)(RSPInfo.DMEM + ((Addr + 0) ^ 3)) = (Value >> 24) & 0xFF;
+		*(uint8_t *)(RSPInfo.DMEM + ((Addr + 1) ^ 3)) = (Value >> 16) & 0xFF;
+		*(uint8_t *)(RSPInfo.DMEM + ((Addr + 2) ^ 3)) = (Value >>  8) & 0xFF;
+		*(uint8_t *)(RSPInfo.DMEM + ((Addr + 3) ^ 3)) = (Value >>  0) & 0xFF;
 		return;
 	}
-	*(DWORD *)(RSPInfo.DMEM + Addr) = Value;
+	*(uint32_t *)(RSPInfo.DMEM + Addr) = Value;
 }
 
-void RSP_SWV_DMEM ( DWORD Addr, int vect, int element ) {
+void RSP_SWV_DMEM ( uint32_t Addr, int vect, int element ) {
 	int Count, offset;
 
 	offset = Addr & 0xF;

--- a/Source/RSP/memory.h
+++ b/Source/RSP/memory.h
@@ -24,6 +24,9 @@
  *
  */
 
+#include <windows.h>
+#include "types.h"
+
 int  AllocateMemory ( void );
 void FreeMemory     ( void );
 void SetJumpTable   ( DWORD End );
@@ -32,33 +35,33 @@ extern BYTE * RecompCode, * RecompCodeSecondary, * RecompPos;
 extern void ** JumpTable;
 extern DWORD Table;
 
-void RSP_LB_DMEM  ( DWORD Addr, BYTE * Value );
-void RSP_LBV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LDV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LFV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LH_DMEM  ( DWORD Addr, WORD * Value );
-void RSP_LHV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LLV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LPV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LRV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LQV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LSV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LTV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LUV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_LW_DMEM  ( DWORD Addr, DWORD * Value );
-void RSP_LW_IMEM  ( DWORD Addr, DWORD * Value );
-void RSP_SB_DMEM  ( DWORD Addr, BYTE Value );
-void RSP_SBV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SDV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SFV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SH_DMEM  ( DWORD Addr, WORD Value );
-void RSP_SHV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SLV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SPV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SQV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SRV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SSV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_STV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SUV_DMEM ( DWORD Addr, int vect, int element );
-void RSP_SW_DMEM  ( DWORD Addr, DWORD Value );
-void RSP_SWV_DMEM ( DWORD Addr, int vect, int element );
+void RSP_LB_DMEM  ( uint32_t Addr, uint8_t * Value );
+void RSP_LBV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LDV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LFV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LH_DMEM  ( uint32_t Addr, uint16_t * Value );
+void RSP_LHV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LLV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LPV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LRV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LQV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LSV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LTV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LUV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_LW_DMEM  ( uint32_t Addr, uint32_t * Value );
+void RSP_LW_IMEM  ( uint32_t Addr, uint32_t * Value );
+void RSP_SB_DMEM  ( uint32_t Addr, uint8_t Value );
+void RSP_SBV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SDV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SFV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SH_DMEM  ( uint32_t Addr, uint16_t Value );
+void RSP_SHV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SLV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SPV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SQV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SRV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SSV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_STV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SUV_DMEM ( uint32_t Addr, int vect, int element );
+void RSP_SW_DMEM  ( uint32_t Addr, uint32_t Value );
+void RSP_SWV_DMEM ( uint32_t Addr, int vect, int element );


### PR DESCRIPTION
Re-doing pull request #92:
_Instantiate fixed-size standard int types to RSP module._

I'm still not very proud of these changes, since forcing exactly an 8-, 16-, or 32-bit type could actually inhibit portability.  (For example, using `unsigned long` instead of `uint32_t` often works just as well, even if the size of `long` is more than 32 bits and you have to `& 0xFFFFFFFFul` from time to time.)  Still, it was agreed that this was more readable for accurate type usage of the MIPS machine versus the Intel machine, and it's still an improvement over the Microsoft WINAPI types.

I redid the pull request to recreate most of the changes, excluding two things @project64 pointed out to be time-consuming to analyze:
* converting MIPS immediate-encoded offset to a signed short instead of an unsigned short
* non-2's-complement CPU portability changes with bit-wise masks and undefined shift left/right