### PR TITLE
Nightmare Creatures fixes.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -3942,8 +3942,8 @@ Internal Name=NIGHTMARE CREATURES
 Status=Compatible
 Core Note=(see GameFAQ)
 AiCountPerBytes=200
-Counter Factor=1
 Delay SI=Yes
+ViRefresh=2200
 
 [CD3C3CDF-317793FA-C:4A]
 Good Name=Nintama Rantarou 64 Game Gallery (J)


### PR DESCRIPTION
Nightmare Creatures runs at 60fps with CF=1, but the game runs too fast and has some odd behavior. (Menu selection is difficult, camera bounce during opening cutscene, odd movement sometimes) CF=2 fixes this but unfortunately gives framerates between 15-30fps. Setting VI to 2200 fixes the jerky animations.

This is one very odd game. I suspect it's still not running right based on Youtube footage, but it's less broken now.