### PR TITLE
Cube Demo (PD) has not had any problems since PJ64 1.6.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -8272,7 +8272,7 @@ Core Note=unknown country error
 [0E3ED77B-8E1C26FD-C:0]
 Good Name=Cube Demo (PD)
 Internal Name=h¼
-Status=Unsupported
+Status=Compatible
 
 [5B9D65DF-A18AB4AE-C:0]
 Good Name=CZN Module Player (PD)


### PR DESCRIPTION
I don't know why, but this demo failed to boot on Project64 1.6, just not on 2.x.

I wish I knew what the fix was, but right now for this it doesn't matter.  The RDB status entry is incorrect.