### PR TITLE
a couple minor improvements to Glitch64 geometry, vector processing

### DIFF
--- a/Source/Glitch64/geometry.cpp
+++ b/Source/Glitch64/geometry.cpp
@@ -228,9 +228,13 @@ grDepthMask( FxBool mask )
 float biasFactor = 0;
 void FindBestDepthBias()
 {
+  GLfloat vertices[4][3];
   float f, bestz = 0.25f;
   int x;
-  if (biasFactor) return;
+
+  if (biasFactor)
+    return;
+
   biasFactor = 64.0f; // default value
   glPushAttrib(GL_ALL_ATTRIB_BITS);
   glEnable(GL_DEPTH_TEST);
@@ -242,14 +246,28 @@ void FindBestDepthBias()
   glDisable(GL_ALPHA_TEST);
   glColor4ub(255,255,255,255);
   glDepthMask(GL_TRUE);
-  for (x=0, f=1.0f; f<=65536.0f; x+=4, f*=2.0f) {
+
+  for (x = 0; x < 4; x++)
+    vertices[x][2] = 0.5;
+
+  for (x = 0, f = 1.0f; f <= 65536.0f; x += 4, f *= 2.0f) {
     float z;
+
+    vertices[0][0] = float(x + 4 - widtho)  / (width  / 2);
+    vertices[0][1] = float(0 + 0 - heighto) / (height / 2);
+    vertices[1][0] = float(x + 0 - widtho)  / (width  / 2);
+    vertices[1][1] = float(0 + 0 - heighto) / (height / 2);
+    vertices[2][0] = float(x + 4 - widtho)  / (width  / 2);
+    vertices[2][1] = float(0 + 4 - heighto) / (height / 2);
+    vertices[3][0] = float(x + 0 - widtho)  / (width  / 2);
+    vertices[3][1] = float(0 + 4 - heighto) / (height / 2);
     glPolygonOffset(0, f);
+
     glBegin(GL_TRIANGLE_STRIP);
-    glVertex3f(float(x+4 - widtho)/(width/2), float(0 - heighto)/(height/2), 0.5);
-    glVertex3f(float(x - widtho)/(width/2), float(0 - heighto)/(height/2), 0.5);
-    glVertex3f(float(x+4 - widtho)/(width/2), float(4 - heighto)/(height/2), 0.5);
-    glVertex3f(float(x - widtho)/(width/2), float(4 - heighto)/(height/2), 0.5);
+    glVertex3fv(vertices[0]);
+    glVertex3fv(vertices[1]);
+    glVertex3fv(vertices[2]);
+    glVertex3fv(vertices[3]);
     glEnd();
 
     glReadPixels(x+2, 2+viewport_offset, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT, &z);

--- a/Source/Glitch64/main.cpp
+++ b/Source/Glitch64/main.cpp
@@ -1786,44 +1786,41 @@ static void render_rectangle(int texture_number,
                              int src_width, int src_height,
                              int tex_width, int tex_height, int invert)
 {
-  GLfloat planar_vertex[2];
+  GLfloat planar_vertices[5][2];
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
+  planar_vertices[0][0] =  ((int)dst_x - widtho)  / (float)(width  / 2);
+  planar_vertices[0][1] = -((int)dst_y - heighto) / (float)(height / 2) * invert;
+  planar_vertices[1][0] =  ((int)dst_x                   - widtho)  / (float)(width  / 2);
+  planar_vertices[1][1] = -((int)dst_y + (int)src_height - heighto) / (float)(height / 2) * invert;
+  planar_vertices[2][0] =  ((int)dst_x + (int)src_width  - widtho)  / (float)(width  / 2);
+  planar_vertices[2][1] = -((int)dst_y + (int)src_height - heighto) / (float)(height / 2) * invert;
+  planar_vertices[3][0] =  ((int)dst_x + (int)src_width  - widtho)  / (float)(width  / 2);
+  planar_vertices[3][1] = -((int)dst_y                   - heighto) / (float)(height / 2) * invert;
+  planar_vertices[4][0] =  ((int)dst_x - widtho)  / (float)(width  / 2);
+  planar_vertices[4][1] = -((int)dst_y - heighto) / (float)(height / 2) * invert;
+
   glBegin(GL_QUADS);
 
   glMultiTexCoord2fARB(texture_number, 0.0f, 0.0f);
-
-  planar_vertex[0] =  ((int)dst_x - widtho)  / (float)(width  / 2);
-  planar_vertex[1] = -((int)dst_y - heighto) / (float)(height / 2) * invert;
-  glVertex2fv(planar_vertex);
+  glVertex2fv(planar_vertices[0]);
 
   glMultiTexCoord2fARB(texture_number, 0.0f, (float)src_height / (float)tex_height);
-
-  planar_vertex[0] =  ((int)dst_x                   - widtho)  / (float)(width  / 2);
-  planar_vertex[1] = -((int)dst_y + (int)src_height - heighto) / (float)(height / 2) * invert;
-  glVertex2fv(planar_vertex);
+  glVertex2fv(planar_vertices[1]);
 
   glMultiTexCoord2fARB(texture_number, (float)src_width / (float)tex_width, (float)src_height / (float)tex_height);
-
-  planar_vertex[0] =  ((int)dst_x + (int)src_width  - widtho)  / (float)(width  / 2);
-  planar_vertex[1] = -((int)dst_y + (int)src_height - heighto) / (float)(height / 2) * invert;
-  glVertex2fv(planar_vertex);
+  glVertex2fv(planar_vertices[2]);
 
   glMultiTexCoord2fARB(texture_number, (float)src_width / (float)tex_width, 0.0f);
-
-  planar_vertex[0] =  ((int)dst_x + (int)src_width  - widtho)  / (float)(width  / 2);
-  planar_vertex[1] = -((int)dst_y                   - heighto) / (float)(height / 2) * invert;
-  glVertex2fv(planar_vertex);
+  glVertex2fv(planar_vertices[3]);
 
   glMultiTexCoord2fARB(texture_number, 0.0f, 0.0f);
+  glVertex2fv(planar_vertices[4]);
 
-  planar_vertex[0] =  ((int)dst_x - widtho)  / (float)(width  / 2);
-  planar_vertex[1] = -((int)dst_y - heighto) / (float)(height / 2) * invert;
-  glVertex2fv(planar_vertex);
   glEnd();
 
   compile_shader();

--- a/Source/Glitch64/main.cpp
+++ b/Source/Glitch64/main.cpp
@@ -1786,26 +1786,44 @@ static void render_rectangle(int texture_number,
                              int src_width, int src_height,
                              int tex_width, int tex_height, int invert)
 {
+  GLfloat planar_vertex[2];
+
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
   glBegin(GL_QUADS);
+
   glMultiTexCoord2fARB(texture_number, 0.0f, 0.0f);
-  glVertex2f(((int)dst_x - widtho) / (float)(width/2),
-    invert*-((int)dst_y - heighto) / (float)(height/2));
+
+  planar_vertex[0] =  ((int)dst_x - widtho)  / (float)(width  / 2);
+  planar_vertex[1] = -((int)dst_y - heighto) / (float)(height / 2) * invert;
+  glVertex2fv(planar_vertex);
+
   glMultiTexCoord2fARB(texture_number, 0.0f, (float)src_height / (float)tex_height);
-  glVertex2f(((int)dst_x - widtho) / (float)(width/2),
-    invert*-((int)dst_y + (int)src_height - heighto) / (float)(height/2));
+
+  planar_vertex[0] =  ((int)dst_x                   - widtho)  / (float)(width  / 2);
+  planar_vertex[1] = -((int)dst_y + (int)src_height - heighto) / (float)(height / 2) * invert;
+  glVertex2fv(planar_vertex);
+
   glMultiTexCoord2fARB(texture_number, (float)src_width / (float)tex_width, (float)src_height / (float)tex_height);
-  glVertex2f(((int)dst_x + (int)src_width - widtho) / (float)(width/2),
-    invert*-((int)dst_y + (int)src_height - heighto) / (float)(height/2));
+
+  planar_vertex[0] =  ((int)dst_x + (int)src_width  - widtho)  / (float)(width  / 2);
+  planar_vertex[1] = -((int)dst_y + (int)src_height - heighto) / (float)(height / 2) * invert;
+  glVertex2fv(planar_vertex);
+
   glMultiTexCoord2fARB(texture_number, (float)src_width / (float)tex_width, 0.0f);
-  glVertex2f(((int)dst_x + (int)src_width - widtho) / (float)(width/2),
-    invert*-((int)dst_y - heighto) / (float)(height/2));
+
+  planar_vertex[0] =  ((int)dst_x + (int)src_width  - widtho)  / (float)(width  / 2);
+  planar_vertex[1] = -((int)dst_y                   - heighto) / (float)(height / 2) * invert;
+  glVertex2fv(planar_vertex);
+
   glMultiTexCoord2fARB(texture_number, 0.0f, 0.0f);
-  glVertex2f(((int)dst_x - widtho) / (float)(width/2),
-    invert*-((int)dst_y - heighto) / (float)(height/2));
+
+  planar_vertex[0] =  ((int)dst_x - widtho)  / (float)(width  / 2);
+  planar_vertex[1] = -((int)dst_y - heighto) / (float)(height / 2) * invert;
+  glVertex2fv(planar_vertex);
   glEnd();
 
   compile_shader();


### PR DESCRIPTION
Looking through Glitch64 source for the first time, I can see that there is an interesting mix of primitive (certainly deprecated) OpenGL commands along with extension loading for more modern OpenGL commands (some of which also deprecated).  A lot of it was a big forest to sift through vectorizing it in a stable manner, but I felt like having fun using coordinate arrays for some very miniscule vectorization.  I don't have any knowledge of OpenGL 3.0 features or things like using shaders so could only go so far with it to begin with.

In spite of being more of a CAD person with OpenGL (computer-aided design, college algebra/trigonometry research) instead of a video gaming and design performance person with OpenGL, I do believe that there is no excuse for not using the vector variants of the immediate-mode `glVertex*` calls, in place of the non-vector variants.

For example, instead of saying this:
```c
extern GLfloat f(GLint coordinate);

for (GLint x = 0; x < 64; x++)
    for (GLint y = 0; y < 64; y++)
        glVertex2f(f(x), y);
```
... it would be a tad improvement to try ...
```c
extern GLfloat f(GLint coordinate);

GLfloat vertices[64 * 64][2];
register int i = 0;

for (GLint x = 0; x < 64; x++)
    for (GLint y = 0; y < 64; y++) {
        vertices[i][0] = f(x);
        vertices[i][1] = y;
        i += 1;
    }

for (x = 0; x < i; x++)
    glVertex2fv(vertices[x]);
```
... which could then of course be improved way further using vertex arrays, first client-side then server-side with shaders probably, but that's beside the point.

The point is that that the vector form of `glVertex*` has been supported since the beginning of time for OpenGL, since version 1.0.  In fact, OpenGL 1.1 documentation specifically states that the vector form can be more optimized within the implementation for a couple reasons.  So, I don't know why Glitch64 has not used it.  I guess Glitch64 was meant to be complete and stable, not necessarily optimized, since the real API in question was GLIDE.

Lastly, believe it or not, but the file size of the DLL went down a little from each of these changes, not up.