### PR TITLE
Change RE2 to 8MB?

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -914,6 +914,7 @@ Plugin Note=[video] depth problem (use Glide64)
 AiCountPerBytes=800
 Audio Signal=Yes
 Counter Factor=1
+RDRAM Size=8
 
 [7C64E6DB-55B924DB-C:50]
 Good Name=Blast Corps (E)
@@ -5373,6 +5374,7 @@ AiCountPerBytes=800
 Audio Signal=Yes
 Clear Frame=0
 Counter Factor=1
+RDRAM Size=8
 
 [2F493DD0-2E64DFD9-C:45]
 Good Name=Resident Evil 2 (U) (V1.0)
@@ -5392,6 +5394,7 @@ RDRAM Size=8
 Resolution Height=239
 Resolution Width=319
 Self Texture=0
+RDRAM Size=8
 
 [AA18B1A5-07DB6AEB-C:45]
 Good Name=Resident Evil 2 (U) (V1.1)
@@ -5408,6 +5411,7 @@ Culling=1
 Emulate Clear=0
 Primary Frame Buffer=0
 Self Texture=0
+RDRAM Size=8
 
 [02D8366A-6CABEF9C-C:50]
 Good Name=Road Rash 64 (E)


### PR DESCRIPTION
I was wondering whether we should switch RE2 from 4MB to 8MB. With the extra memory, the game starts using all sorts of fancy custom resolutions every time the camera angle changes. (Kinda like Factor 5 games, but way more drastic.) Now while this was a good idea on a real N64, I'm not sure whether it should be enabled on PJ64 by default since most plugins are gonna ignore the resolution anyway - and also because the resolution setting can't be altered ingame.