### PR TITLE
matched incomplete Bio F.R.E.A.K.S. fix to apply also to (E)

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -655,6 +655,7 @@ Internal Name=BIOFREAKS
 Status=Compatible
 AiCountPerBytes=200
 Culling=1
+RDRAM Size=8
 
 [08123595-0510F1DE-C:45]
 Good Name=Bio F.R.E.A.K.S. (U)


### PR DESCRIPTION
The commit here was incomplete.
https://github.com/project64/project64/pull/270

Testing the other version, we see that the design is no different.  It does either SP DMA read or write beyond the 4-MiB point.