### PR TITLE
Slightly less broken Indiana Jones VI\AI

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -2850,7 +2850,7 @@ Status=Issues (mixed)
 Core Note=Recompiler Trading Post freeze.
 Plugin Note=[rsp] interpreter only
 32bit=No
-AiCountPerBytes=785
+AiCountPerBytes=650
 CPU Type=Recompiler
 Counter Factor=1
 Fast SP=No
@@ -2865,7 +2865,7 @@ SMM-FUNC=0
 SMM-PI DMA=0
 SMM-TLB=0
 Sync Audio=0
-ViRefresh=2200
+ViRefresh=1800
 
 [AF9DCC15-1A723D88-C:45]
 Good Name=Indiana Jones and the Infernal Machine (U)
@@ -2874,7 +2874,7 @@ Status=Issues (mixed)
 Core Note=Recompiler Trading Post freeze.
 Plugin Note=[rsp] interpreter only [audio] wrong speed;use(E)ROM
 32bit=No
-AiCountPerBytes=785
+AiCountPerBytes=740
 CPU Type=Recompiler
 Counter Factor=1
 Fast SP=No
@@ -2889,7 +2889,7 @@ SMM-FUNC=0
 SMM-PI DMA=0
 SMM-TLB=0
 Sync Audio=0
-ViRefresh=2200
+ViRefresh=2050
 
 [E436467A-82DE8F9B-C:45]
 Good Name=Indy Racing 2000 (U)


### PR DESCRIPTION
The US and PAL versions behave quite differently when it comes to refusing to boot randomly. The ideal VI should be around 1500, but the closest I can get seems around 1800 for PAL and 2050 for US. US version runs faster - significantly so in certain levels. However, this could be related to the PAL conversion - although I doubt it.

WIth these settings, the PAL version seems to have no voice clipping. The US one does, but it's improved over 2200 settings.