### PR TITLE
Glide Config/About dialog memory leak fix?

### DIFF
--- a/Source/Glide64/Config.cpp
+++ b/Source/Glide64/Config.cpp
@@ -1122,6 +1122,7 @@ void CALL DllConfig ( HWND hParent )
 
   Glide64ConfigDialog* Glide64Config = new Glide64ConfigDialog(hostWindow, wxID_ANY, wxEmptyString);
   Glide64Config->ShowModal();
+  delete hostWindow;
 }
 
 /*#ifndef _DEBUG
@@ -1304,5 +1305,6 @@ void CALL DllAbout ( HWND hParent )
   hostWindow->Enable();
   //  hostWindow->UnsubclassWin();
   hostWindow->SetHWND(NULL);
+  delete hostWindow;
 #endif
 }


### PR DESCRIPTION
I'm still getting this one.  Haven't a clue about it.

>Order, Source File, Line Number, Mem Size
4332,Unknown, 0, 64

Its triggered also when starting a game with glide and closing project64 as soon as glide has loaded.