### PR TITLE
(Glide64) Try to maintain handling the ROM header ANSI text as ASCII data.

### DIFF
--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -1737,6 +1737,8 @@ void CALL RomOpen (void)
     const char invalid_ch = '?'; /* Some Japanese games use wide chars. */
 
     ch = (char)gfx.HEADER[(32 + i) ^ 3];
+    if (ch == '\0')
+      ch = ' ';
     if (ch < ' ')
       ch = invalid_ch;
     if (ch > '~')

--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -1732,8 +1732,18 @@ void CALL RomOpen (void)
 
   // get the name of the ROM
   for (int i=0; i<20; i++)
-    name[i] = gfx.HEADER[(32+i)^3];
-  name[20] = 0;
+  {
+    char ch;
+    const char invalid_ch = '?'; /* Some Japanese games use wide chars. */
+
+    ch = (char)gfx.HEADER[(32 + i) ^ 3];
+    if (ch < ' ')
+      ch = invalid_ch;
+    if (ch > '~')
+      ch = invalid_ch;
+    name[i] = ch;
+  }
+  name[20] = '\0';
 
   // remove all trailing spaces
   while (name[strlen(name)-1] == ' ')

--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -1751,7 +1751,7 @@ void CALL RomOpen (void)
   while (name[strlen(name)-1] == ' ')
     name[strlen(name)-1] = 0;
 
-  wxString strRomName = wxString::FromUTF8(name);
+  wxString strRomName = wxString::FromAscii(name);
   if (settings.ghq_use && strRomName != rdp.RomName)
   {
     ext_ghq_shutdown();


### PR DESCRIPTION
There was a bug some time ago with handling the game title field of the ROM header as ASCII data which triggered an assertion with wxsomething (guess wx is some sort of API I'm unfamiliar with).  @Frank-74 was able to fix this by changing the text processing to assume UTF8 level of input instead of ASCII data.

I wanted to attempt getting it back to ASCII data while still working in the plugin, as this is the native feature of the `char` data type in C anyway, and documentation shows that this part of the ROM header is intended for printable ASCII characters only (`' ' <= char <= '~'`), even though in Japan I guess they use wide chars which was never documented.

So, Frank74, if you can pull from these changes, does this seem to work fine to you?  If we can get your approval on this then maybe we can have zilmar merge these changes.