### PR TITLE
ABL turned off in Pokemon Stadium games

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -4888,12 +4888,8 @@ Clear Frame=0
 Culling=1
 Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [91C9E05D-AD3AAFB9-C:50]
 Good Name=Pokemon Stadium (E) (V1.1)
@@ -4904,12 +4900,8 @@ Clear Frame=0
 Culling=1
 Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [A23553A3-42BF2D39-C:46]
 Good Name=Pokemon Stadium (F)
@@ -4920,12 +4912,8 @@ Clear Frame=0
 Culling=1
 Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [42011E1B-E3552DB5-C:44]
 Good Name=Pokemon Stadium (G)
@@ -4936,12 +4924,8 @@ Clear Frame=0
 Culling=1
 Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [A53FA82D-DAE2C15D-C:49]
 Good Name=Pokemon Stadium (I)
@@ -4952,24 +4936,20 @@ Clear Frame=0
 Culling=1
 Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [665E8259-D098BD1D-C:4A]
 Good Name=Pokemon Stadium (J)
 Internal Name=POKEMON STADIUM
 Status=Compatible
 Plugin Note=[video] (see GameFAQ)
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
-Save Type=Sram
+Clear Frame=0
+Culling=1
+Emulate Clear=1
+Primary Frame Buffer=0
+Self Texture=0
+Linking=Off
 
 [B6E549CE-DC8134C0-C:53]
 Good Name=Pokemon Stadium (S)
@@ -4980,12 +4960,8 @@ Clear Frame=0
 Culling=1
 Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [90F5D9B3-9D0EDCF0-C:45]
 Good Name=Pokemon Stadium (U) (V1.0)
@@ -4994,14 +4970,10 @@ Status=Compatible
 Plugin Note=[video] (see GameFAQ)
 Clear Frame=0
 Culling=1
-Emulate Clear=0
+Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [1A122D43-C17DAF0F-C:45]
 Good Name=Pokemon Stadium - Kiosk (U) (V1.1)
@@ -5012,12 +4984,8 @@ Clear Frame=0
 Culling=1
 Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [9C8FB2FA-9B84A09B-C:45]
 Good Name=Pokemon Stadium (U) (V1.2)
@@ -5026,25 +4994,22 @@ Status=Compatible
 Plugin Note=[video] (see GameFAQ)
 Clear Frame=0
 Culling=1
-Emulate Clear=0
+Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [2952369C-B6E4C3A8-C:50]
 Good Name=Pokemon Stadium 2 (E)
 Internal Name=POKEMON STADIUM 2
 Status=Compatible
 Plugin Note=[video] (see GameFAQ)
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
+Clear Frame=0
+Culling=1
+Emulate Clear=1
+Primary Frame Buffer=0
+Self Texture=0
+Linking=Off
 
 [AC5AA5C7-A9B0CDC3-C:46]
 Good Name=Pokemon Stadium 2 (F)
@@ -5053,58 +5018,58 @@ Status=Compatible
 Plugin Note=[video] (see GameFAQ)
 Clear Frame=0
 Culling=1
-Emulate Clear=0
+Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [439B7E7E-C1A1495D-C:44]
 Good Name=Pokemon Stadium 2 (G)
 Internal Name=POKEMON STADIUM 2
 Status=Compatible
 Plugin Note=[video] (see GameFAQ)
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
+Clear Frame=0
+Culling=1
+Emulate Clear=1
+Primary Frame Buffer=0
+Self Texture=0
+Linking=Off
 
 [EFCEAF00-22094848-C:49]
 Good Name=Pokemon Stadium 2 (I)
 Internal Name=POKEMON STADIUM 2
 Status=Compatible
 Plugin Note=[video] (see GameFAQ)
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
+Clear Frame=0
+Culling=1
+Emulate Clear=1
+Primary Frame Buffer=0
+Self Texture=0
+Linking=Off
 
 [63775886-5FB80E7B-C:4A]
 Good Name=Pokemon Stadium 2 (J)
 Internal Name=POKEMON STADIUM 2
 Status=Compatible
 Plugin Note=[video] (see GameFAQ)
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
+Clear Frame=0
+Culling=1
+Emulate Clear=1
+Primary Frame Buffer=0
+Self Texture=0
+Linking=Off
 
 [D0A1FC5B-2FB8074B-C:53]
 Good Name=Pokemon Stadium 2 (S)
 Internal Name=POKEMON STADIUM 2
 Status=Compatible
 Plugin Note=[video] (see GameFAQ)
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
+Clear Frame=0
+Culling=1
+Emulate Clear=1
+Primary Frame Buffer=0
+Self Texture=0
+Linking=Off
 
 [03571182-892FD06D-C:45]
 Good Name=Pokemon Stadium 2 (U)
@@ -5113,25 +5078,22 @@ Status=Compatible
 Plugin Note=[video] (see GameFAQ)
 Clear Frame=0
 Culling=1
-Emulate Clear=0
+Emulate Clear=1
 Primary Frame Buffer=0
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
 Self Texture=0
+Linking=Off
 
 [EE4FD7C2-9CF1D938-C:4A]
 Good Name=Pokemon Stadium Kin Gin (J)
 Internal Name=POKEMON STADIUM G&S
 Status=Compatible
 Plugin Note=[video] (see GameFAQ)
-SMM-Cache=0
-SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
-SMM-TLB=0
+Clear Frame=0
+Culling=1
+Emulate Clear=1
+Primary Frame Buffer=0
+Self Texture=0
+Linking=Off
 
 [41380792-A167E045-C:45]
 Good Name=Polaris SnoCross (U)


### PR DESCRIPTION
Temporary workaround until the ABL be fixed, Vigilante 8 games are already with ABL turned off.