### PR TITLE
I don't always debug, but when I do...

### DIFF
--- a/Source/Glide64/Debugger.cpp
+++ b/Source/Glide64/Debugger.cpp
@@ -1045,6 +1045,11 @@ int grDisplayGLError(const char* message)
     GLenum status;
     unsigned int error_index;
     int failure;
+    const short debug_setting = FindSystemSettingId("Debugger");
+    const unsigned int Project64_debugging = GetSystemSetting(debug_setting);
+
+    if (Project64_debugging == 0)
+        return (failure = -1); /* error checking for errors:  pj64 debug off */
 
     status = glGetError();
     failure = 1;

--- a/Source/Glide64/Debugger.cpp
+++ b/Source/Glide64/Debugger.cpp
@@ -41,15 +41,6 @@
 #include "Util.h"
 #include "Debugger.h"
 
-/*
- * required to include OpenGL library without errors
- * Dependency on OpenGL in this module is limited to just `glGetError`.
- */
-#ifdef _WIN32
-#include <windows.h>
-#endif
-#include <GL/gl.h>
-
 GLIDE64_DEBUGGER _debugger;
 
 #define SX(x) ((x)*rdp.scale_1024)
@@ -1026,58 +1017,4 @@ void output (float x, float y, int scale, const char *fmt, ...)
 
     x+=8;
   }
-}
-
-static const char * GL_errors[7 + 1] = {
-    "GL_NO_ERROR", /* "There is no current error." */
-    "GL_INVALID_ENUM", /* "Invalid parameter." */
-    "GL_INVALID_VALUE", /* "Invalid enum parameter value." */
-    "GL_INVALID_OPERATION", /* "Illegal call." */
-    "GL_STACK_OVERFLOW",
-    "GL_STACK_UNDERFLOW",
-    "GL_OUT_OF_MEMORY", /* "Unable to allocate memory." */
-
-    "GL_UNKNOWN_ERROR" /* ??? */
-};
-
-int grDisplayGLError(const char* message)
-{
-    GLenum status;
-    unsigned int error_index;
-    int failure;
-    const short debug_setting = FindSystemSettingId("Debugger");
-    const unsigned int Project64_debugging = GetSystemSetting(debug_setting);
-
-    if (Project64_debugging == 0)
-        return (failure = -1); /* error checking for errors:  pj64 debug off */
-
-    status = glGetError();
-    failure = 1;
-
-    if (status == GL_NO_ERROR)
-        error_index = failure = 0;
-    else
-        error_index =
-            (status < GL_INVALID_ENUM) /* to avoid underflow when subtracting */
-          ? ( 7 ) /* our own, made-up "GL_UNKNOWN_ERROR" error */
-          : (status - GL_INVALID_ENUM) + 1;
-
-    if (error_index > 7)
-        error_index = 7;
-
-#if !0
-/*
- * In most cases, we don't want to spam the screen to repeatedly say that
- * there were no OpenGL errors yet, though sometimes one may need verbosity.
- */
-    if (failure == 0)
-        return (failure);
-#endif
-
-#ifdef _WIN32
-    MessageBoxA(NULL, message, GL_errors[error_index], MB_ICONERROR);
-#else
-    fprintf(stderr, "%s\n%s\n\n", GL_errors[error_index], message);
-#endif
-    return (failure);
 }

--- a/Source/Glide64/Debugger.h
+++ b/Source/Glide64/Debugger.h
@@ -135,5 +135,3 @@ void debug_cacheviewer ();
 void debug_mouse ();
 void debug_keys ();
 void output (float x, float y, int scale, const char *fmt, ...);
-
-extern int grDisplayGLError( const char * message );

--- a/Source/Glide64/Glide64.vcxproj
+++ b/Source/Glide64/Glide64.vcxproj
@@ -44,6 +44,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(Root)Source\3rd Party\wx\lib\vc_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Glide64/Glide64.vcxproj
+++ b/Source/Glide64/Glide64.vcxproj
@@ -45,6 +45,7 @@
     <Link>
       <AdditionalLibraryDirectories>$(Root)Source\3rd Party\wx\lib\vc_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Windows</SubSystem>
