### PR TITLE
speed improvements to "CD64 Memory Test" ROM

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -8146,7 +8146,7 @@ Status=Unsupported
 [95081A8B-49DFE4FA-C:45]
 Good Name=CD64 Memory Test (PD)
 Internal Name=CD64 SIMMtest
-Status=Issues (core)
+Status=Compatible
 CPU Type=Interpreter
 
 [EDA1A0C7-58EE0464-C:0]

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -8148,6 +8148,7 @@ Good Name=CD64 Memory Test (PD)
 Internal Name=CD64 SIMMtest
 Status=Issues (core)
 Core Note=unknown country error
+CPU Type=Interpreter
 
 [EDA1A0C7-58EE0464-C:0]
 Good Name=Chaos 89 Demo (PD)

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -8147,7 +8147,6 @@ Status=Unsupported
 Good Name=CD64 Memory Test (PD)
 Internal Name=CD64 SIMMtest
 Status=Issues (core)
-Core Note=unknown country error
 CPU Type=Interpreter
 
 [EDA1A0C7-58EE0464-C:0]

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -8148,6 +8148,7 @@ Good Name=CD64 Memory Test (PD)
 Internal Name=CD64 SIMMtest
 Status=Compatible
 CPU Type=Interpreter
+Use TLB=No
 
 [EDA1A0C7-58EE0464-C:0]
 Good Name=Chaos 89 Demo (PD)


### PR DESCRIPTION
A few of these demos seem to have not had their status checked for a very long time.  This is one of those ROMs that's marked to have core issues (or even sometimes "Unsupported") when actually it works just fine in Project64 1.7+.  https://github.com/project64/project64/issues/219

The only issue here is that there were pros and cons to implementing range-checking to the compiler before generating code, so it's decided we would have the best performance when using the interpreter core.  So that was set in the RDB.  Also disabled TLB since ROM doesn't seem to use it, for another 2 VI/s.