### PR TITLE
Fix problem with Bio F.R.E.A.K.S. (U)

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -746,6 +746,7 @@ Clear Frame=0
 Culling=1
 Emulate Clear=0
 Primary Frame Buffer=0
+RDRAM Size=8
 Self Texture=0
 
 [7EAE2488-9D40A35A-C:4A]


### PR DESCRIPTION
The RSP accesses memory past 0x3FFFFF in RDRAM, so this game needs
expansion pack enabled.