### PR TITLE
minor clean-ups to how MIPS GPR $zero is handled in VR4300 and RSP CPUs

### DIFF
--- a/Source/Project64/N64 System/Interpreter/Interpreter CPU.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter CPU.cpp
@@ -337,7 +337,7 @@ void CInterpreterCPU::ExecuteOps ( int Cycles )
 					//WriteTraceF((TraceType)(TraceError | TraceNoHeader),"%X: %d %d",*_PROGRAM_COUNTER,*g_NextTimer,g_SystemTimer->CurrentType());
 				}*/				
 				m_R4300i_Opcode[ Opcode.op ]();
-				_GPR[0].DW = 0;
+				_GPR[0].DW = 0; /* MIPS $zero hard-wired to 0 */
 
 				Cycles -= CountPerOp;
 				*g_NextTimer -= CountPerOp;

--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops 32.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops 32.cpp
@@ -709,7 +709,6 @@ void R4300iOp32::ADDI (void) {
 		StackValue += (short)m_Opcode.immediate;
 	}
 #endif
-	if (m_Opcode.rt == 0) { return; }
 	_GPR[m_Opcode.rt].W[0] = (_GPR[m_Opcode.rs].W[0] + ((short)m_Opcode.immediate));
 #ifdef Interpreter_StackTest
 	if (m_Opcode.rt == 29 && m_Opcode.rs != 29) {
@@ -761,7 +760,6 @@ void R4300iOp32::XORI (void) {
 }
 
 void R4300iOp32::LUI (void) {
-	if (m_Opcode.rt == 0) { return; }
 	_GPR[m_Opcode.rt].W[0] = (long)((short)m_Opcode.offset << 16);
 #ifdef Interpreter_StackTest
 	if (m_Opcode.rt == 29) {
@@ -840,7 +838,6 @@ void R4300iOp32::BGTZL (void) {
 
 void R4300iOp32::LB (void) {
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
-	if (m_Opcode.rt == 0) { return; }
 	if (!g_MMU->LB_VAddr(Address,_GPR[m_Opcode.rt].UB[0])) {
 		if (bShowTLBMisses()) {
 			g_Notify->DisplayError(L"LB TLB: %X",Address);
@@ -891,8 +888,6 @@ void R4300iOp32::LW (void) {
 	{ 
 		Log_LW((*_PROGRAM_COUNTER),Address);
 	}
-
-	if (m_Opcode.rt == 0) { return; }
 
 	if (!g_MMU->LW_VAddr(Address,_GPR[m_Opcode.rt].UW[0])) {
 		if (bShowTLBMisses()) {
@@ -952,7 +947,6 @@ void R4300iOp32::LWR (void) {
 void R4300iOp32::LWU (void) {
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0) { ADDRESS_ERROR_EXCEPTION(Address,TRUE); }
-	if (m_Opcode.rt == 0) { return; }
 
 	if (!g_MMU->LW_VAddr(Address,_GPR[m_Opcode.rt].UW[0])) {
 		if (bShowTLBMisses()) {
@@ -968,8 +962,6 @@ void R4300iOp32::LWU (void) {
 void R4300iOp32::LL (void) {
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0) { ADDRESS_ERROR_EXCEPTION(Address,TRUE); }
-
-	if (m_Opcode.rt == 0) { return; }
 
 	if (!g_MMU->LW_VAddr(Address,_GPR[m_Opcode.rt].UW[0])) {
 		if (bShowTLBMisses()) {
@@ -996,7 +988,6 @@ void R4300iOp32::SPECIAL_SRA (void) {
 }
 
 void R4300iOp32::SPECIAL_SLLV (void) {
-	if (m_Opcode.rd == 0) { return; }
 	_GPR[m_Opcode.rd].W[0] = (_GPR[m_Opcode.rt].W[0] << (_GPR[m_Opcode.rs].UW[0] & 0x1F));
 }
 

--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
@@ -814,7 +814,6 @@ void R4300iOp::ADDI (void)
 		StackValue += (short)m_Opcode.immediate;
 	}
 #endif
-	if (m_Opcode.rt == 0) { return; }
 	_GPR[m_Opcode.rt].DW = (_GPR[m_Opcode.rs].W[0] + ((short)m_Opcode.immediate));
 #ifdef Interpreter_StackTest
 	if (m_Opcode.rt == 29 && m_Opcode.rs != 29) {
@@ -873,7 +872,6 @@ void R4300iOp::XORI (void)
 
 void R4300iOp::LUI (void)
 {
-	if (m_Opcode.rt == 0) { return; }
 	_GPR[m_Opcode.rt].DW = (long)((short)m_Opcode.offset << 16);
 #ifdef Interpreter_StackTest
 	if (m_Opcode.rt == 29) {
@@ -1016,7 +1014,6 @@ void R4300iOp::LDR (void)
 void R4300iOp::LB (void)
 {
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
-	if (m_Opcode.rt == 0) { return; }
 	if (!g_MMU->LB_VAddr(Address,_GPR[m_Opcode.rt].UB[0])) {
 		if (bShowTLBMisses()) {
 			g_Notify->DisplayError(L"LB TLB: %X",Address);
@@ -1071,8 +1068,6 @@ void R4300iOp::LW (void)
 	{ 
 		Log_LW((*_PROGRAM_COUNTER),Address);
 	}
-
-	if (m_Opcode.rt == 0) { return; }
 
 	if (!g_MMU->LW_VAddr(Address,_GPR[m_Opcode.rt].UW[0])) {
 		if (bShowTLBMisses()) {
@@ -1136,7 +1131,6 @@ void R4300iOp::LWU (void)
 {
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0) { ADDRESS_ERROR_EXCEPTION(Address,TRUE); }
-	if (m_Opcode.rt == 0) { return; }
 
 	if (!g_MMU->LW_VAddr(Address,_GPR[m_Opcode.rt].UW[0])) {
 		if (bShowTLBMisses()) {
@@ -1381,8 +1375,6 @@ void R4300iOp::LL (void)
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0) { ADDRESS_ERROR_EXCEPTION(Address,TRUE); }
 
-	if (m_Opcode.rt == 0) { return; }
-
 	if (!g_MMU->LW_VAddr(Address,_GPR[m_Opcode.rt].UW[0])) 
 	{
 		if (bShowTLBMisses()) 
@@ -1543,7 +1535,6 @@ void R4300iOp::SPECIAL_SRA (void)
 
 void R4300iOp::SPECIAL_SLLV (void)
 {
-	if (m_Opcode.rd == 0) { return; }
 	_GPR[m_Opcode.rd].DW = (_GPR[m_Opcode.rt].W[0] << (_GPR[m_Opcode.rs].UW[0] & 0x1F));
 }
 

--- a/Source/RSP/Interpreter CPU.c
+++ b/Source/RSP/Interpreter CPU.c
@@ -444,6 +444,7 @@ DWORD RunInterpreterCPU(DWORD Cycles) {
 
 		RSP_LW_IMEM(*PrgCount, &RSPOpC.Hex);
 		RSP_Opcode[ RSPOpC.op ]();
+		RSP_GPR[0].W = 0x00000000; /* MIPS $zero hard-wired to 0 */
 
 		switch (RSP_NextInstruction) {
 		case NORMAL: 

--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -98,19 +98,14 @@ void RSP_Opcode_BGTZ ( void ) {
 }
 
 void RSP_Opcode_ADDI ( void ) {
-	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W + (int16_t)RSPOpC.immediate;
-	}
+	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W + (int16_t)RSPOpC.immediate;
 }
 
 void RSP_Opcode_ADDIU ( void ) {
-	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rs].UW + (uint32_t)((int16_t)RSPOpC.immediate);
-	}
+	RSP_GPR[RSPOpC.rt].UW = RSP_GPR[RSPOpC.rs].UW + (uint32_t)((int16_t)RSPOpC.immediate);
 }
 
 void RSP_Opcode_SLTI (void) {
-	if (RSPOpC.rt == 0) { return; }
 	if (RSP_GPR[RSPOpC.rs].W < (int16_t)RSPOpC.immediate) {
 		RSP_GPR[RSPOpC.rt].W = 1;
 	} else {
@@ -119,7 +114,6 @@ void RSP_Opcode_SLTI (void) {
 }
 
 void RSP_Opcode_SLTIU (void) {
-	if (RSPOpC.rt == 0) { return; }
 	if (RSP_GPR[RSPOpC.rs].UW < (uint32_t)(int16_t)RSPOpC.immediate) {
 		RSP_GPR[RSPOpC.rt].W = 1;
 	} else {
@@ -128,27 +122,19 @@ void RSP_Opcode_SLTIU (void) {
 }
 
 void RSP_Opcode_ANDI ( void ) {
-	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W & RSPOpC.immediate;
-	}
+	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W & RSPOpC.immediate;
 }
 
 void RSP_Opcode_ORI ( void ) {
-	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W | RSPOpC.immediate;
-	}
+	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W | RSPOpC.immediate;
 }
 
 void RSP_Opcode_XORI ( void ) {
-	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W ^ RSPOpC.immediate;
-	}
+	RSP_GPR[RSPOpC.rt].W = RSP_GPR[RSPOpC.rs].W ^ RSPOpC.immediate;
 }
 
 void RSP_Opcode_LUI (void) {
-	if (RSPOpC.rt != 0) {
-		RSP_GPR[RSPOpC.rt].W = RSPOpC.immediate << 16;
-	}
+	RSP_GPR[RSPOpC.rt].W = RSPOpC.immediate << 16;
 }
 
 void RSP_Opcode_COP0 (void) {
@@ -213,39 +199,27 @@ void RSP_Opcode_SC2 (void) {
 
 /********************** R4300i OpCodes: Special **********************/
 void RSP_Special_SLL ( void ) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W << RSPOpC.sa;
-	}
+	RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W << RSPOpC.sa;
 }
 
 void RSP_Special_SRL ( void ) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rt].UW >> RSPOpC.sa;
-	}
+	RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rt].UW >> RSPOpC.sa;
 }
 
 void RSP_Special_SRA ( void ) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W >> RSPOpC.sa;
-	}
+	RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W >> RSPOpC.sa;
 }
 
 void RSP_Special_SLLV (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W << (RSP_GPR[RSPOpC.rs].W & 0x1F);
-	}
+	RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W << (RSP_GPR[RSPOpC.rs].W & 0x1F);
 }
 
 void RSP_Special_SRLV (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rt].UW >> (RSP_GPR[RSPOpC.rs].W & 0x1F);
-	}
+	RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rt].UW >> (RSP_GPR[RSPOpC.rs].W & 0x1F);
 }
 
 void RSP_Special_SRAV (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W >> (RSP_GPR[RSPOpC.rs].W & 0x1F);
-	}
+	RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rt].W >> (RSP_GPR[RSPOpC.rs].W & 0x1F);
 }
 
 void RSP_Special_JR (void) {
@@ -269,55 +243,38 @@ void RSP_Special_BREAK ( void ) {
 }
 
 void RSP_Special_ADD (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rs].W + RSP_GPR[RSPOpC.rt].W;
-	}
+	RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rs].W + RSP_GPR[RSPOpC.rt].W;
 }
 
 void RSP_Special_ADDU (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rs].UW + RSP_GPR[RSPOpC.rt].UW;
-	}
+	RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rs].UW + RSP_GPR[RSPOpC.rt].UW;
 }
 
 void RSP_Special_SUB (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rs].W - RSP_GPR[RSPOpC.rt].W;
-	}
+	RSP_GPR[RSPOpC.rd].W = RSP_GPR[RSPOpC.rs].W - RSP_GPR[RSPOpC.rt].W;
 }
 
 void RSP_Special_SUBU (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rs].UW - RSP_GPR[RSPOpC.rt].UW;
-	}
+	RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rs].UW - RSP_GPR[RSPOpC.rt].UW;
 }
 
 void RSP_Special_AND (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rs].UW & RSP_GPR[RSPOpC.rt].UW;
-	}
+	RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rs].UW & RSP_GPR[RSPOpC.rt].UW;
 }
 
 void RSP_Special_OR (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rs].UW | RSP_GPR[RSPOpC.rt].UW;
