### PR TITLE
Include more debugging in PJGlide64 for the OpenGL side of it.

### DIFF
--- a/Source/Glide64/Debugger.cpp
+++ b/Source/Glide64/Debugger.cpp
@@ -1072,7 +1072,7 @@ int grDisplayGLError(const char* message)
 #ifdef _WIN32
     MessageBoxA(NULL, message, GL_errors[error_index], MB_ICONERROR);
 #else
-    fprintf(stderr, "%s\n%s\n\n", GL_errors[index], message);
+    fprintf(stderr, "%s\n%s\n\n", GL_errors[error_index], message);
 #endif
     return (failure);
 }

--- a/Source/Glide64/Debugger.cpp
+++ b/Source/Glide64/Debugger.cpp
@@ -1072,7 +1072,7 @@ int grDisplayGLError(const char* message)
 #ifdef _WIN32
     MessageBoxA(NULL, message, GL_errors[error_index], MB_ICONERROR);
 #else
-    fprintf(stderr, "%s\n%s\n\n", GL_errors[index], text);
+    fprintf(stderr, "%s\n%s\n\n", GL_errors[index], message);
 #endif
     return (failure);
 }

--- a/Source/Glide64/Debugger.h
+++ b/Source/Glide64/Debugger.h
@@ -135,3 +135,5 @@ void debug_cacheviewer ();
 void debug_mouse ();
 void debug_keys ();
 void output (float x, float y, int scale, const char *fmt, ...);
+
+extern int grDisplayGLError( const char * message );

--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -1878,6 +1878,10 @@ void CALL UpdateScreen (void)
   if (fullscreen && (*gfx.VI_ORIGIN_REG  > width))
     update_screen_count++;
 
+#if defined(_DEBUG) || 0
+  grDisplayGLError("UpdateScreen");
+#endif
+
 #ifdef FPS
   // vertical interrupt has occurred, increment counter
   vi_count ++;

--- a/Source/Glitch64/main.cpp
+++ b/Source/Glitch64/main.cpp
@@ -2115,6 +2115,10 @@ grBufferSwap( FxU32 swap_interval )
   for (i = 0; i < nb_fb; i++)
     fbs[i].buff_clear = 1;
 
+#ifdef _DEBUG
+  grFinish();
+#endif
+
   // VP debugging
 #ifdef VPDEBUG
   dump_stop();

--- a/Source/Glitch64/main.cpp
+++ b/Source/Glitch64/main.cpp
@@ -2572,13 +2572,13 @@ grErrorSetCallback( GrErrorCallbackFnc_t /*fnc*/ )
 FX_ENTRY void FX_CALL
 grFinish(void)
 {
-  display_warning("grFinish");
+  glFinish();
 }
 
 FX_ENTRY void FX_CALL
 grFlush(void)
 {
-  display_warning("grFlush");
+  glFlush();
 }
 
 FX_ENTRY void FX_CALL


### PR DESCRIPTION
Currently there seems to be no checking done whatsoever in this plugin for OpenGL state machine errors.  (This is always done in any version of OpenGL since 1.0 up to 4.x using the call `glGetError`.)  I added a function that can be used to check if anything is in the error queue for OpenGL at run-time and, if so, pop up a Win32 MessageBox on-screen to alert the user that there is an error.  Since constantly probing the GL as a state machine tends to be unusually resource-intensive on common implementations, I decided to macro it out if not compiling as a Debug build.

This is also partly an attempt to debug an issue Frank74 is having here with black frozen screen:
https://github.com/project64/project64/issues/152

Since it happens on his machine and not mine, there is a vague possibility that it is a problem with his OpenGL drivers.  I might or might not be able to catch it by merely checking for state machine errors using this function, but still I think it is a nice resource to have for virtually any OpenGL application that would ever have any use for debugging.

I also implemented `glFlush` and `glFinish` and told the buffer-swapping mechanism inside Glitch64 to call `glFinish` in Debug builds of this plugin, to help guarantee the synchronicity of OpenGL commands to the current thread status.  This might or might not also affect frozen screen issue.