+      <SubSystem Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -1890,9 +1890,7 @@ void CALL UpdateScreen (void)
   if (fullscreen && (*gfx.VI_ORIGIN_REG  > width))
     update_screen_count++;
 
-#if defined(_DEBUG) || 0
   grDisplayGLError("UpdateScreen");
-#endif
 
 #ifdef FPS
   // vertical interrupt has occurred, increment counter

--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -1890,8 +1890,6 @@ void CALL UpdateScreen (void)
   if (fullscreen && (*gfx.VI_ORIGIN_REG  > width))
     update_screen_count++;
 
-  grDisplayGLError("UpdateScreen");
-
 #ifdef FPS
   // vertical interrupt has occurred, increment counter
   vi_count ++;

--- a/Source/Glitch64/combiner.cpp
+++ b/Source/Glitch64/combiner.cpp
@@ -167,6 +167,8 @@ void updateCombiner(int i)
   glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_RGB_ARB, operand1[i]);
   glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE2_RGB_ARB, source2[i]);
   glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND2_RGB_ARB, operand2[i]);
+
+  grDisplayGLError("updateCombiner");
 }
 
 void updateCombinera(int i)
@@ -179,6 +181,8 @@ void updateCombinera(int i)
   glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND1_ALPHA_ARB, operanda1[i]);
   glTexEnvi(GL_TEXTURE_ENV, GL_SOURCE2_ALPHA_ARB, sourcea2[i]);
   glTexEnvi(GL_TEXTURE_ENV, GL_OPERAND2_ALPHA_ARB, operanda2[i]);
+
+  grDisplayGLError("updateCombinera");
 }
 
 void init_combiner()
@@ -301,6 +305,8 @@ void init_combiner()
   dither_enabled = 0;
   blackandwhite0 = 0;
   blackandwhite1 = 0;
+
+  grDisplayGLError("init_combiner");
 }
 
 void compile_chroma_shader()
@@ -339,6 +345,8 @@ void compile_chroma_shader()
 
   strcat(fragment_shader_chroma, "if (color.rgb == chroma_color.rgb) discard; \n");
   strcat(fragment_shader_chroma, "}");
+
+  grDisplayGLError("compile_chroma_shader");
 }
 
 typedef struct _shader_program_key
@@ -525,6 +533,8 @@ void compile_shader()
 
   set_lambda();
   number_of_programs++;
+
+  grDisplayGLError("compile_shader");
 }
 
 void free_combiners()
@@ -541,6 +551,8 @@ void set_copy_shader()
   glUseProgramObjectARB(program_object_default);
   texture0_location = glGetUniformLocationARB(program_object, "texture0");
   glUniform1iARB(texture0_location, 0);
+
+  grDisplayGLError("set_copy_shader");
 }
 
 void set_depth_shader()
@@ -550,12 +562,16 @@ void set_depth_shader()
   glUseProgramObjectARB(program_object_depth);
   texture0_location = glGetUniformLocationARB(program_object, "texture0");
   glUniform1iARB(texture0_location, 0);
+
+  grDisplayGLError("set_depth_shader");
 }
 
 void set_lambda()
 {
   int lambda_location = glGetUniformLocationARB(program_object, "lambda");
   glUniform1fARB(lambda_location, lambda);
+
+  grDisplayGLError("set_lambda");
 }
 
 FX_ENTRY void FX_CALL 
@@ -583,6 +599,8 @@ grConstantColorValue( GrColor_t value )
   constant_color_location = glGetUniformLocationARB(program_object, "constant_color");
   glUniform4fARB(constant_color_location, texture_env_color[0], texture_env_color[1], 
     texture_env_color[2], texture_env_color[3]);