-	}
+	RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rs].UW | RSP_GPR[RSPOpC.rt].UW;
 }
 
 void RSP_Special_XOR (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rs].UW ^ RSP_GPR[RSPOpC.rt].UW;
-	}
+	RSP_GPR[RSPOpC.rd].UW = RSP_GPR[RSPOpC.rs].UW ^ RSP_GPR[RSPOpC.rt].UW;
 }
 
 void RSP_Special_NOR (void) {
-	if (RSPOpC.rd != 0) {
-		RSP_GPR[RSPOpC.rd].UW = ~(RSP_GPR[RSPOpC.rs].UW | RSP_GPR[RSPOpC.rt].UW);
-	}
+	RSP_GPR[RSPOpC.rd].UW = ~(RSP_GPR[RSPOpC.rs].UW | RSP_GPR[RSPOpC.rt].UW);
 }
 
 void RSP_Special_SLT (void) {
-	if (RSPOpC.rd == 0) { return; }
 	if (RSP_GPR[RSPOpC.rs].W < RSP_GPR[RSPOpC.rt].W) {
 		RSP_GPR[RSPOpC.rd].UW = 1;
 	} else {
@@ -326,7 +283,6 @@ void RSP_Special_SLT (void) {
 }
 
 void RSP_Special_SLTU (void) {
-	if (RSPOpC.rd == 0) { return; }
 	if (RSP_GPR[RSPOpC.rs].UW < RSP_GPR[RSPOpC.rt].UW) {
 		RSP_GPR[RSPOpC.rd].UW = 1;
 	} else {


### PR DESCRIPTION
In the master CPU (the modified R4300), only 7 interpreter op-codes completely prevented the possibility of overwriting $zero (in either 32- or 64-bit MIPS mode).  It was decided this shouldn't really be necessary, since it seemed more sizable, smaller and readable to just handle the read-only state of MIPS register $zero in the running CPU loop rather than the individual op-codes.

A similar change was made for the RSP, which should fix the vulnerability to overwriting $0 for RSP MFC0, MFC2, CFC2 and any of the primary op-codes for memory loads and stores (e.g., LB and SB).