### PR TITLE
Change Supercross 2000 to 64 bit.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -6244,6 +6244,7 @@ Internal Name=Supercross
 Status=Compatible
 Plugin Note=[video] errors:track; use Glide64
 RDRAM Size=8
+32bit=No
 
 [C1452553-5D7B24D9-C:45]
 Good Name=Supercross 2000 (U)
@@ -6251,6 +6252,7 @@ Internal Name=Supercross
 Status=Compatible
 Plugin Note=[video] errors:track; use Glide64
 RDRAM Size=8
+32bit=No
 
 [B44CAB74-07029A29-C:50]
 Good Name=Superman (E) (M6)


### PR DESCRIPTION
The game's music is corrupt in 32 bit mode.