+
+  grDisplayGLError("grConstantColorValue");
 }
 
 int setOtherColorSource(int other)
@@ -1470,6 +1488,8 @@ grAlphaBlendFunction(
     glBlendFuncSeparateEXT(sfactorRGB, dfactorRGB, sfactorAlpha, dfactorAlpha);
   else
     glBlendFunc(sfactorRGB, dfactorRGB);
+
+  grDisplayGLError("grAlphaBlendFunction");
 }
 
 FX_ENTRY void FX_CALL
@@ -1496,12 +1516,15 @@ grAlphaTestFunction( GrCmpFnc_t function )
   case GR_CMP_ALWAYS:
     glAlphaFunc(GL_ALWAYS, alpha_ref/255.0f);
     glDisable(GL_ALPHA_TEST);
+    grDisplayGLError("grAlphaTestFunction :: GR_CMP_ALWAYS");
     return;
     break;
   default:
     display_warning("grAlphaTestFunction : unknown function : %x", function);
   }
+
   glEnable(GL_ALPHA_TEST);
+  grDisplayGLError("grAlphaTestFunction");
 }
 
 // fog
@@ -1530,6 +1553,8 @@ grFogMode( GrFogMode_t mode )
     display_warning("grFogMode : unknown mode : %x", mode);
   }
   need_to_compile = 1;
+
+  grDisplayGLError("grFogMode");
 }
 
 FX_ENTRY float FX_CALL
@@ -1548,6 +1573,8 @@ guFogGenerateLinear(GrFog_t * /*fogtable*/,
   glFogi(GL_FOG_COORDINATE_SOURCE_EXT, GL_FOG_COORDINATE_EXT);
   glFogf(GL_FOG_START, nearZ / 255.0f);
   glFogf(GL_FOG_END, farZ / 255.0f);
+
+  grDisplayGLError("guFogGenerateLinear");
 }
 
 FX_ENTRY void FX_CALL 
@@ -1581,6 +1608,7 @@ grFogColorValue( GrColor_t fogcolor )
   }
 
   glFogfv(GL_FOG_COLOR, color); 
+  grDisplayGLError("glFogfv");
 }
 
 // chroma
@@ -1630,6 +1658,7 @@ grChromakeyValue( GrColor_t value )
   chroma_color_location = glGetUniformLocationARB(program_object, "chroma_color");
   glUniform4fARB(chroma_color_location, chroma_color[0], chroma_color[1],
     chroma_color[2], chroma_color[3]);
+  grDisplayGLError("grChromakeyValue");
 }
 
 static void setPattern()
@@ -1667,6 +1696,8 @@ static void setPattern()
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glDisable(GL_TEXTURE_2D);
+
+  grDisplayGLError("setPattern");
 }
 
 FX_ENTRY void FX_CALL
@@ -1704,7 +1735,9 @@ grStippleMode( GrStippleMode_t mode )
   default:
     display_warning("grStippleMode:%x", mode);
   }
+
   need_to_compile = 1;
+  grDisplayGLError("grStippleMode");
 }
 
 FX_ENTRY void FX_CALL 
@@ -2748,4 +2781,5 @@ grConstantColorValueExt(GrChipID_t    tmu,
     ccolor1_location = glGetUniformLocationARB(program_object, "ccolor1");
     glUniform4fARB(ccolor1_location, ccolor1[0], ccolor1[1], ccolor1[2], ccolor1[3]);
   }
+  grDisplayGLError("grConstantColorValueExt");
 }

--- a/Source/Glitch64/geometry.cpp
+++ b/Source/Glitch64/geometry.cpp
@@ -55,6 +55,7 @@ void init_geometry()
 
   glDisable(GL_CULL_FACE);
   glDisable(GL_DEPTH_TEST);
+  grDisplayGLError("init_geometry");
 }
 
 FX_ENTRY void FX_CALL
@@ -141,6 +142,7 @@ grCullMode( GrCullMode_t mode )
   default:
     display_warning("unknown cull mode : %x", mode);
   }
