### PR TITLE
updating FPU locations just if STATUS_FR was changed, not entire reg

### DIFF
--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops 32.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops 32.cpp
@@ -1229,7 +1229,7 @@ void R4300iOp32::COP0_MT (void) {
 		g_SystemTimer->UpdateCompareTimer();
 		break;		
 	case 12: //Status
-		if ((_CP0[m_Opcode.rd] ^ _GPR[m_Opcode.rt].UW[0]) != 0) {
+		if ((_CP0[m_Opcode.rd] & STATUS_FR) != (_GPR[m_Opcode.rt].UW[0] & STATUS_FR)) {
 			_CP0[m_Opcode.rd] = _GPR[m_Opcode.rt].UW[0];
 			g_Reg->FixFpuLocations();
 		} else {

--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
@@ -1996,7 +1996,7 @@ void R4300iOp::COP0_MT (void)
 		g_SystemTimer->UpdateCompareTimer();
 		break;		
 	case 12: //Status
-		if ((_CP0[m_Opcode.rd] ^ _GPR[m_Opcode.rt].UW[0]) != 0) {
+		if ((_CP0[m_Opcode.rd] & STATUS_FR) != (_GPR[m_Opcode.rt].UW[0] & STATUS_FR)) {
 			_CP0[m_Opcode.rd] = _GPR[m_Opcode.rt].UW[0];
 			g_Reg->FixFpuLocations();
 		} else {


### PR DESCRIPTION
We were pretty sure the intention was to just fix FPU locations if the FPU STATUS_FR status was changed.  The rest of the status registers' bits had nothing to do with whether it needed fixing.