### PR TITLE
Resident Evil 2 rdb fixes

### DIFF
--- a/Config/Glide64.rdb
+++ b/Config/Glide64.rdb
@@ -482,6 +482,7 @@ fb_smart=1
 fix_tex_coord=128
 n64_z_scale=1
 swapmode=2
+fb_render=1
 
 [7C64E6DB-55B924DB-C:50]
 Good Name=Blast Corps (E)

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -930,7 +930,6 @@ Sync Audio=No
 Fixed Audio=1
 Audio Signal=Yes
 Counter Factor=1
-RDRAM Size=8
 
 [7C64E6DB-55B924DB-C:50]
 Good Name=Blast Corps (E)
@@ -5471,7 +5470,6 @@ Fixed Audio=1
 Sync Audio=No
 Clear Frame=0
 Counter Factor=1
-RDRAM Size=8
 
 [2F493DD0-2E64DFD9-C:45]
 Good Name=Resident Evil 2 (U) (V1.0)
@@ -5494,7 +5492,6 @@ RDRAM Size=8
 Resolution Height=239
 Resolution Width=319
 Self Texture=0
-RDRAM Size=8
 
 [AA18B1A5-07DB6AEB-C:45]
 Good Name=Resident Evil 2 (U) (V1.1)
@@ -5514,7 +5511,6 @@ Culling=1
 Emulate Clear=0
 Primary Frame Buffer=0
 Self Texture=0
-RDRAM Size=8
 
 [02D8366A-6CABEF9C-C:50]
 Good Name=Road Rash 64 (E)


### PR DESCRIPTION
Changed back RDRAM to 4, if set to 8 will cause resolution issues with Glide64