+  grDisplayGLError("grCullMode");
 }
 
 // Depth buffer
@@ -168,6 +170,7 @@ grDepthBufferMode( GrDepthBufferMode_t mode )
   default:
     display_warning("unknown depth buffer mode : %x", mode);
   }
+  grDisplayGLError("grDepthBufferMode");
 }
 
 FX_ENTRY void FX_CALL
@@ -216,6 +219,7 @@ grDepthBufferFunction( GrCmpFnc_t function )
   default:
     display_warning("unknown depth buffer function : %x", function);
   }
+  grDisplayGLError("grDepthBufferFunction");
 }
 
 FX_ENTRY void FX_CALL
@@ -223,6 +227,7 @@ grDepthMask( FxBool mask )
 {
   LOG("grDepthMask(%d)\r\n", mask);
   glDepthMask((GLboolean)mask);
+  grDisplayGLError("grDepthMask");
 }
 
 float biasFactor = 0;
@@ -282,6 +287,7 @@ void FindBestDepthBias()
   }
   //printf(" --> bias factor %g\n", biasFactor);
   glPopAttrib();
+  grDisplayGLError("FindBestDepthBias");
 }
 
 FX_ENTRY void FX_CALL
@@ -301,6 +307,7 @@ grDepthBiasLevel( FxI32 level )
     glPolygonOffset(0,0);
     glDisable(GL_POLYGON_OFFSET_FILL);
   }
+  grDisplayGLError("grDepthBiasLevel");
 }
 
 // draw
@@ -439,6 +446,7 @@ grDrawTriangle( const void *a, const void *b, const void *c )
     -(*c_y - (float)heighto) / (float)(height/2) / *c_q, ZCALC(*c_z ,*c_q), 1.0f / *c_q);
 
   glEnd();
+  grDisplayGLError("grDrawTriangle");
 }
 
 FX_ENTRY void FX_CALL
@@ -496,6 +504,7 @@ grDrawPoint( const void *pt )
     -(*y - (float)heighto) / (float)(height/2) / *q, ZCALC(*z ,*q), 1.0f / *q);
 
   glEnd();
+  grDisplayGLError("grDrawPoint");
 }
 
 FX_ENTRY void FX_CALL
@@ -588,6 +597,7 @@ grDrawLine( const void *a, const void *b )
     -(*b_y - (float)heighto) / (float)(height/2) / *b_q, ZCALC(*b_z, *b_q), 1.0f / *b_q);
 
   glEnd();
+  grDisplayGLError("grDrawLine");
 }
 
 FX_ENTRY void FX_CALL
@@ -659,6 +669,8 @@ grDrawVertexArray(FxU32 mode, FxU32 Count, void *pointers2)
       -(*y - (float)heighto) / (float)(height/2) / *q, ZCALC(*z, *q), 1.0f / *q);
   }
   glEnd();
+
+  grDisplayGLError("grDrawVertexArray");
 }
 
 FX_ENTRY void FX_CALL
@@ -735,4 +747,6 @@ grDrawVertexArrayContiguous(FxU32 mode, FxU32 Count, void *pointers, FxU32 strid
       -(*y - (float)heighto) / (float)(height/2) / *q, ZCALC(*z, *q), 1.0f / *q);
   }
   glEnd();
+
+  grDisplayGLError("grDrawVertexArrayContiguous");
 }

--- a/Source/Glitch64/main.cpp
+++ b/Source/Glitch64/main.cpp
@@ -249,6 +249,7 @@ static inline void opt_glCopyTexImage2D( GLenum target,
     //       printf("--> %dx%d newfmt %x\n", width, height, fmt);
     glCopyTexImage2D(target, level, internalFormat, x, y, width, height, border);
   }
+  grDisplayGLError("opt_glCopyTexImage2D");
 }
 #define glCopyTexImage2D opt_glCopyTexImage2D
 
