### PR TITLE
RDB fixes to "Battlezone:  Rize of the Black Dogs"

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -845,8 +845,7 @@ Counter Factor=3
 [55D4C4CE-7753C78A-C:45]
 Good Name=Battlezone - Rise of the Black Dogs (U)
 Internal Name=BATTLEZONE
-Status=Broken (core)
-Core Note=broken graphics; use older PJ64
+Status=Compatible
 AiCountPerBytes=200
 Counter Factor=1
 

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -848,6 +848,7 @@ Internal Name=BATTLEZONE
 Status=Broken (core)
 Core Note=broken graphics; use older PJ64
 AiCountPerBytes=200
+Counter Factor=1
 
 [9C7318D2-24AE0DC1-C:4A]
 Good Name=Beetle Adventure Racing (J)


### PR DESCRIPTION
A couple issues with this game were raised on IRC when theboy181 mentioned some flickering polygons on/off with all graphics plugins/RSP plugins/different emulator cores besides Project64.  Actually the real issue was that "Counter Factor" should be set to not 2, 3 or 4, but to 1.

This also improves the high-res video display with a pixel-accurate plugin and 8 MB RDRAM expansion pak installed, though I would rather not set RDRAM size from 4 to 8 MB in the RDB yet since Project64's VI timing is still off and has jittery scan-line interlacing.  So currently have it set to 4 MB for low-res graphics but less line glitching.