### PR TITLE
Infernal Machine stability fixes.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -2967,13 +2967,12 @@ Status=Compatible
 Plugin Note=[video] errors:HUD; use Glide64
 Counter Factor=1
 
-
 [3A6F8C6B-2897BAEB-C:50]
 Good Name=Indiana Jones and the Infernal Machine (E) (Unreleased)
 Internal Name=Indiana Jones
-Status=Only intro/part OK
-Core Note=unstable (see GameFAQ)
-Plugin Note=[rsp] interpreter only [video] errors:various (see GameFAQ)
+Status=Issues (mixed)
+Core Note=Recompiler Trading Post freeze.
+Plugin Note=[rsp] interpreter only [sound] timing and crackle
 32bit=No
 RDRAM Size=8
 FuncFind=1
@@ -2982,32 +2981,38 @@ ViRefresh=1400
 RSP-JumpTableSize=3584
 SMM-Cache=1
 SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
+SMM-PI DMA=1
+SMM-Protect=0
 SMM-TLB=0
 Sync Audio=0
 Fixed Audio=1
-CPU Type=Interpreter
+CPU Type=Recompiler
+Linking=Off
+Fast SP=No
 
 [AF9DCC15-1A723D88-C:45]
 Good Name=Indiana Jones and the Infernal Machine (U)
 Internal Name=Indiana Jones
-Status=Only intro/part OK
-Core Note=unstable (see GameFAQ)
-Plugin Note=[rsp] interpreter only [video] errors:various (see GameFAQ)
+Status=Issues (mixed)
+Core Note=Recompiler Trading Post freeze.
+Plugin Note=[rsp] interpreter only [sound] timing and crackle
 32bit=No
+Counter Factor=1
+RDRAM Size=8
 FuncFind=1
 HLE GFX=No
 ViRefresh=1400
 RSP-JumpTableSize=3584
 SMM-Cache=1
 SMM-FUNC=0
-SMM-PI DMA=0
-SMM-Protect=1
+SMM-PI DMA=1
+SMM-Protect=0
 SMM-TLB=0
 Sync Audio=0
 Fixed Audio=1
-CPU Type=Interpreter
+CPU Type=Recompiler
+Linking=Off
+Fast SP=No
 
 [E436467A-82DE8F9B-C:45]
 Good Name=Indy Racing 2000 (U)


### PR DESCRIPTION
Changing to CF1 fixes the jeep handling and some nasty stuttering.
Disabling Fast SP fixed some crashes with recompiler. Also seems to fix environment flicker?
Plus some other tweaks.

The game seems stable on a custom build (with the Factor 5 hack) with CPU recompiler and cxd4 RSP interpreter during testing except for the end of levels, when Indy's Trading Post causes the game to crash without Interpreter. The game appears to be far more stable in PJ64 than mupen64plus, however the game's audio timings are off, and the sound crackles. But I was able to drive Indy's jeep round in circles for 15 minutes without a single lockup.