@@ -649,6 +650,7 @@ grClipWindow( FxU32 minx, FxU32 miny, FxU32 maxx, FxU32 maxy )
     if (maxy < miny) maxy = miny;
     glScissor(minx, miny, maxx - minx, maxy - miny);
     glEnable(GL_SCISSOR_TEST);
+    grDisplayGLError("grClipWindow :: use_fbo");
     return;
   }
 
@@ -671,6 +673,7 @@ grClipWindow( FxU32 minx, FxU32 miny, FxU32 maxx, FxU32 maxy )
     glScissor(minx, (viewport_offset)+height-maxy, maxx - minx, maxy - miny);
   }
   glEnable(GL_SCISSOR_TEST);
+  grDisplayGLError("grClipWindow");
 }
 
 FX_ENTRY void FX_CALL
@@ -678,6 +681,7 @@ grColorMask( FxBool rgb, FxBool a )
 {
   LOG("grColorMask(%d, %d)\r\n", rgb, a);
   glColorMask((GLboolean)rgb, (GLboolean)rgb, (GLboolean)rgb, (GLboolean)a);
+  grDisplayGLError("grColorMask");
 }
 
 FX_ENTRY void FX_CALL
@@ -1384,6 +1388,7 @@ grSstWinOpen(
       ati_sucks = 0;
   }
 
+  grDisplayGLError("grSstWinOpen");
   return 1;
 }
 
@@ -1597,7 +1602,7 @@ FX_ENTRY void FX_CALL grTextureBufferExt( GrChipID_t  		tmu,
 
     glScissor(0, viewport_offset, width, height);
 
-
+    grDisplayGLError("grTextureBufferExt :: A");
   } else {
     if (!render_to_texture) //initialization
     {
@@ -1651,6 +1656,7 @@ FX_ENTRY void FX_CALL grTextureBufferExt( GrChipID_t  		tmu,
           }
           CHECK_FRAMEBUFFER_STATUS();
           curBufferAddr = pBufferAddress;
+          grDisplayGLError("grTextureBufferExt :: C");
           return;
         }
         else //create new FBO at the same address, delete old one
@@ -1695,6 +1701,7 @@ FX_ENTRY void FX_CALL grTextureBufferExt( GrChipID_t  		tmu,
     CHECK_FRAMEBUFFER_STATUS();
     curBufferAddr = pBufferAddress;
     nb_fb++;
+    grDisplayGLError("grTextureBufferExt :: B");
   }
 }
 
@@ -2052,6 +2059,7 @@ static void render_rectangle(int texture_number,
 
   glEnable(GL_DEPTH_TEST);
   glEnable(GL_BLEND);
+  grDisplayGLError("render_rectangle");
 }
 
 void reloadTexture()
@@ -2081,6 +2089,7 @@ void reloadTexture()
     width, height, -1);
   glBindTexture(GL_TEXTURE_2D, default_texture);
   glPopAttrib();
+  grDisplayGLError("reloadTexture");
 }
 
 void updateTexture()
@@ -2112,6 +2121,7 @@ void updateTexture()
     glBindTexture(GL_TEXTURE_2D, default_texture);
     glPopAttrib();
   }
+  grDisplayGLError("updateTexture");
 }
 
 FX_ENTRY void FX_CALL grFramebufferCopyExt(int /*x*/, int /*y*/, int /*w*/, int /*h*/,
@@ -2135,6 +2145,7 @@ FX_ENTRY void FX_CALL grFramebufferCopyExt(int /*x*/, int /*y*/, int /*w*/, int 
       glCopyTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT,
         0, viewport_offset, tw, th, 0);
       glBindTexture(GL_TEXTURE_2D, default_texture);
+      grDisplayGLError("grFramebufferCopyExt :: A");
       return;
     }
     if (from == GR_FBCOPY_BUFFER_FRONT && to == GR_FBCOPY_BUFFER_BACK) {
@@ -2156,6 +2167,7 @@ FX_ENTRY void FX_CALL grFramebufferCopyExt(int /*x*/, int /*y*/, int /*w*/, int 
       glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
       glBindTexture(GL_TEXTURE_2D, default_texture);
       glPopAttrib();
+      grDisplayGLError("grFramebufferCopyExt :: B");
       return;
     }
 
@@ -2276,6 +2288,7 @@ grRenderBuffer( GrBuffer_t buffer )
   default:
     display_warning("grRenderBuffer : unknown buffer : %x", buffer);
   }
+  grDisplayGLError("grRenderBuffer");
 }
 
 FX_ENTRY void FX_CALL
@@ -2300,6 +2313,7 @@ grAuxBufferExt( GrBuffer_t buffer )
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
     need_to_compile = 1;
   }
+  grDisplayGLError("grAuxBufferExt");
 }
 
 FX_ENTRY void FX_CALL
@@ -2333,6 +2347,7 @@ grBufferClear( GrColor_t color, GrAlpha_t alpha, FxU32 depth )
   // ZIGGY TODO check that color mask is on
   buffer_cleared = 1;
 
+  grDisplayGLError("grBufferClear");
 }
 
 // #include <unistd.h>
@@ -2454,6 +2469,7 @@ grLfbLock( GrLock_t type, GrBuffer_t buffer, GrLfbWriteMode_t writeMode,
     }
   }
 
+  grDisplayGLError("grLfbLock");
   return FXTRUE;
 }
 
@@ -2530,6 +2546,7 @@ grLfbReadRegion( GrBuffer_t src_buffer,
     free(buf);
   }
 
+  grDisplayGLError("grLfbReadRegion");
   return FXTRUE;
 }
 
@@ -2689,6 +2706,8 @@ grLfbWriteRegion( GrBuffer_t dst_buffer,
   }
   glDrawBuffer(current_buffer);
   glPopAttrib();
+
+  grDisplayGLError("grLfbWriteRegion");
   return FXTRUE;
 }
 
@@ -2817,12 +2836,14 @@ FX_ENTRY void FX_CALL
 grFinish(void)
 {
   glFinish();
+  grDisplayGLError("grFinish");
 }
 
 FX_ENTRY void FX_CALL
 grFlush(void)
 {
   glFlush();
+  grDisplayGLError("grFlush");
 }
 
 FX_ENTRY void FX_CALL
@@ -3101,7 +3122,61 @@ void grTexChromaModeExt(GrChipID_t /*tmu*/, GrChromakeyMode_t /*mode*/)
   display_warning("grTexChromaRangeModeExt");
 }
 
+static const char * GL_errors[7 + 1] = {
+    "GL_NO_ERROR", /* "There is no current error." */
+    "GL_INVALID_ENUM", /* "Invalid parameter." */
+    "GL_INVALID_VALUE", /* "Invalid enum parameter value." */
+    "GL_INVALID_OPERATION", /* "Illegal call." */
+    "GL_STACK_OVERFLOW",
+    "GL_STACK_UNDERFLOW",
+    "GL_OUT_OF_MEMORY", /* "Unable to allocate memory." */
 
+    "GL_UNKNOWN_ERROR" /* ??? */
+};
+
+#ifndef _DEBUG
+int grDisplayGLError(const char* /*unused*/)
+{
+    return -1;
+}
+#else
+int grDisplayGLError(const char* message)
+{
+    GLenum status;
+    unsigned int error_index;
+    int failure;
+
+    status = glGetError();
+    failure = 1;
+
+    if (status == GL_NO_ERROR)
+        error_index = failure = 0;
+    else
+        error_index =
+            (status < GL_INVALID_ENUM) /* to avoid underflow when subtracting */
+          ? ( 7 ) /* our own, made-up "GL_UNKNOWN_ERROR" error */
+          : (status - GL_INVALID_ENUM) + 1;
+
+    if (error_index > 7)
+        error_index = 7;
+
+#if !0
+/*
+ * In most cases, we don't want to spam the screen to repeatedly say that
+ * there were no OpenGL errors yet, though sometimes one may need verbosity.
+ */
+    if (failure == 0)
+        return (failure);
+#endif
+
+#ifdef _WIN32
+    MessageBoxA(NULL, message, GL_errors[error_index], MB_ICONERROR);
+#else
+    fprintf(stderr, "%s\n%s\n\n", GL_errors[error_index], message);
+#endif
+    return (failure);
+}
+#endif
 
 // VP debug
 #ifdef VPDEBUG
@@ -3187,6 +3262,7 @@ void dump_stop()
     free(pixels);
   }
   glBindTexture(GL_TEXTURE_2D, default_texture);
+  grDisplayGLError("dump_stop");
 }
 
 void dump_tex(int id)

--- a/Source/Glitch64/main.h
+++ b/Source/Glitch64/main.h
@@ -27,6 +27,9 @@ extern wrapper_config config;
 // returns the bytes per pixel of a given GR texture format
 int grTexFormatSize(int fmt);
 
+/* 2015.03.07 cxd4 -- regulated GL state machine debugging using glGetError */
+extern int grDisplayGLError(const char* message);
+
 extern int packed_pixels_support;
 extern int ati_sucks;
 extern float largest_supported_anisotropy;

--- a/Source/Glitch64/textures.cpp
+++ b/Source/Glitch64/textures.cpp
@@ -639,6 +639,7 @@ grTexDownloadMipMap( GrChipID_t tmu,
   }
 
   glBindTexture(GL_TEXTURE_2D, default_texture);
+  grDisplayGLError("grTexDownloadMipMap");
 }
 
 int CheckTextureBufferFormat(GrChipID_t tmu, FxU32 startAddress, GrTexInfo *info );
@@ -722,6 +723,7 @@ grTexSource( GrChipID_t tmu,
     grAuxBufferExt(auxbuffer);
   oldbuffer = auxbuffer;
 #endif
+  grDisplayGLError("grTexSource");
 }
 
 FX_ENTRY void FX_CALL
@@ -788,6 +790,7 @@ grTexFilterMode(
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, min_filter1);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, mag_filter1);
   }
+  grDisplayGLError("grTexFilterMode");
 }
 
 FX_ENTRY void FX_CALL
@@ -867,4 +870,5 @@ grTexClampMode(
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrap_s1);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrap_t1);
   }
+  grDisplayGLError("grTexClampMode");
 }


### PR DESCRIPTION
...I do it within Glitch64, not Glide64. :)

If you have an INI file error where Glide64.rdb does not report the RSP microcode used by this game for graphics, then you will get a perpetual `GL_INVALID_OPERATION` error message box in the debug build of this plugin.  This was caused by actually, the calling of the very OpenGL function for checking errors itself:  `glGetError`, being called within the zilmar spec function `UpdateScreen`.  I originally thought that checking for OpenGL errors within `UpdateScreen` would be a good idea since this was one of those plugin spec functions which would get called routinely often and periodically to make sure nothing got missed over, but I forgot that the emulator (not just Project64 either) never calls `UpdateScreen` from within the same thread as `ProcessDList` or the functions that actually go through the statically linked Glitch64 library to call OpenGL commands.

To get around this, if I'm not mistaken you would have to use something like `wglShareLists` on Windows (which I'm not really into the practice of doing) to share the OpenGL context between multiple calling threads.  Instead, I wanted to move the OpenGL debugging to each and every Glitch64 function which calls at least one OpenGL command, for more precise debugging and better error messages.

The third commit down is my point behind this.

Ignore my first commit.  At first I thought it could be a good idea to debug GL errors #ifndef _DEBUG by just detecting the presence of the Project64 debugger and whether or not that was enabled, but I ended up changing my mind because non-debug builds would have that much more bloat in the instruction cache and DLL size increase.  So I think this should only be done in debug builds.