### PR TITLE
converted most components to Project64 for Allman-style braces

### DIFF
--- a/Source/Common/Ini File Class.cpp
+++ b/Source/Common/Ini File Class.cpp
@@ -28,13 +28,15 @@ void CIniFileBase::fInsertSpaces ( int Pos, int NoOfSpaces )
 	m_File.Seek(0,CFileBase::end);
 	end = m_File.GetPosition();
 
-	if (NoOfSpaces > 0) {
+	if (NoOfSpaces > 0)
+	{
 		stdstr_f SpaceBuffer(_T("%*c"),NoOfSpaces,' ');
 
 		do {
 			SizeToRead = end - Pos;
 			if (SizeToRead > fIS_MvSize) { SizeToRead = fIS_MvSize; }
-			if (SizeToRead > 0) {
+			if (SizeToRead > 0)
+			{
 				m_File.Seek(SizeToRead * -1,CFileBase::current);
 				WritePos = m_File.GetPosition();
 				memset(Data,0,sizeof(Data));
@@ -47,9 +49,12 @@ void CIniFileBase::fInsertSpaces ( int Pos, int NoOfSpaces )
 				m_File.Seek(WritePos,CFileBase::begin);
 			}
 		} while (SizeToRead > 0);
-	} if (NoOfSpaces < 0) {
+	}
+	if (NoOfSpaces < 0)
+	{
 		int ReadPos = Pos + (NoOfSpaces * -1);
 		int WritePos = Pos;
+
 		do {
 			SizeToRead = end - ReadPos;
 			if (SizeToRead > fIS_MvSize) { SizeToRead = fIS_MvSize; }
@@ -60,6 +65,7 @@ void CIniFileBase::fInsertSpaces ( int Pos, int NoOfSpaces )
 			ReadPos += SizeToRead;
 			WritePos += SizeToRead;
 		} while (SizeToRead > 0);
+
 		m_File.Seek(WritePos,CFileBase::begin);
 		stdstr_f SpaceBuffer(_T("%*c"),(NoOfSpaces * -1),' ');
 		m_File.Write(SpaceBuffer.c_str(),(ULONG)SpaceBuffer.length());
@@ -81,10 +87,12 @@ int CIniFileBase::GetStringFromFile ( char * & String, char * &Data, int & MaxDa
 		DataSize = m_File.Read(&Data[DataSize],MaxDataSize);
 	}
 
-	for (;;) {
+	for (;;)
+	{
 		int count;
 
-		for (count = ReadPos; count < DataSize; count ++) {
+		for (count = ReadPos; count < DataSize; count ++)
+		{
 			if (Data[count] == '\n') 
 			{
 				int len = (count - ReadPos) + 1;
@@ -103,7 +111,9 @@ int CIniFileBase::GetStringFromFile ( char * & String, char * &Data, int & MaxDa
 			}
 			DataSize -= ReadPos;
 			ReadPos = 0;
-		} else {
+		}
+		else
+		{
 			//Increase buffer size
 			int NewMaxDataSize = MaxDataSize + BufferIncrease;
 			char * NewBuffer = new char[NewMaxDataSize];
@@ -159,13 +169,17 @@ void CIniFileBase::SaveCurrentSection ( void )
 		if (m_File.GetLength() < (int)strlen(m_LineFeed))
 		{
 			sprintf(SectionName.get(),"[%s]%s",m_CurrentSection.c_str(),m_LineFeed);
-		} else {
+		}
+		else
+		{
 			sprintf(SectionName.get(),"%s[%s]%s",m_LineFeed,m_CurrentSection.c_str(),m_LineFeed);
 		}
 		m_File.Write(SectionName.get(),(int)strlen(SectionName.get()));
 		m_CurrentSectionFilePos = m_File.GetPosition();
 		m_SectionsPos.insert(FILELOC::value_type(m_CurrentSection,m_CurrentSectionFilePos));
-	} else {
+	}
+	else
+	{
 		//increase/decrease space needed
 		int NeededBufferLen = 0;
 		{
@@ -197,8 +211,7 @@ void CIniFileBase::SaveCurrentSection ( void )
 		do {
 			result = GetStringFromFile(Input,Data,MaxDataSize,DataSize,ReadPos);
 			if (result <= 1) { continue; }
-			if (strlen(CleanLine(Input)) <= 1 || 
-				Input[0] != '[')
+			if (strlen(CleanLine(Input)) <= 1 || Input[0] != '[')
 			{
 				EndPos = ((m_File.GetPosition() - DataSize) + ReadPos);
 
@@ -270,7 +283,9 @@ bool CIniFileBase::MoveToSectionNameData ( LPCSTR lpSectionName, bool ChangeCurr
 		}
 		m_File.Seek(iter->second,CFileBase::begin);
 		bFoundSection = true;
-	} else {
+	}
+	else
+	{
 		m_File.Seek(m_lastSectionSearch, CFileBase::begin);
 
 		//long Fpos;
@@ -287,7 +302,7 @@ bool CIniFileBase::MoveToSectionNameData ( LPCSTR lpSectionName, bool ChangeCurr
 			//We Only care about sections
 			char * CurrentSection = Input;
 
-			if(m_lastSectionSearch == 0 && !memcmp(CurrentSection, pUTF8, 3))
+			if (m_lastSectionSearch == 0 && !memcmp(CurrentSection, pUTF8, 3))
 			{
 				CurrentSection += 3;
 			}
@@ -301,14 +316,18 @@ bool CIniFileBase::MoveToSectionNameData ( LPCSTR lpSectionName, bool ChangeCurr
 			m_lastSectionSearch = (m_File.GetPosition() - DataSize) + ReadPos;
 			m_SectionsPos.insert(FILELOC::value_type(CurrentSection,m_lastSectionSearch));
 
-			if (_stricmp(lpSectionName,CurrentSection) != 0) { 
+			if (_stricmp(lpSectionName,CurrentSection) != 0)
+			{
 				continue;
 			}
+
 			if (ChangeCurrentSection)
 			{
 				m_CurrentSection = lpSectionName;
 				m_CurrentSectionFilePos = m_lastSectionSearch;
-			} else {
+			}
+			else
+			{
 				m_File.Seek(m_lastSectionSearch,CFileBase::begin);
 			}
 			bFoundSection = true;
@@ -329,7 +348,7 @@ bool CIniFileBase::MoveToSectionNameData ( LPCSTR lpSectionName, bool ChangeCurr
 			char * Value = &Pos[1];
 
 			char * Pos1 = Pos-1;
-			while(((*Pos1 == ' ') || (*Pos1 == '\t')) && (Pos1 > Input))
+			while (((*Pos1 == ' ') || (*Pos1 == '\t')) && (Pos1 > Input))
 			{
 				Pos1--;
 			}
@@ -348,38 +367,39 @@ const char * CIniFileBase::CleanLine ( char * const Line )
 	char * Pos = Line;
 
 	//Remove any comment from the line
-	while (Pos != NULL) 
+	while (Pos != NULL)
 	{
 		Pos = strchr(Pos,'/');
-		if (Pos != NULL) 
+		if (Pos != NULL)
 		{
-			if (Pos[1] == '/') 
+			if (Pos[1] == '/')
 			{ 
-				if(Pos > Line)
+				if (Pos > Line)
 				{
 					char * Pos_1 = Pos-1;
 
-					if(Pos_1[0] != ':')
+					if (Pos_1[0] != ':')
 					{
-						Pos[0] = 0; 
+						Pos[0] = 0;
 					}
 					else
-						Pos += 1; 
+						Pos += 1;
 				}
 				else
 				{
-					Pos[0] = 0; 
+					Pos[0] = 0;
 				}
 			} 
 			else 
 			{ 
-				Pos += 1; 
+				Pos += 1;
 			}
 		}
 	}
 
 	//strip any spaces or line feeds from the end of the line
-	for (int count = (int)strlen(&Line[0]) - 1; count >= 0; count --) {
+	for (int count = (int)strlen(&Line[0]) - 1; count >= 0; count --)
+	{
 		if (Line[count] != ' ' && Line[count] != '\r') { break; }
 		Line[count] = 0;
 	}
@@ -421,13 +441,12 @@ void CIniFileBase::OpenIniFile(bool bCreate)
 
 bool CIniFileBase::IsEmpty()
 {
-	if(m_File.GetLength()==0)
+	if (m_File.GetLength() == 0)
 		return true;
-
 	return false;
 }
 
-bool CIniFileBase::IsFileOpen ( void ) 
+bool CIniFileBase::IsFileOpen ( void )
 { 
 	return m_File.IsOpen(); 
 }
@@ -535,7 +554,9 @@ bool CIniFileBase::GetString ( LPCWSTR lpSectionName, LPCWSTR lpKeyName, LPCWSTR
 	if (lpSectionName == NULL || wcslen(lpSectionName) == 0)
 	{
 		strSection = "default";
-	} else {
+	}
+	else
+	{
 		stdstr::fromTString(lpSectionName,strSection);
 	}
 
@@ -570,7 +591,9 @@ ULONG  CIniFileBase::GetString  ( LPCTSTR lpSectionName, LPCTSTR lpKeyName, LPCT
 	if (lpSectionName == NULL || _tcslen(lpSectionName) == 0)
 	{
 		strSection = "default";
-	} else {
+	}
+	else
+	{
 		strSection = lpSectionName;
 	}
 
@@ -605,7 +628,9 @@ bool CIniFileBase::GetNumber ( LPCWSTR lpSectionName, LPCWSTR lpKeyName, ULONG n
 	{
 		stdstr::fromTString(lpSectionName,strSection);
 		return GetNumber(strSection.c_str(),lpKeyName.c_str(),nDefault,Value);
-	} else {
+	}
+	else
+	{
 		return GetNumber(NULL,lpKeyName.c_str(),nDefault,Value);
 	}
 }
@@ -660,7 +685,9 @@ void  CIniFileBase::SaveString ( LPCTSTR lpSectionName, LPCTSTR lpKeyName, LPCTS
 	if (lpSectionName == NULL || _tcslen(lpSectionName) == 0)
 	{
 		strSection = "default";
-	} else {
+	}
+	else
+	{
 		strSection = lpSectionName;
 	}
 
@@ -681,12 +708,16 @@ void  CIniFileBase::SaveString ( LPCTSTR lpSectionName, LPCTSTR lpKeyName, LPCTS
 				iter->second = lpString;
 				m_CurrentSectionDirty = true;
 			}
-		} else {
+		}
+		else
+		{
 			m_CurrentSectionData.erase(iter);
 			m_CurrentSectionDirty = true;
 		}
-	} else {
-		if (lpString) 
+	}
+	else
+	{
+		if (lpString)
 		{
 			m_CurrentSectionData.insert(KeyValueList::value_type(lpKeyName,lpString));
 			m_CurrentSectionDirty = true;
@@ -744,20 +775,22 @@ void CIniFileBase::GetKeyList ( LPCTSTR lpSectionName, strlist &List )
 	}
 }
 
-void CIniFileBase::GetKeyValueData ( LPCTSTR lpSectionName, KeyValueData & List ) 
+void CIniFileBase::GetKeyValueData ( LPCTSTR lpSectionName, KeyValueData & List )
 {
 	CGuard Guard(m_CS);
 	if (!m_File.IsOpen())
 	{
-		return; 
+		return;
 	}
 
-	std::string strSection; 
+	std::string strSection;
 
 	if (lpSectionName == NULL || _tcslen(lpSectionName) == 0)
 	{
 		strSection = "default";
-	} else {
+	}
+	else
+	{
 		strSection = lpSectionName;
 	}
 
@@ -779,13 +812,15 @@ void CIniFileBase::GetKeyValueData ( LPCTSTR lpSectionName, KeyValueData & List 
 	if (Data) {  delete [] Data;  Data = NULL; }
 }
 
-void CIniFileBase::ClearSectionPosList( long FilePos ) 
+void CIniFileBase::ClearSectionPosList( long FilePos )
 {
 	if (FilePos <= 0)
 	{
 		m_SectionsPos.clear();
 		m_lastSectionSearch = 0;
-	} else {
+	}
+	else
+	{
 		FILELOC::iterator iter = m_SectionsPos.begin();
 		while (iter != m_SectionsPos.end())
 		{
@@ -802,7 +837,7 @@ void CIniFileBase::ClearSectionPosList( long FilePos )
 
 }
 
-void CIniFileBase::GetVectorOfSections( SectionList & sections) 
+void CIniFileBase::GetVectorOfSections( SectionList & sections)
 {
 	sections.clear();
 

--- a/Source/Common/Log Class.cpp
+++ b/Source/Common/Log Class.cpp
@@ -11,7 +11,8 @@ CLog::CLog (void ) :
 {
 }
 
-CLog::~CLog (void) {
+CLog::~CLog (void)
+{
 }
 
 bool CLog::Open( LPCTSTR FileName, LOG_OPEN_MODE mode /* = Log_New  */)
@@ -43,8 +44,7 @@ bool CLog::Open( LPCTSTR FileName, LOG_OPEN_MODE mode /* = Log_New  */)
 	m_hLogFile.Seek(0,mode == Log_Append ? CFile::end : CFile::begin);
 
 #ifdef _UNICODE
-
-	if(m_hLogFile.GetLength()==0)
+	if (m_hLogFile.GetLength() == 0)
 	{
 		WORD wUNICODE = 0xFEFF;
 
@@ -93,7 +93,7 @@ void CLog::LogArgs(LPCTSTR Message, va_list & args )
 		Log(L"Invalid message format");
 	}
 
-	if(buffer)
+	if (buffer)
 		delete [] buffer;
 #else
 	char* buffer = NULL;
@@ -110,7 +110,7 @@ void CLog::LogArgs(LPCTSTR Message, va_list & args )
 		Log("Invalid message format");
 	}
 
-	if(buffer)
+	if (buffer)
 		delete [] buffer;
 #endif
 }

--- a/Source/Common/MemTest.cpp
+++ b/Source/Common/MemTest.cpp
@@ -24,13 +24,15 @@
 #define MB_SERVICE_NOTIFICATION          0x00200000L
 #endif
 
-CMemList *MemList ( void ) {
+CMemList *MemList ( void )
+{
 	static CMemList m_MemList;
 
 	return &m_MemList;
 }
 
-CMemList::CMemList() { 
+CMemList::CMemList()
+{
 	MemList.clear(); 
 	hSemaphone = CreateSemaphore(NULL, 1,1, NULL);
 	State = Initialized;
@@ -51,11 +53,13 @@ CMemList::CMemList() {
 	}
 }
 
-CMemList::~CMemList() {
+CMemList::~CMemList()
+{
 	size_t ItemsLeft = MemList.size();
-	if (ItemsLeft > 0) {
-		TCHAR path_buffer[_MAX_PATH], drive[_MAX_DRIVE] ,dir[_MAX_DIR];
-		TCHAR fname[_MAX_FNAME],ext[_MAX_EXT], LogFileName[_MAX_PATH];
+	if (ItemsLeft > 0)
+	{
+		TCHAR path_buffer[_MAX_PATH], drive[_MAX_DRIVE], dir[_MAX_DIR];
+		TCHAR fname[_MAX_FNAME], ext[_MAX_EXT], LogFileName[_MAX_PATH];
 
 		memset(path_buffer, 0, sizeof(path_buffer));
 		memset(drive, 0, sizeof(drive));
@@ -68,21 +72,28 @@ CMemList::~CMemList() {
 		_tsplitpath( path_buffer, drive, dir, fname, ext );
 
 		_tmakepath( LogFileName, drive, dir, fname, _T("leak.csv") );
-			
-		
+
 		HANDLE hLogFile = INVALID_HANDLE_VALUE;
 		do 
 		{
-			hLogFile = CreateFile(LogFileName,GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,NULL,
-				CREATE_ALWAYS,FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
-			
+			hLogFile = CreateFile(
+				LogFileName,
+				GENERIC_WRITE,
+				FILE_SHARE_READ | FILE_SHARE_WRITE,
+				NULL,
+				CREATE_ALWAYS,
+				FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
+				NULL
+			);
 			if (hLogFile == INVALID_HANDLE_VALUE) 
 			{
-				if (GetLastError() == ERROR_SHARING_VIOLATION) {
+				if (GetLastError() == ERROR_SHARING_VIOLATION)
+				{
 					TCHAR Msg[3000];
 					_stprintf(Msg,TEXT("%s\nCan not be opened for writing please close app using this file\n\nTry Again ?"),LogFileName);
 					int Result = MessageBox(NULL,Msg,_T("Memory Leak"),MB_YESNO|MB_ICONQUESTION|MB_SETFOREGROUND | MB_SERVICE_NOTIFICATION);
-					if (Result == IDNO) {
+					if (Result == IDNO)
+					{
 						break;
 					}
 				}
@@ -112,7 +123,8 @@ CMemList::~CMemList() {
 		TCHAR Msg[3000];
 		_stprintf(Msg,TEXT("%s%s\n\nMemory Leaks detected\n\nOpen the Log File ?"),fname,ext);
 		int Result = MessageBox(NULL,Msg,_T("Memory Leak"),MB_YESNO|MB_ICONQUESTION|MB_SETFOREGROUND| MB_SERVICE_NOTIFICATION);
-		if (Result == IDYES) {
+		if (Result == IDYES)
+		{
 			ShellExecute(NULL,_T("open"),LogFileName,NULL,NULL,SW_SHOW);
 		}
 	}
@@ -120,7 +132,7 @@ CMemList::~CMemList() {
 	hSemaphone = NULL;
 	State = NotInitialized;
 }
-	
+
 void * CMemList::AddItem ( size_t size, char * filename, int line)
 {
 	void *res = malloc(size);		
@@ -135,10 +147,12 @@ void * CMemList::AddItem ( size_t size, char * filename, int line)
 void CMemList::RecordAddItem ( void * ptr, size_t size, const char * filename, int line)
 {
 	__try {
-		if (State == Initialized && hSemaphone != NULL) {
+		if (State == Initialized && hSemaphone != NULL)
+		{
 			DWORD CurrentThread = GetCurrentThreadId();
 			DWORD Result = WaitForSingleObject(hSemaphone,CurrentThread != ThreadID ? 30000: 0);
-			if (Result != WAIT_TIMEOUT) {
+			if (Result != WAIT_TIMEOUT)
+			{
 				ThreadID = CurrentThread;
 				
 				DEBUG_LOCATION info;
@@ -166,17 +180,20 @@ void CMemList::Insert(void *res, DEBUG_LOCATION &info)
 
 void * CMemList::ReAllocItem ( void * ptr, size_t size, const char * filename, int line)
 {
-	void *res = realloc(ptr, size);		
-	if (res == NULL) 
+	void *res = realloc(ptr, size);
+	if (res == NULL)
 	{
 		return res;
 	}
-	if (ptr != res) {
+	if (ptr != res)
+	{
 		__try {
-			if (State == Initialized && hSemaphone != NULL) {
+			if (State == Initialized && hSemaphone != NULL)
+			{
 				DWORD CurrentThread = GetCurrentThreadId();
 				DWORD Result = WaitForSingleObject(hSemaphone,CurrentThread != ThreadID ? 30000 : 0);
-				if (Result != WAIT_TIMEOUT) {
+				if (Result != WAIT_TIMEOUT)
+				{
 					ThreadID = CurrentThread;
 					//Add new pointer
 					DEBUG_LOCATION info;
@@ -206,22 +223,26 @@ void CMemList::Remove(void *ptr)
 {
 	//remove old pointer
 	MEMLIST_ITER item = MemList.find(ptr);
-	if (item != MemList.end()) {
+	if (item != MemList.end())
+	{
 		MemList.erase(ptr);
 	}
 }
 
-void CMemList::removeItem (void * ptr, bool bFree  ) 
+void CMemList::removeItem (void * ptr, bool bFree  )
 {
 	if (bFree)
 	{
 		free(ptr);
 	}
+
 	__try {
-			if (State == Initialized && hSemaphone != NULL) {
+		if (State == Initialized && hSemaphone != NULL)
+		{
 			DWORD CurrentThread = GetCurrentThreadId();
 			DWORD Result = WaitForSingleObject(hSemaphone,CurrentThread != ThreadID ? 30000 : 0);
-			if (Result != WAIT_TIMEOUT) {
+			if (Result != WAIT_TIMEOUT)
+			{
 				ThreadID = CurrentThread;
 				
 				Remove(ptr);
@@ -236,15 +257,18 @@ void CMemList::removeItem (void * ptr, bool bFree  )
 	}
 }
 
-void  MemTest_AddLeak(char* Comment) {
+void  MemTest_AddLeak(char* Comment)
+{
 	MemList()->AddItem(1,Comment,-1);
 }
 
-void* MemTest_malloc (size_t size, char* filename, int line) {
+void* MemTest_malloc (size_t size, char* filename, int line)
+{
 	return MemList()->AddItem(size,filename,line);
 }
 
-void* MemTest_realloc (void* ptr, size_t size, char* filename, int line) {
+void* MemTest_realloc (void* ptr, size_t size, char* filename, int line)
+{
 	return MemList()->ReAllocItem(ptr, size,filename,line);
 }
 

--- a/Source/Common/Trace.cpp
+++ b/Source/Common/Trace.cpp
@@ -2,12 +2,14 @@
 
 BOOL TraceClosed = FALSE;
 
-class CTraceLog {
+class CTraceLog
+{
 	std::vector<CTraceModule *> m_Modules;
 	CriticalSection             m_CS;
 
 public:
-	CTraceLog()  {
+	CTraceLog()
+	{
 	}
 	~CTraceLog() { CloseTrace (); }
 
@@ -54,8 +56,8 @@ void CTraceLog::CloseTrace ( void)
 
 	for (int i = 0; i < (int)m_Modules.size(); i++ )
 	{
-			if(m_Modules[i])
-				delete m_Modules[i];
+		if(m_Modules[i])
+			delete m_Modules[i];
 	}
 	m_Modules.clear();
 }
@@ -102,7 +104,7 @@ void CTraceLog::WriteTrace ( TraceType Type, LPCTSTR Message)
 		);
 
 		// show the debug level
-	   if (Type == TraceNone) { nPos += _stprintf(pBuffer+nPos,_T("%s"),_T("None   : ")); }
+		if (Type == TraceNone) { nPos += _stprintf(pBuffer+nPos,_T("%s"),_T("None   : ")); }
 		else if ((Type & TraceError)     != 0) { nPos += _stprintf(pBuffer+nPos,_T("%s"),_T("Error  : ")); }
 		else if ((Type & TraceSettings)  != 0) { nPos += _stprintf(pBuffer+nPos,_T("%s"),_T("Setting: ")); }
 		else if ((Type & TraceGfxPlugin) != 0) { nPos += _stprintf(pBuffer+nPos,_T("%s"),_T("Gfx    : ")); }

--- a/Source/Common/path.cpp
+++ b/Source/Common/path.cpp
@@ -924,11 +924,15 @@ BOOL CPath::FindNext()
 				{
 	                // Found a directory
 					UpDirectory();
-				} else {
+				}
+				else
+				{
 					SetNameExtension("");
 				}
 				AppendDirectory(FindData.cFileName);
-			} else {
+			}
+			else
+			{
                 // Found a file
 				if (IsDirectory())
 				{

--- a/Source/Common/std string.cpp
+++ b/Source/Common/std string.cpp
@@ -159,7 +159,9 @@ stdstr & stdstr::Trim (const char * chars2remove)
 		if (pos != std::string::npos)
 		{
 			erase(0,pos);
-		} else {
+		}
+		else
+		{
 			erase(begin(), end()); // make empty
 		}
 
@@ -167,7 +169,9 @@ stdstr & stdstr::Trim (const char * chars2remove)
 		if (pos != std::string::npos)
 		{
 			erase(pos+1);
-		} else {
+		}
+		else
+		{
 			erase(begin(), end()); // make empty
 		}
 	}

--- a/Source/RSP/Cpu.c
+++ b/Source/RSP/Cpu.c
@@ -57,10 +57,12 @@ void BuildRecompilerCPU(void);
 
 extern HANDLE hMutex;
 
-void SetCPU(DWORD core) {
+void SetCPU(DWORD core)
+{
 	WaitForSingleObjectEx(hMutex, 1000 * 100, FALSE);
 	CPUCore = core;
-	switch (core) {
+	switch (core)
+	{
 	case RecompilerCPU:
 		BuildRecompilerCPU();
 		break;
@@ -71,7 +73,8 @@ void SetCPU(DWORD core) {
 	ReleaseMutex(hMutex);
 }
 
-void Build_RSP ( void ) {
+void Build_RSP ( void )
+{
 	int i;
 	extern UWORD32 Recp, RecpResult, SQroot, SQrootResult;
 
@@ -150,16 +153,19 @@ void Build_RSP ( void ) {
 	Indx[30].DW = 0x0001020304050706; /* 6 */
 	Indx[31].DW = 0x0001020304050607; /* 7 */
 
-	for (i = 16; i < 32; i ++) {
+	for (i = 16; i < 32; i ++)
+	{
 		int count;
 
-		for (count = 0; count < 8; count ++) {
+		for (count = 0; count < 8; count ++)
+		{
 			Indx[i].B[count] = 7 - Indx[i].B[count];
 			EleSpec[i].B[count] = 7 - EleSpec[i].B[count];
 		}
-		for (count = 0; count < 4; count ++) {
+		for (count = 0; count < 4; count ++)
+		{
 			BYTE Temp;
-			
+
 			Temp = Indx[i].B[count];
 			Indx[i].B[count] = Indx[i].B[7 - count]; 
 			Indx[i].B[7 - count] = Temp;
@@ -182,44 +188,55 @@ void Build_RSP ( void ) {
 *******************************************************************/ 
 
 DWORD RunInterpreterCPU(DWORD Cycles);
-DWORD RunRecompilerCPU ( DWORD Cycles );
+DWORD RunRecompilerCPU (DWORD Cycles);
 
 #define MI_INTR_SP				0x01		/* Bit 0: SP intr */
 
-__declspec(dllexport) DWORD DoRspCycles ( DWORD Cycles ) {
+__declspec(dllexport) DWORD DoRspCycles ( DWORD Cycles )
+{
 	extern BOOL AudioHle, GraphicsHle;
 	DWORD TaskType = *(DWORD*)(RSPInfo.DMEM + 0xFC0);
 		
-/*	if (*RSPInfo.SP_STATUS_REG & SP_STATUS_SIG0) { 
+/*	if (*RSPInfo.SP_STATUS_REG & SP_STATUS_SIG0)
+	{
 		*RSPInfo.SP_STATUS_REG &= ~SP_STATUS_SIG0;
 		*RSPInfo.MI_INTR_REG |= MI_INTR_SP; 
 		RSPInfo.CheckInterrupts();
 		return Cycles;
 	}
 */
-	if (TaskType == 1 && GraphicsHle && *(DWORD*)(RSPInfo.DMEM + 0x0ff0) != 0) {
-		if (RSPInfo.ProcessDList != NULL) {
+	if (TaskType == 1 && GraphicsHle && *(DWORD*)(RSPInfo.DMEM + 0x0ff0) != 0)
+	{
+		if (RSPInfo.ProcessDList != NULL)
+		{
 			RSPInfo.ProcessDList();
 		}
 		*RSPInfo.SP_STATUS_REG |= (0x0203 );
-		if ((*RSPInfo.SP_STATUS_REG & SP_STATUS_INTR_BREAK) != 0 ) {
+		if ((*RSPInfo.SP_STATUS_REG & SP_STATUS_INTR_BREAK) != 0 )
+		{
 			*RSPInfo.MI_INTR_REG |= R4300i_SP_Intr;
 			RSPInfo.CheckInterrupts();
 		}
 
 		*RSPInfo.DPC_STATUS_REG &= ~0x0002;
 		return Cycles;
-	} else if (TaskType == 2 && AudioHle) {
-		if (RSPInfo.ProcessAList != NULL) {
+	}
+	else if (TaskType == 2 && AudioHle)
+	{
+		if (RSPInfo.ProcessAList != NULL)
+		{
 			RSPInfo.ProcessAList();
 		}
 		*RSPInfo.SP_STATUS_REG |= (0x0203 );
-		if ((*RSPInfo.SP_STATUS_REG & SP_STATUS_INTR_BREAK) != 0 ) {
+		if ((*RSPInfo.SP_STATUS_REG & SP_STATUS_INTR_BREAK) != 0 )
+		{
 			*RSPInfo.MI_INTR_REG |= R4300i_SP_Intr;
 			RSPInfo.CheckInterrupts();
 		}
 		return Cycles;
-	} else if (TaskType == 7) {
+	}
+	else if (TaskType == 7)
+	{
 		RSPInfo.ShowCFB();
 	}
 
@@ -227,14 +244,16 @@ __declspec(dllexport) DWORD DoRspCycles ( DWORD Cycles ) {
 
 /*
 	*RSPInfo.SP_STATUS_REG |= (0x0203 );
-	if ((*RSPInfo.SP_STATUS_REG & SP_STATUS_INTR_BREAK) != 0 ) {
+	if ((*RSPInfo.SP_STATUS_REG & SP_STATUS_INTR_BREAK) != 0 )
+	{
 		*RSPInfo.MI_INTR_REG |= R4300i_SP_Intr;
 		RSPInfo.CheckInterrupts();
 	}
 	//return Cycles;
 */	
 
-	if (Profiling && !IndvidualBlock) {
+	if (Profiling && !IndvidualBlock)
+	{
 		StartTimer((DWORD)Timer_RSP_Running);
 	}
 
@@ -246,7 +265,8 @@ __declspec(dllexport) DWORD DoRspCycles ( DWORD Cycles ) {
 	}
 	RSP_MfStatusCount = 0;
 
-	switch (CPUCore) {
+	switch (CPUCore)
+	{
 	case RecompilerCPU:
 		RunRecompilerCPU(Cycles);
 		break;
@@ -256,7 +276,8 @@ __declspec(dllexport) DWORD DoRspCycles ( DWORD Cycles ) {
 	}
 	ReleaseMutex(hMutex);
 
-	if (Profiling && !IndvidualBlock) {
+	if (Profiling && !IndvidualBlock)
+	{
 		StartTimer((DWORD)Timer_R4300_Running);
 	}
 

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -96,15 +96,18 @@ const char * AboutMsg ( void )
 }
 
 /************ Functions ***********/
-DWORD AsciiToHex (char * HexValue) {
+DWORD AsciiToHex (char * HexValue)
+{
 	DWORD Count, Finish, Value = 0;
 
 	Finish = strlen(HexValue);
 	if (Finish > 8 ) { Finish = 8; }
 
-	for (Count = 0; Count < Finish; Count++){
+	for (Count = 0; Count < Finish; Count++)
+	{
 		Value = (Value << 4);
-		switch( HexValue[Count] ) {
+		switch( HexValue[Count] )
+		{
 		case '0': break;
 		case '1': Value += 1; break;
 		case '2': Value += 2; break;
@@ -135,7 +138,8 @@ DWORD AsciiToHex (char * HexValue) {
 	return Value;
 }
 
-void DisplayError (char * Message, ...) {
+void DisplayError (char * Message, ...)
+{
 	char Msg[400];
 	va_list ap;
 
@@ -152,7 +156,8 @@ void DisplayError (char * Message, ...) {
   input:    none
   output:   none
 *******************************************************************/ 
-__declspec(dllexport) void CloseDLL (void) {
+__declspec(dllexport) void CloseDLL (void)
+{
 	FreeMemory();
 }
 
@@ -163,11 +168,13 @@ __declspec(dllexport) void CloseDLL (void) {
   input:    a handle to the window that calls this function
   output:   none
 *******************************************************************/ 
-__declspec(dllexport) void DllAbout ( HWND hParent ) {
+__declspec(dllexport) void DllAbout ( HWND hParent )
+{
 	MessageBox(hParent,AboutMsg(),"About",MB_OK | MB_ICONINFORMATION );
 }
 
-BOOL WINAPI DllMain(  HINSTANCE hinst, DWORD /*fdwReason*/, LPVOID /*lpvReserved*/ ){ 
+BOOL WINAPI DllMain(  HINSTANCE hinst, DWORD /*fdwReason*/, LPVOID /*lpvReserved*/ )
+{
 	hinstDLL = hinst;
 	return TRUE;
 }
@@ -179,7 +186,8 @@ BOOL WINAPI DllMain(  HINSTANCE hinst, DWORD /*fdwReason*/, LPVOID /*lpvReserved
             filled by the function. (see def above)
   output:   none
 *******************************************************************/ 
-__declspec(dllexport) void GetDllInfo ( PLUGIN_INFO * PluginInfo ) {
+__declspec(dllexport) void GetDllInfo ( PLUGIN_INFO * PluginInfo )
+{
 	PluginInfo->Version = 0x0102;
 	PluginInfo->Type = PLUGIN_TYPE_RSP;
 #ifdef _DEBUG
@@ -259,7 +267,8 @@ __declspec(dllexport) void GetRspDebugInfo ( RSPDEBUG_INFO * DebugInfo )
 
 RSP_COMPILER Compiler;
 
-void DetectCpuSpecs(void) {
+void DetectCpuSpecs(void)
+{
 	DWORD Intel_Features = 0;
 	DWORD AMD_Features = 0;
 
@@ -279,24 +288,31 @@ void DetectCpuSpecs(void) {
 		AMD_Features = Intel_Features = 0;
     }
 
-	if (Intel_Features & 0x02000000) {
+	if (Intel_Features & 0x02000000)
+	{
 		Compiler.mmx2 = TRUE;
 		Compiler.sse = TRUE;
 	}
-	if (Intel_Features & 0x00800000) {
+	if (Intel_Features & 0x00800000)
+	{
 		Compiler.mmx = TRUE;
 	}
-	if (AMD_Features & 0x40000000) {
+	if (AMD_Features & 0x40000000)
+	{
 		Compiler.mmx2 = TRUE;
 	}
-	if (Intel_Features & 0x00008000) {
+	if (Intel_Features & 0x00008000)
+	{
 		ConditionalMove = TRUE;
-	} else {
+	}
+	else
+	{
 		ConditionalMove = FALSE;
 	}
 }
 
-__declspec(dllexport) void InitiateRSP ( RSP_INFO Rsp_Info, DWORD * CycleCount) {
+__declspec(dllexport) void InitiateRSP ( RSP_INFO Rsp_Info, DWORD * CycleCount)
+{
 	RSPInfo = Rsp_Info;
 	AudioHle = GetSystemSetting(Set_AudioHle);
 	GraphicsHle = GetSystemSetting(Set_GraphicsHle);
@@ -320,14 +336,17 @@ __declspec(dllexport) void InitiateRSP ( RSP_INFO Rsp_Info, DWORD * CycleCount) 
             above.
   output:   none
 *******************************************************************/ 
-__declspec(dllexport) void InitiateRSPDebugger ( DEBUG_INFO Debug_Info) {
+__declspec(dllexport) void InitiateRSPDebugger ( DEBUG_INFO Debug_Info)
+{
 	DebugInfo = Debug_Info;
 }
 
-void ProcessMenuItem(int ID) {
+void ProcessMenuItem(int ID)
+{
 	UINT uState;
 
-	switch (ID) {
+	switch (ID)
+	{
 	case ID_RSPCOMMANDS: Enter_RSP_Commands_Window(); break;
 	case ID_RSPREGISTERS: Enter_RSP_Register_Window(); break;
 	case ID_DUMP_RSPCODE: DumpRSPCode(); break;
@@ -337,12 +356,15 @@ void ProcessMenuItem(int ID) {
 		{
 			uState = GetMenuState(hRSPMenu, ID_PROFILING_ON, MF_BYCOMMAND);
 			
-			if (uState & MFS_CHECKED) {
+			if (uState & MFS_CHECKED)
+			{
 				CheckMenuItem( hRSPMenu, ID_PROFILING_ON, MF_BYCOMMAND | MFS_UNCHECKED );
 				CheckMenuItem( hRSPMenu, ID_PROFILING_OFF, MF_BYCOMMAND | MFS_CHECKED );
 				SetSetting(Set_Profiling,FALSE);
 				if (DebuggingEnabled) { Profiling = FALSE; }
-			} else {
+			}
+			else
+			{
 				CheckMenuItem( hRSPMenu, ID_PROFILING_ON, MF_BYCOMMAND | MFS_CHECKED );
 				CheckMenuItem( hRSPMenu, ID_PROFILING_OFF, MF_BYCOMMAND | MFS_UNCHECKED );
 				SetSetting(Set_Profiling,TRUE);
@@ -356,11 +378,14 @@ void ProcessMenuItem(int ID) {
 		{
 			uState = GetMenuState(hRSPMenu, ID_PROFILING_LOGINDIVIDUALBLOCKS, MF_BYCOMMAND);
 			
-			if (uState & MFS_CHECKED) {
+			if (uState & MFS_CHECKED)
+			{
 				CheckMenuItem( hRSPMenu, ID_PROFILING_LOGINDIVIDUALBLOCKS, MF_BYCOMMAND | MFS_UNCHECKED );
 				SetSetting(Set_IndvidualBlock,FALSE);
 				if (DebuggingEnabled) { IndvidualBlock = FALSE; }
-			} else {
+			}
+			else
+			{
 				CheckMenuItem( hRSPMenu, ID_PROFILING_LOGINDIVIDUALBLOCKS, MF_BYCOMMAND | MFS_CHECKED );
 				SetSetting(Set_IndvidualBlock,TRUE);
 				if (DebuggingEnabled) {  IndvidualBlock = TRUE; }
@@ -371,11 +396,14 @@ void ProcessMenuItem(int ID) {
 		{
 			uState = GetMenuState(hRSPMenu, ID_SHOWCOMPILERERRORS, MF_BYCOMMAND);
 			
-			if (uState & MFS_CHECKED) {
+			if (uState & MFS_CHECKED)
+			{
 				CheckMenuItem( hRSPMenu, ID_SHOWCOMPILERERRORS, MF_BYCOMMAND | MFS_UNCHECKED );
 				SetSetting(Set_ShowErrors,FALSE);
 				if (DebuggingEnabled) { ShowErrors = FALSE; }
-			} else {
+			}
+			else
+			{
 				CheckMenuItem( hRSPMenu, ID_SHOWCOMPILERERRORS, MF_BYCOMMAND | MFS_CHECKED );
 				SetSetting(Set_ShowErrors,TRUE);
 				if (DebuggingEnabled) {  ShowErrors = TRUE; }
@@ -389,11 +417,14 @@ void ProcessMenuItem(int ID) {
 		{
 			uState = GetMenuState(hRSPMenu, ID_BREAKONSTARTOFTASK, MF_BYCOMMAND);
 			
-			if (uState & MFS_CHECKED) {
+			if (uState & MFS_CHECKED)
+			{
 				CheckMenuItem( hRSPMenu, ID_BREAKONSTARTOFTASK, MF_BYCOMMAND | MFS_UNCHECKED );
 				SetSetting(Set_BreakOnStart,FALSE);
 				if (DebuggingEnabled) { BreakOnStart = FALSE; }
-			} else {
+			}
+			else
+			{
 				CheckMenuItem( hRSPMenu, ID_BREAKONSTARTOFTASK, MF_BYCOMMAND | MFS_CHECKED );
 				SetSetting(Set_BreakOnStart,TRUE);
 				if (DebuggingEnabled) {  BreakOnStart = TRUE; }
@@ -404,7 +435,8 @@ void ProcessMenuItem(int ID) {
 		{
 			uState = GetMenuState(hRSPMenu, ID_LOGRDPCOMMANDS, MF_BYCOMMAND);
 			
-			if (uState & MFS_CHECKED) {
+			if (uState & MFS_CHECKED)
+			{
 				CheckMenuItem( hRSPMenu, ID_LOGRDPCOMMANDS, MF_BYCOMMAND | MFS_UNCHECKED );
 				SetSetting(Set_LogRDP,FALSE);
 				if (DebuggingEnabled) 
@@ -412,7 +444,9 @@ void ProcessMenuItem(int ID) {
 					LogRDP = FALSE; 
 					StopRDPLog();
 				}
-			} else {
+			}
+			else
+			{
 				CheckMenuItem( hRSPMenu, ID_LOGRDPCOMMANDS, MF_BYCOMMAND | MFS_CHECKED );
 				SetSetting(Set_LogRDP,TRUE);
 				if (DebuggingEnabled)
@@ -427,7 +461,8 @@ void ProcessMenuItem(int ID) {
 		{
 			uState = GetMenuState(hRSPMenu, ID_SETTINGS_LOGX86CODE, MF_BYCOMMAND);
 			
-			if (uState & MFS_CHECKED) {
+			if (uState & MFS_CHECKED)
+			{
 				CheckMenuItem( hRSPMenu, ID_SETTINGS_LOGX86CODE, MF_BYCOMMAND | MFS_UNCHECKED );
 				SetSetting(Set_LogX86Code,FALSE);
 				if (DebuggingEnabled) 
@@ -435,7 +470,9 @@ void ProcessMenuItem(int ID) {
 					LogX86Code = FALSE; 
 					StopCPULog();
 				}
-			} else {
+			}
+			else
+			{
 				CheckMenuItem( hRSPMenu, ID_SETTINGS_LOGX86CODE, MF_BYCOMMAND | MFS_CHECKED );
 				SetSetting(Set_LogX86Code,TRUE);
 				if (DebuggingEnabled)
@@ -488,7 +525,8 @@ __declspec(dllexport) void RomOpen (void)
   output:   none
 *******************************************************************/ 
 __declspec(dllexport) void RomClosed (void) {
-	if (Profiling) {
+	if (Profiling)
+	{
 		StopTimer();
 		GenerateTimerResults();
 	}
@@ -501,14 +539,17 @@ __declspec(dllexport) void RomClosed (void) {
 #endif
 }
 
-static BOOL GetBooleanCheck(HWND hDlg, DWORD DialogID) {
+static BOOL GetBooleanCheck(HWND hDlg, DWORD DialogID)
+{
 	return (IsDlgButtonChecked(hDlg, DialogID) == BST_CHECKED) ? TRUE : FALSE;
 }
 
-BOOL CALLBACK CompilerDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM /*lParam*/) {
+BOOL CALLBACK CompilerDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM /*lParam*/)
+{
 	char Buffer[256];
 
-	switch (uMsg) {	
+	switch (uMsg)
+	{
 	case WM_INITDIALOG:	
 		if (Compiler.bDest == TRUE)
 			CheckDlgButton(hDlg, IDC_COMPILER_DEST, BST_CHECKED);
@@ -535,16 +576,15 @@ BOOL CALLBACK CompilerDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM /*lPar
 
 		SetTimer(hDlg, 1, 250, NULL);
 		break;
-
 	case WM_TIMER:
 		sprintf(Buffer, "x86: %2.2f KB / %2.2f KB", (float)(RecompPos - RecompCode) / 1024.0F,
 			pLastSecondary?(float)((pLastSecondary - RecompCodeSecondary) / 1024.0F):0);
 
 		SetDlgItemText(hDlg, IDC_COMPILER_BUFFERS, Buffer);
 		break;
-
 	case WM_COMMAND:
-		switch (GET_WM_COMMAND_ID(wParam, lParam)) {
+		switch (GET_WM_COMMAND_ID(wParam, lParam))
+		{
 		case IDOK:
 			Compiler.bDest = GetBooleanCheck(hDlg, IDC_COMPILER_DEST);
 			Compiler.bAccum = GetBooleanCheck(hDlg, IDC_COMPILER_ACCUM);
@@ -570,31 +610,32 @@ BOOL CALLBACK CompilerDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM /*lPar
 			KillTimer(hDlg, 1);
 			EndDialog(hDlg, TRUE);
 			break;
-
 		case IDCANCEL:	
 			KillTimer(hDlg, 1);
 			EndDialog(hDlg, TRUE);
 			break;
 		}
 		break;
-
 	default:
 		return FALSE;
 	}
 	return TRUE;
 }
 
-BOOL CALLBACK ConfigDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM /*lParam*/) {
+BOOL CALLBACK ConfigDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM /*lParam*/)
+{
 	HWND hWndItem;
 	DWORD value;
 
-	switch (uMsg) {	
+	switch (uMsg)
+	{
 	case WM_INITDIALOG:	
-		if (AudioHle == TRUE) {
+		if (AudioHle == TRUE)
+		{
 			CheckDlgButton(hDlg, IDC_AUDIOHLE, BST_CHECKED);
 		}
-
-		if (GraphicsHle == TRUE) {
+		if (GraphicsHle == TRUE)
+		{
 			CheckDlgButton(hDlg, IDC_GRAPHICSHLE, BST_CHECKED);
 		}
 
@@ -603,9 +644,9 @@ BOOL CALLBACK ConfigDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM /*lParam
 		ComboBox_AddString(hWndItem, "Recompiler");
 		ComboBox_SetCurSel(hWndItem, CPUCore);
 		break;
-
 	case WM_COMMAND:
-		switch (GET_WM_COMMAND_ID(wParam, lParam)) {
+		switch (GET_WM_COMMAND_ID(wParam, lParam))
+		{
 		case IDOK:
 			hWndItem = GetDlgItem(hDlg, IDC_COMPILER_SELECT);
 			value = ComboBox_GetCurSel(hWndItem);
@@ -621,19 +662,20 @@ BOOL CALLBACK ConfigDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM /*lParam
 			break;
 		}
 		break;
-
 	default:
 		return FALSE;
 	}
 	return TRUE;
 }
 
-/*__declspec(dllexport) void DllConfig (HWND hWnd) {
+/*__declspec(dllexport) void DllConfig (HWND hWnd)
+{
 	// DialogBox(hinstDLL, "RSPCONFIG", hWnd, ConfigDlgProc);
 	DialogBox(hinstDLL, "RSPCONFIG", GetForegroundWindow(), ConfigDlgProc);
 }*/
 
-__declspec(dllexport) void EnableDebugging (BOOL Enabled) {
+__declspec(dllexport) void EnableDebugging (BOOL Enabled)
+{
 	DebuggingEnabled = Enabled;
 	if (DebuggingEnabled)
 	{

--- a/Source/RSP/Profiling.cpp
+++ b/Source/RSP/Profiling.cpp
@@ -36,7 +36,8 @@ extern "C" {
 #include <map>
 #include <vector>
 
-class CProfiling {
+class CProfiling
+{
 typedef std::map<DWORD, __int64 >     PROFILE_ENRTIES;
 typedef PROFILE_ENRTIES::iterator     PROFILE_ENRTY;
 typedef PROFILE_ENRTIES::value_type   PROFILE_VALUE;
@@ -89,9 +90,12 @@ public:
 		__int64 TimeTaken = StopTime - StartTime;
 		
 		PROFILE_ENRTY Entry = m_Entries.find(m_CurrentTimerAddr);
-		if (Entry != m_Entries.end()) {
+		if (Entry != m_Entries.end())
+		{
 			Entry->second += TimeTaken;
-		} else {
+		}
+		else
+		{
 			m_Entries.insert(PROFILE_ENRTIES::value_type(m_CurrentTimerAddr,TimeTaken));
 		}
 
@@ -117,22 +121,27 @@ public:
 
 			//Get the total time
 			__int64 TotalTime = 0;
-			for (PROFILE_ENRTY itemTime = m_Entries.begin(); itemTime != m_Entries.end(); itemTime++ ) {
+			for (PROFILE_ENRTY itemTime = m_Entries.begin(); itemTime != m_Entries.end(); itemTime++ )
+			{
 				TotalTime += itemTime->second;
 			}
 
 			//Create a sortable list of items
 			std::vector<PROFILE_VALUE *> ItemList;
-			for (PROFILE_ENRTY Entry = m_Entries.begin(); Entry != m_Entries.end(); Entry++ ) {
+			for (PROFILE_ENRTY Entry = m_Entries.begin(); Entry != m_Entries.end(); Entry++ )
+			{
 				ItemList.push_back(&(*Entry));
 			}
-			
+
 			//sort the list with a basic bubble sort
 			if (ItemList.size() > 0)
 			{
-				for (size_t OuterPass = 0; OuterPass < (ItemList.size() - 1); OuterPass++ ) {
-					for (size_t InnerPass = 0; InnerPass < (ItemList.size() - 1); InnerPass++ ) {
-						if (ItemList[InnerPass]->second < ItemList[InnerPass + 1]->second) {
+				for (size_t OuterPass = 0; OuterPass < (ItemList.size() - 1); OuterPass++ )
+				{
+					for (size_t InnerPass = 0; InnerPass < (ItemList.size() - 1); InnerPass++ )
+					{
+						if (ItemList[InnerPass]->second < ItemList[InnerPass + 1]->second)
+						{
 							PROFILE_VALUE * TempPtr = ItemList[InnerPass];
 							ItemList[InnerPass] = ItemList[InnerPass + 1];
 							ItemList[InnerPass + 1] = TempPtr;
@@ -147,14 +156,17 @@ public:
 				{Timer_R4300_Running, "R4300: Running"},
 				{Timer_RDP_Running,   "RDP: Running"},
 			};
-			
-			for (size_t count = 0; count < ItemList.size(); count++ ) {
+
+			for (size_t count = 0; count < ItemList.size(); count++ )
+			{
 				char Buffer[255];
 				float CpuUsage = (float)(((double)ItemList[count]->second / (double)TotalTime) * 100);
 				if (CpuUsage <= 0.2) { continue; }
 				sprintf(Buffer,"Func 0x%08X",ItemList[count]->first);
-				for (int NameID = 0; NameID < (sizeof(TimerNames) / sizeof(TIMER_NAME)); NameID++) {
-					if (ItemList[count]->first == (DWORD)TimerNames[NameID].Timer) {
+				for (int NameID = 0; NameID < (sizeof(TimerNames) / sizeof(TIMER_NAME)); NameID++)
+				{
+					if (ItemList[count]->first == (DWORD)TimerNames[NameID].Timer)
+					{
 						strcpy(Buffer,TimerNames[NameID].Name);
 						break;
 					}
@@ -165,7 +177,6 @@ public:
 
 		ShellExecute(NULL,"open",LogFileName.c_str(),NULL,NULL,SW_SHOW);
 		ResetCounters();
-		
 	}
 };
 
@@ -176,22 +187,25 @@ CProfiling& GetProfiler ( void )
 	return Profile;
 }
 
-void ResetTimerList (void) {
+void ResetTimerList (void)
+{
 	GetProfiler().ResetCounters();
 }
 
-DWORD StartTimer (DWORD Address) {
+DWORD StartTimer (DWORD Address)
+{
 	return GetProfiler().StartTimer(Address);
 }
 
-void StopTimer (void) {
+void StopTimer (void)
+{
 	GetProfiler().StopTimer();
 }
 
-void GenerateTimerResults (void) {
+void GenerateTimerResults (void)
+{
 	GetProfiler().GenerateLog();
 }
-
 
 #ifdef todelete
 #include <windows.h>
@@ -206,14 +220,16 @@ DWORD StartTimeHi, StartTimeLo, StopTimeHi, StopTimeLo, TSE_Count, TSE_Max;
 TIME_STAMP_ENTRY * TS_Entries = NULL;
 char LastLabel[100];
 
-void ResetTimerList (void) {
+void ResetTimerList (void)
+{
 	if (TS_Entries) { free(TS_Entries); }
 	TS_Entries = NULL;
 	TSE_Count = 0;
 	TSE_Max = 0;
 }
 
-void StartTimer (char * Label) {
+void StartTimer (char * Label)
+{
 	strcpy(LastLabel,Label);
 	_asm {
 		pushad
@@ -224,7 +240,8 @@ void StartTimer (char * Label) {
 	}
 }
 
-void StopTimer (void) {
+void StopTimer (void)
+{
 	_asm {
 		pushad
 		rdtsc
@@ -236,8 +253,10 @@ void StopTimer (void) {
 	{
 		DWORD count;
 
-		for (count = 0; count < TSE_Count; count ++) {
-			if (strcmp(LastLabel,TS_Entries[count].Label) == 0) {
+		for (count = 0; count < TSE_Count; count ++)
+		{
+			if (strcmp(LastLabel,TS_Entries[count].Label) == 0)
+			{
 				__int64 Time = ((unsigned __int64)StopTimeHi << 32) + (unsigned __int64)StopTimeLo;
 				Time -= ((unsigned __int64)StartTimeHi << 32) + (unsigned __int64)StartTimeLo;
 				TS_Entries[count].TimeTotal += Time;
@@ -245,16 +264,21 @@ void StopTimer (void) {
 			}
 		}
 	}
-	if (TSE_Count == 0) {
+	if (TSE_Count == 0)
+	{
 		TS_Entries = (TIME_STAMP_ENTRY *)malloc(sizeof(TIME_STAMP_ENTRY) * 100);
-		if (TS_Entries == NULL) {
+		if (TS_Entries == NULL)
+		{
 			MessageBox(NULL,"TIME_STAMP_ENTRY == NULL ??","ERROR",MB_OK|MB_ICONERROR|MB_SETFOREGROUND);
 		}
 		TSE_Max = 100;
-	} else if (TSE_Count == TSE_Max) {
+	}
+	else if (TSE_Count == TSE_Max)
+	{
 		TSE_Max += 100;
 		TS_Entries = (TIME_STAMP_ENTRY *)realloc(TS_Entries,sizeof(TIME_STAMP_ENTRY) * TSE_Max);
-		if (TS_Entries == NULL) {
+		if (TS_Entries == NULL)
+		{
 			MessageBox(NULL,"TIME_STAMP_ENTRY == NULL ??","ERROR",MB_OK|MB_ICONERROR|MB_SETFOREGROUND);
 		}
 	}
@@ -264,7 +288,8 @@ void StopTimer (void) {
 	TSE_Count +=1;
 }
 
-void GenerateTimerResults (void) {
+void GenerateTimerResults (void)
+{
 	char buffer[_MAX_PATH], drive[_MAX_DRIVE] ,dir[_MAX_DIR];
 	char fname[_MAX_FNAME],ext[_MAX_EXT], LogFileName[_MAX_PATH];
 	DWORD dwWritten, count, count2;
@@ -280,10 +305,13 @@ void GenerateTimerResults (void) {
 	hLogFile = CreateFile(LogFileName,GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE,NULL,
 		CREATE_ALWAYS,FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
 	SetFilePointer(hLogFile,0,NULL,FILE_BEGIN);
-	
-	for (count = 0; count < TSE_Count; count ++) {
-		for (count2 = 0; count2 < (TSE_Count - 1); count2 ++) {
-			if (TS_Entries[count2].TimeTotal < TS_Entries[count2 + 1].TimeTotal) {
+
+	for (count = 0; count < TSE_Count; count ++)
+	{
+		for (count2 = 0; count2 < (TSE_Count - 1); count2 ++)
+		{
+			if (TS_Entries[count2].TimeTotal < TS_Entries[count2 + 1].TimeTotal)
+			{
 				TIME_STAMP_ENTRY Temp;
 				memcpy(&Temp,&TS_Entries[count2],sizeof(TIME_STAMP_ENTRY));
 				memcpy(&TS_Entries[count2],&TS_Entries[count2 + 1],sizeof(TIME_STAMP_ENTRY));
@@ -292,10 +320,12 @@ void GenerateTimerResults (void) {
 		}
 	}
 	TotalTime = 0;
-	for (count = 0; count < TSE_Count; count ++) {
+	for (count = 0; count < TSE_Count; count ++)
+	{
 		TotalTime += TS_Entries[count].TimeTotal;
 	}
-	for (count = 0; count < (TSE_Count < 50?TSE_Count:50); count ++) {
+	for (count = 0; count < (TSE_Count < 50?TSE_Count:50); count ++)
+	{
 		sprintf(buffer,"%s - %0.2f%c\r\n",
 			TS_Entries[count].Label,
 			(((double)TS_Entries[count].TimeTotal / (double)TotalTime) * 100),'%'

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -72,29 +72,36 @@ BOOL InRSPCommandsWindow;
 char CommandName[100];
 DWORD Stepping_Commands, WaitingForStep;
 
-
-void Create_RSP_Commands_Window ( int Child ) {
+void Create_RSP_Commands_Window ( int Child )
+{
 	DWORD ThreadID;
 
-	if ( Child ) {
+	if ( Child )
+	{
 		InRSPCommandsWindow = TRUE;
 		DialogBox( hinstDLL, "RSPCOMMAND", NULL,(DLGPROC)RSP_Commands_Proc );
 
 		InRSPCommandsWindow = FALSE;
 		memset(RSPCommandLine,0,sizeof(RSPCommandLine));
 		SetRSPCommandToRunning();
-	} else {
-		if (!InRSPCommandsWindow) {
+	}
+	else
+	{
+		if (!InRSPCommandsWindow)
+		{
 			Stepping_Commands = TRUE;
 			CreateThread(NULL,0,(LPTHREAD_START_ROUTINE)Create_RSP_Commands_Window,
 				(LPVOID)TRUE,0, &ThreadID);	
-		} else {
+		}
+		else
+		{
 			SetForegroundWindow(RSPCommandshWnd);
 		}	
 	}
 }
 
-void Disable_RSP_Commands_Window ( void ) {
+void Disable_RSP_Commands_Window ( void )
+{
 	SCROLLINFO si;
 
 	if (!InRSPCommandsWindow) { return; }
@@ -108,7 +115,7 @@ void Disable_RSP_Commands_Window ( void ) {
 	EnableWindow(hRSPRegisters,    FALSE);
 	EnableWindow(hR4300iDebugger,     FALSE);
 	EnableWindow(hMemory,          FALSE);
-	
+
 	si.cbSize = sizeof(si);
 	si.fMask  = SIF_RANGE | SIF_POS | SIF_PAGE;
 	si.nMin   = 0;
@@ -118,28 +125,33 @@ void Disable_RSP_Commands_Window ( void ) {
 	SetScrollInfo(hScrlBar,SB_CTL,&si,TRUE);
 }
 
-int DisplayRSPCommand (DWORD location, int InsertPos) {
+int DisplayRSPCommand (DWORD location, int InsertPos)
+{
 	uint32_t OpCode;
 	DWORD LinesUsed = 1, status;
 	BOOL Redraw = FALSE;	
 
 	RSP_LW_IMEM(location, &OpCode);
-	
+
 	status = 0;
 	if (location == *PrgCount) {status = RSP_Status_PC; }
 	if (CheckForRSPBPoint(location)) { status |= RSP_Status_BP; }
 	if (RSPCommandLine[InsertPos].opcode != OpCode) { Redraw = TRUE; }
 	if (RSPCommandLine[InsertPos].Location != location) { Redraw = TRUE; }
 	if (RSPCommandLine[InsertPos].status != status) { Redraw = TRUE; }
-	if (Redraw) {
+	if (Redraw)
+	{
 		RSPCommandLine[InsertPos].Location = location;
 		RSPCommandLine[InsertPos].status = status;
 		RSPCommandLine[InsertPos].opcode = OpCode;
 		sprintf(RSPCommandLine[InsertPos].String," 0x%03X\t%s",location, 
 			RSPOpcodeName ( OpCode, location ));
-		if ( SendMessage(hList,LB_GETCOUNT,0,0) <= InsertPos) {
+		if ( SendMessage(hList,LB_GETCOUNT,0,0) <= InsertPos)
+		{
 			SendMessage(hList,LB_INSERTSTRING,(WPARAM)InsertPos, (LPARAM)location); 
-		} else {
+		}
+		else
+		{
 			RECT ItemRC;
 			SendMessage(hList,LB_GETITEMRECT,(WPARAM)InsertPos, (LPARAM)&ItemRC); 
 			RedrawWindow(hList,&ItemRC,NULL, RDW_INVALIDATE );
@@ -148,7 +160,8 @@ int DisplayRSPCommand (DWORD location, int InsertPos) {
 	return LinesUsed;
 }
 
-void DumpRSPCode (void) {
+void DumpRSPCode (void)
+{
 	char string[100], LogFileName[255], *p ;
 	uint32_t OpCode;
 	DWORD location, dwWritten;
@@ -156,14 +169,17 @@ void DumpRSPCode (void) {
 
 	strcpy(LogFileName,GetCommandLine() + 1);
 	
-	if (strchr(LogFileName,'\"')) {
+	if (strchr(LogFileName,'\"'))
+	{
 		p = strchr(LogFileName,'\"');
 		*p = '\0';
 	}
 	
-	if (strchr(LogFileName,'\\')) {
+	if (strchr(LogFileName,'\\'))
+	{
 		p = LogFileName;
-		while (strchr(p,'\\')) {
+		while (strchr(p,'\\'))
+		{
 			p = strchr(p,'\\');
 			p++;
 		}
@@ -185,20 +201,23 @@ void DumpRSPCode (void) {
 	CloseHandle(hLogFile);
 }
 
-void DumpRSPData (void) {
+void DumpRSPData (void)
+{
 	char string[100], LogFileName[255], *p ;
 	uint32_t value;
 	DWORD location, dwWritten;
 	HANDLE hLogFile = NULL;
 
 	strcpy(LogFileName,GetCommandLine() + 1);
-	
-	if (strchr(LogFileName,'\"')) {
+
+	if (strchr(LogFileName,'\"'))
+	{
 		p = strchr(LogFileName,'\"');
 		*p = '\0';
 	}
-	
-	if (strchr(LogFileName,'\\')) {
+
+	if (strchr(LogFileName,'\\'))
+	{
 		p = LogFileName;
 		while (strchr(p,'\\')) {
 			p = strchr(p,'\\');
@@ -214,7 +233,8 @@ void DumpRSPData (void) {
 		FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
 	SetFilePointer(hLogFile,0,NULL,FILE_BEGIN);
 
-	for (location = 0; location < 0x1000; location += 4) {
+	for (location = 0; location < 0x1000; location += 4)
+	{
 		RSP_LW_DMEM(location, &value);
 		sprintf(string," 0x%03X\t0x%08X\r\n", location, value);
 		WriteFile( hLogFile,string,strlen(string),&dwWritten,NULL );
@@ -222,7 +242,8 @@ void DumpRSPData (void) {
 	CloseHandle(hLogFile);
 }
 
-void DrawRSPCommand ( LPARAM lParam ) {	
+void DrawRSPCommand ( LPARAM lParam )
+{
 	char Command[150], Offset[30], Instruction[30], Arguments[40];
 	LPDRAWITEMSTRUCT ditem;
 	COLORREF oldColor = {0};
@@ -233,40 +254,53 @@ void DrawRSPCommand ( LPARAM lParam ) {
 
 	ditem  = (LPDRAWITEMSTRUCT)lParam;
 	strcpy(Command, RSPCommandLine[ditem->itemID].String);
-	
-	if (strchr(Command,'\t')) {
+
+	if (strchr(Command,'\t'))
+	{
 		p1 = strchr(Command,'\t');
 		sprintf(Offset,"%.*s",p1 - Command, Command);
 		p1++;
-		if (strchr(p1,'\t')) {
+		if (strchr(p1,'\t'))
+		{
 			p2 = strchr(p1,'\t');
 			sprintf(Instruction,"%.*s",p2 - p1, p1);
 			sprintf(Arguments,"%s",p2 + 1);
-		} else {
+		}
+		else
+		{
 			sprintf(Instruction,"%s",p1);
 			sprintf(Arguments,"\0");
 		}
 		sprintf(Command,"\0");
-	} else {
+	}
+	else
+	{
 		sprintf(Offset,"\0");
 		sprintf(Instruction,"\0");
 		sprintf(Arguments,"\0");
 	}
-		
-	if (*PrgCount == RSPCommandLine[ditem->itemID].Location) {
+
+	if (*PrgCount == RSPCommandLine[ditem->itemID].Location)
+	{
 		ResetColor = TRUE;
 		hBrush     = (HBRUSH)(COLOR_HIGHLIGHT + 1);
 		oldColor   = SetTextColor(ditem->hDC,RGB(255,255,255));
-	} else {
+	}
+	else
+	{
 		ResetColor = FALSE;
 		hBrush     = (HBRUSH)GetStockObject(WHITE_BRUSH);
 	}
 
-	if (CheckForRSPBPoint( RSPCommandLine[ditem->itemID].Location )) {
+	if (CheckForRSPBPoint( RSPCommandLine[ditem->itemID].Location ))
+	{
 		ResetColor = TRUE;
-		if (*PrgCount == RSPCommandLine[ditem->itemID].Location) {
+		if (*PrgCount == RSPCommandLine[ditem->itemID].Location)
+		{
 			SetTextColor(ditem->hDC,RGB(255,0,0));
-		} else {
+		}
+		else
+		{
 			oldColor = SetTextColor(ditem->hDC,RGB(255,0,0));
 		}
 	}
@@ -274,11 +308,12 @@ void DrawRSPCommand ( LPARAM lParam ) {
 	FillRect( ditem->hDC, &ditem->rcItem,hBrush);	
 	SetBkMode( ditem->hDC, TRANSPARENT );
 
-	if (strlen (Command) == 0 ) {
+	if (strlen (Command) == 0 )
+	{
 		SetRect(&TextRect,ditem->rcItem.left,ditem->rcItem.top, ditem->rcItem.left + 83,
 			ditem->rcItem.bottom);	
 		DrawText(ditem->hDC,Offset,strlen(Offset), &TextRect,DT_SINGLELINE | DT_VCENTER);
-		
+
 		SetRect(&TextRect,ditem->rcItem.left + 83,ditem->rcItem.top, ditem->rcItem.left + 165,
 			ditem->rcItem.bottom);	
 		DrawText(ditem->hDC,Instruction,strlen(Instruction), &TextRect,DT_SINGLELINE | DT_VCENTER);
@@ -286,18 +321,19 @@ void DrawRSPCommand ( LPARAM lParam ) {
 		SetRect(&TextRect,ditem->rcItem.left + 165,ditem->rcItem.top, ditem->rcItem.right,
 			ditem->rcItem.bottom);	
 		DrawText(ditem->hDC,Arguments,strlen(Arguments), &TextRect,DT_SINGLELINE | DT_VCENTER);
-	} else {
+	}
+	else
+	{
 		DrawText(ditem->hDC,Command,strlen(Command), &ditem->rcItem,DT_SINGLELINE | DT_VCENTER);
 	}
 
 	if (ResetColor == TRUE) {
 		SetTextColor( ditem->hDC, oldColor );
 	}
-
 }
 
-
-void Enable_RSP_Commands_Window ( void ) {
+void Enable_RSP_Commands_Window ( void )
+{
 	SCROLLINFO si;
 
 	if (!InRSPCommandsWindow) { return; }
@@ -314,7 +350,7 @@ void Enable_RSP_Commands_Window ( void ) {
 	SendMessage(hBPButton, BM_SETSTYLE, BS_PUSHBUTTON,TRUE);
 	SendMessage(hStepButton, BM_SETSTYLE, BS_DEFPUSHBUTTON,TRUE);
 	SendMessage(RSPCommandshWnd, DM_SETDEFID,IDC_STEP_BUTTON,0);
-	
+
 	if (Stepping_Commands) {
 		si.cbSize = sizeof(si);
 		si.fMask  = SIF_RANGE | SIF_POS | SIF_PAGE;
@@ -323,24 +359,26 @@ void Enable_RSP_Commands_Window ( void ) {
 		si.nPos   = (*PrgCount >> 2);
 		si.nPage  = 30;
 		SetScrollInfo(hScrlBar,SB_CTL,&si,TRUE);		
-	
+
 		SetRSPCommandViewto( *PrgCount );
 		SetForegroundWindow(RSPCommandshWnd);
 	}
 }
 
-void Enter_RSP_Commands_Window ( void ) {
+void Enter_RSP_Commands_Window ( void )
+{
     Create_RSP_Commands_Window ( FALSE );
 }
 
-void Paint_RSP_Commands (HWND hDlg) {
+void Paint_RSP_Commands (HWND hDlg)
+{
 	PAINTSTRUCT ps;
 	RECT rcBox;
 	HFONT hOldFont;
 	int OldBkMode;
 
 	BeginPaint( hDlg, &ps );
-		
+
 	rcBox.left   = 5;   rcBox.top    = 5;
 	rcBox.right  = 343; rcBox.bottom = 463;
 	DrawEdge( ps.hdc, &rcBox, EDGE_RAISED, BF_RECT );
@@ -384,7 +422,8 @@ void Paint_RSP_Commands (HWND hDlg) {
 	EndPaint( hDlg, &ps );
 }
 
-void RefreshRSPCommands ( void ) {
+void RefreshRSPCommands ( void )
+{
 	DWORD location, LinesUsed;
 	char AsciiAddress[20];
 	int count;
@@ -395,14 +434,17 @@ void RefreshRSPCommands ( void ) {
 	location = AsciiToHex(AsciiAddress) & ~3;
 
 	if (location > 0xF88) { location = 0xF88; }
-	for (count = 0 ; count < RSP_MaxCommandLines; count += LinesUsed ){
+	for (count = 0 ; count < RSP_MaxCommandLines; count += LinesUsed )
+	{
 		LinesUsed = DisplayRSPCommand ( location, count );
 		location += 4;
 	}
 }
 
-LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam) {	
-	switch (uMsg) {
+LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+	switch (uMsg)
+	{
 	case WM_INITDIALOG:
 		RSPCommandshWnd = hDlg;
 		RSP_Commands_Setup( hDlg );
@@ -411,7 +453,8 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 		//StoreCurrentWinPos("RSP Commands",hDlg);
 		break;
 	case WM_DRAWITEM:
-		if (wParam == IDC_LIST) {
+		if (wParam == IDC_LIST)
+		{
 			DrawRSPCommand (lParam);
 		}
 		break;
@@ -420,16 +463,22 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 		RedrawWindow(hScrlBar,NULL,NULL, RDW_INVALIDATE |RDW_ERASE);
 		return TRUE;
 	case WM_COMMAND:
-		switch (LOWORD(wParam)) {
+		switch (LOWORD(wParam))
+		{
 		case IDC_LIST:
-			if (HIWORD(wParam) == LBN_DBLCLK ) {
+			if (HIWORD(wParam) == LBN_DBLCLK )
+			{
 				DWORD Location, Selected;
 				Selected = SendMessage(hList,LB_GETCURSEL,(WPARAM)0, (LPARAM)0); 
 				Location = RSPCommandLine[Selected].Location; 
-				if (Location != (DWORD)-1) {
-					if (CheckForRSPBPoint(Location)) {
+				if (Location != (DWORD)-1)
+				{
+					if (CheckForRSPBPoint(Location))
+					{
 						RemoveRSPBreakPoint(Location);
-					} else {
+					}
+					else
+					{
 						AddRSP_BPoint(Location, FALSE);
 					}
 					RefreshRSPCommands();
@@ -437,7 +486,8 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 			}
 			break;
 		case IDC_ADDRESS:
-			if (HIWORD(wParam) == EN_CHANGE ) {
+			if (HIWORD(wParam) == EN_CHANGE )
+			{
 				RefreshRSPCommands();
 			}
 			break;
@@ -455,7 +505,8 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 			WaitingFor_RSPStep   = FALSE;
 			break;*/
 		case IDC_BP_BUTTON:	
-			if (DebugInfo.Enter_BPoint_Window != NULL) {
+			if (DebugInfo.Enter_BPoint_Window != NULL)
+			{
 				DebugInfo.Enter_BPoint_Window(); 
 			}
 			break;
@@ -463,17 +514,20 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 			Enter_RSP_Register_Window();
 			break;
 		case IDC_R4300I_DEBUGGER_BUTTON: 
-			if (DebugInfo.Enter_R4300i_Commands_Window != NULL) {
+			if (DebugInfo.Enter_R4300i_Commands_Window != NULL)
+			{
 				DebugInfo.Enter_R4300i_Commands_Window(); 
 			}
 			break;
 		case IDC_R4300I_REGISTERS_BUTTON:
-			if (DebugInfo.Enter_R4300i_Register_Window != NULL) {
+			if (DebugInfo.Enter_R4300i_Register_Window != NULL)
+			{
 				DebugInfo.Enter_R4300i_Register_Window(); 
 			}
 			break;
 		case IDC_MEMORY_BUTTON:
-			if (DebugInfo.Enter_Memory_Window != NULL) {
+			if (DebugInfo.Enter_Memory_Window != NULL)
+			{
 				DebugInfo.Enter_Memory_Window(); 
 			}
 			break;
@@ -483,15 +537,17 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 		}
 		break;
 	case WM_VSCROLL:
-		if ((HWND)lParam == hScrlBar) {
+		if ((HWND)lParam == hScrlBar)
+		{
 			DWORD location;
 			char Value[20];
 			SCROLLINFO si;
-		
+
 			GetWindowText(hAddress,Value,sizeof(Value));
 			location = AsciiToHex(Value) & ~3;
-			
-			switch (LOWORD(wParam))  {			
+
+			switch (LOWORD(wParam))
+			{
 			case SB_THUMBTRACK:
 				sprintf(Value,"%03X",((short int)HIWORD(wParam) << 2 ));
 				SetWindowText(hAddress,Value);
@@ -501,14 +557,17 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 				SetScrollInfo(hScrlBar,SB_CTL,&si,TRUE);
 				break;
 			case SB_LINEDOWN:
-				if (location < 0xF88) {
+				if (location < 0xF88)
+				{
 					sprintf(Value,"%03X",location + 0x4);
 					SetWindowText(hAddress,Value);
 					si.cbSize = sizeof(si);			
 					si.fMask  = SIF_POS;
 					si.nPos   = ((location + 0x4) >> 2);
 					SetScrollInfo(hScrlBar,SB_CTL,&si,TRUE);
-				} else {
+				}
+				else
+				{
 					sprintf(Value,"%03X",0xF88);
 					SetWindowText(hAddress,Value);
 					si.cbSize = sizeof(si);			
@@ -518,14 +577,17 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 				}
 				break;
 			case SB_LINEUP:
-				if (location > 0x4 ) {
+				if (location > 0x4 )
+				{
 					sprintf(Value,"%03X",location - 0x4);
 					SetWindowText(hAddress,Value);
 					si.cbSize = sizeof(si);			
 					si.fMask  = SIF_POS;
 					si.nPos   = ((location - 0x4) >> 2);
 					SetScrollInfo(hScrlBar,SB_CTL,&si,TRUE);
-				} else {
+				}
+				else
+				{
 					sprintf(Value,"%03X",0);
 					SetWindowText(hAddress,Value);
 					si.cbSize = sizeof(si);			
@@ -535,14 +597,17 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 				}
 				break;
 			case SB_PAGEDOWN:				
-				if ((location + 0x74)< 0xF88) {
+				if ((location + 0x74)< 0xF88)
+				{
 					sprintf(Value,"%03X",location + 0x74);
 					SetWindowText(hAddress,Value);
 					si.cbSize = sizeof(si);			
 					si.fMask  = SIF_POS;
 					si.nPos   = ((location + 0x74) >> 2);
 					SetScrollInfo(hScrlBar,SB_CTL,&si,TRUE);
-				} else {
+				}
+				else
+				{
 					sprintf(Value,"%03X",0xF88);
 					SetWindowText(hAddress,Value);
 					si.cbSize = sizeof(si);			
@@ -552,14 +617,17 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 				}
 				break;			
 			case SB_PAGEUP:
-				if ((location - 0x74) > 0x74 ) {
+				if ((location - 0x74) > 0x74 )
+				{
 					sprintf(Value,"%03X",location - 0x74);
 					SetWindowText(hAddress,Value);
 					si.cbSize = sizeof(si);			
 					si.fMask  = SIF_POS;
 					si.nPos   = ((location - 0x74) >> 2);
 					SetScrollInfo(hScrlBar,SB_CTL,&si,TRUE);
-				} else {
+				}
+				else
+				{
 					sprintf(Value,"%03X",0);
 					SetWindowText(hAddress,Value);
 					si.cbSize = sizeof(si);			
@@ -577,7 +645,8 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 	return TRUE;
 }
 
-void RSP_Commands_Setup ( HWND hDlg ) {
+void RSP_Commands_Setup ( HWND hDlg )
+{
 #define WindowWidth  457
 #define WindowHeight 494
 	char Location[10];
@@ -586,7 +655,8 @@ void RSP_Commands_Setup ( HWND hDlg ) {
 	hList = CreateWindowEx(WS_EX_STATICEDGE, "LISTBOX","", WS_CHILD | WS_VISIBLE | 
 		LBS_OWNERDRAWFIXED | LBS_NOTIFY,14,30,303,445, hDlg, 
 		(HMENU)IDC_LIST, hinstDLL,NULL );
-	if ( hList) {
+	if ( hList)
+	{
 		SendMessage(hList,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 		SendMessage(hList,LB_SETITEMHEIGHT, (WPARAM)0,(LPARAM)MAKELPARAM(14, 0));
 	}
@@ -594,43 +664,49 @@ void RSP_Commands_Setup ( HWND hDlg ) {
 	sprintf(Location,"%03X",*PrgCount);
 	hAddress = CreateWindowEx(0,"EDIT",Location, WS_CHILD | ES_UPPERCASE | WS_VISIBLE | 
 		WS_BORDER | WS_TABSTOP,375,17,36,18, hDlg,(HMENU)IDC_ADDRESS,hinstDLL, NULL );
-	if (hAddress) {
+	if (hAddress)
+	{
 		SendMessage(hAddress,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 		SendMessage(hAddress,EM_SETLIMITTEXT, (WPARAM)3,(LPARAM)0);
-	} 
+	}
 
 	hFunctionlist = CreateWindowEx(0,"COMBOBOX","", WS_CHILD | WS_VSCROLL |
 		CBS_DROPDOWNLIST | CBS_SORT | WS_TABSTOP,352,56,89,150,hDlg,
 		(HMENU)IDC_FUNCTION_COMBO,hinstDLL,NULL);		
-	if (hFunctionlist) {
+	if (hFunctionlist)
+	{
 		SendMessage(hFunctionlist,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	} 
 
 	hGoButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Go", WS_CHILD | 
 		BS_DEFPUSHBUTTON | WS_VISIBLE | WS_TABSTOP, 347,56,100,24, hDlg,(HMENU)IDC_GO_BUTTON,
 		hinstDLL,NULL );
-	if (hGoButton) {
+	if (hGoButton)
+	{
 		SendMessage(hGoButton,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	} 
-	
+
 	hBreakButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Break", WS_DISABLED | 
 		WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,85,100,24,hDlg,
 		(HMENU)IDC_BREAK_BUTTON,hinstDLL,NULL );
-	if (hBreakButton) {
+	if (hBreakButton)
+	{
 		SendMessage(hBreakButton,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	}
 
 	hStepButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Step", WS_CHILD | 
 		BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,114,100,24,hDlg,
 		(HMENU)IDC_STEP_BUTTON,hinstDLL,NULL );
-	if (hStepButton) {
+	if (hStepButton)
+	{
 		SendMessage(hStepButton,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	}
 
 	hSkipButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Skip", WS_CHILD | 
 		BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,143,100,24,hDlg,
 		(HMENU)IDC_SKIP_BUTTON,hinstDLL,NULL );
-	if (hSkipButton) {
+	if (hSkipButton)
+	{
 		SendMessage(hSkipButton,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	}
 
@@ -640,11 +716,13 @@ void RSP_Commands_Setup ( HWND hDlg ) {
 	if (DebugInfo.Enter_R4300i_Register_Window == NULL) { WndPos += 29;}
 	if (DebugInfo.Enter_Memory_Window == NULL) { WndPos += 29;}
 
-	if (DebugInfo.Enter_BPoint_Window != NULL) {
+	if (DebugInfo.Enter_BPoint_Window != NULL)
+	{
 		hBPButton = CreateWindowEx(WS_EX_STATICEDGE, "BUTTON","&Break Points", WS_CHILD | 
 			BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,WndPos,100,24,hDlg,
 			(HMENU)IDC_BP_BUTTON,hinstDLL,NULL );
-		if (hBPButton) {
+		if (hBPButton)
+		{
 			SendMessage(hBPButton,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 		}
 	}
@@ -653,49 +731,59 @@ void RSP_Commands_Setup ( HWND hDlg ) {
 	hRSPRegisters = CreateWindowEx(WS_EX_STATICEDGE,"BUTTON", "RSP &Registers...",
 		WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,WndPos,100,24,hDlg,
 		(HMENU)IDC_RSP_REGISTERS_BUTTON,hinstDLL,NULL );
-	if (hRSPRegisters) {
+	if (hRSPRegisters)
+	{
 		SendMessage(hRSPRegisters,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 	} 
 
 	WndPos += 29;
-	if (DebugInfo.Enter_R4300i_Commands_Window != NULL) {
+	if (DebugInfo.Enter_R4300i_Commands_Window != NULL)
+	{
 		hR4300iDebugger = CreateWindowEx(WS_EX_STATICEDGE,"BUTTON", "R4300i &Debugger...", 
 			WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,WndPos,100,24,hDlg,
 			(HMENU)IDC_R4300I_DEBUGGER_BUTTON,hinstDLL,NULL );
-		if (hR4300iDebugger) {
+		if (hR4300iDebugger)
+		{
 			SendMessage(hR4300iDebugger,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 		}
 	}
 
 	WndPos += 29;
-	if (DebugInfo.Enter_R4300i_Register_Window != NULL) {
+	if (DebugInfo.Enter_R4300i_Register_Window != NULL)
+	{
 		hR4300iRegisters = CreateWindowEx(WS_EX_STATICEDGE,"BUTTON","R4300i R&egisters...",
 			WS_CHILD | BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,WndPos,100,24,hDlg,
 			(HMENU)IDC_R4300I_REGISTERS_BUTTON,hinstDLL,NULL );
-		if (hR4300iRegisters) {
+		if (hR4300iRegisters)
+		{
 			SendMessage(hR4300iRegisters,WM_SETFONT, (WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 		}
 	}
 
 	WndPos += 29;
-	if (DebugInfo.Enter_Memory_Window != NULL) {
+	if (DebugInfo.Enter_Memory_Window != NULL)
+	{
 		hMemory = CreateWindowEx(WS_EX_STATICEDGE,"BUTTON", "&Memory...", WS_CHILD | 
 			BS_PUSHBUTTON | WS_VISIBLE | WS_TABSTOP | BS_TEXT, 347,WndPos,100,24,hDlg,
 			(HMENU)IDC_MEMORY_BUTTON,hinstDLL,NULL );
-		if (hMemory) {
+		if (hMemory)
+		{
 			SendMessage(hMemory,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 		}
 	}
-	
+
 	hScrlBar = CreateWindowEx(WS_EX_STATICEDGE, "SCROLLBAR","", WS_CHILD | WS_VISIBLE | 
 		WS_TABSTOP | SBS_VERT, 318,14,18,439, hDlg, (HMENU)IDC_SCRL_BAR, hinstDLL, NULL );
 
-	if ( RSP_Running ) {
+	if ( RSP_Running )
+	{
 		Enable_RSP_Commands_Window();
-	} else {
+	}
+	else
+	{
 		Disable_RSP_Commands_Window();
 	}
-	
+
 	//if ( !GetStoredWinPos("RSP Commands", &X, &Y ) ) {
 		X = (GetSystemMetrics( SM_CXSCREEN ) - WindowWidth) / 2;
 		Y = (GetSystemMetrics( SM_CYSCREEN ) - WindowHeight) / 2;
@@ -705,18 +793,23 @@ void RSP_Commands_Setup ( HWND hDlg ) {
 	SetWindowPos(hDlg,NULL,X,Y,WindowWidth,WindowHeight, SWP_NOZORDER | SWP_SHOWWINDOW);
 }
 
-char * RSPSpecialName ( DWORD OpCode, DWORD PC ) {
+char * RSPSpecialName ( DWORD OpCode, DWORD PC )
+{
 	OPCODE command;
 	command.Hex = OpCode;
 	
 	PC = PC; // unused
 
-	switch (command.funct) {
+	switch (command.funct)
+	{
 	case RSP_SPECIAL_SLL:
-		if (command.rd != 0) {
+		if (command.rd != 0)
+		{
 			sprintf(CommandName,"SLL\t%s, %s, 0x%X",GPR_Name(command.rd),
 				GPR_Name(command.rt), command.sa);
-		} else {
+		}
+		else
+		{
 			sprintf(CommandName,"NOP");
 		}
 		break;
@@ -796,11 +889,13 @@ char * RSPSpecialName ( DWORD OpCode, DWORD PC ) {
 	return CommandName;
 }
 
-char * RSPRegimmName ( DWORD OpCode, DWORD PC ) {
+char * RSPRegimmName ( DWORD OpCode, DWORD PC )
+{
 	OPCODE command;
 	command.Hex = OpCode;
 		
-	switch (command.rt) {
+	switch (command.rt)
+	{
 	case RSP_REGIMM_BLTZ:
 		sprintf(CommandName,"BLTZ\t%s, 0x%03X",GPR_Name(command.rs),
 			(PC + ((short)command.offset << 2) + 4) & 0xFFC);
@@ -814,9 +909,12 @@ char * RSPRegimmName ( DWORD OpCode, DWORD PC ) {
 			(PC + ((short)command.offset << 2) + 4) & 0xFFC);
 		break;
 	case RSP_REGIMM_BGEZAL:
-		if (command.rs == 0) {
+		if (command.rs == 0)
+		{
 			sprintf(CommandName,"BAL\t0x%03X",(PC + ((short)command.offset << 2) + 4) & 0xFFC);
-		} else {
+		}
+		else
+		{
 			sprintf(CommandName,"BGEZAL\t%s, 0x%03X",GPR_Name(command.rs),
 				(PC + ((short)command.offset << 2) + 4) & 0xFFC);
 		}	
@@ -828,13 +926,15 @@ char * RSPRegimmName ( DWORD OpCode, DWORD PC ) {
 	return CommandName;
 }
 
-char * RSPCop0Name ( DWORD OpCode, DWORD PC ) {
+char * RSPCop0Name ( DWORD OpCode, DWORD PC )
+{
 	OPCODE command;
 	command.Hex = OpCode;
 
 	PC = PC; // unused
 
-	switch (command.rs) {
+	switch (command.rs)
+	{
 	case RSP_COP0_MF:
 		sprintf(CommandName,"MFC0\t%s, %s",GPR_Name(command.rt),COP0_Name(command.rd));
 		break;
@@ -848,14 +948,17 @@ char * RSPCop0Name ( DWORD OpCode, DWORD PC ) {
 	return CommandName;
 }
 
-char * RSPCop2Name ( DWORD OpCode, DWORD PC ) {
+char * RSPCop2Name ( DWORD OpCode, DWORD PC )
+{
 	OPCODE command;
 	command.Hex = OpCode;
 
 	PC = PC; // unused
-		
-	if ( ( command.rs & 0x10 ) == 0 ) {
-		switch (command.rs) {
+
+	if ( ( command.rs & 0x10 ) == 0 )
+	{
+		switch (command.rs)
+		{
 		case RSP_COP2_MF:
 			sprintf(CommandName,"MFC2\t%s, $v%d [%d]",GPR_Name(command.rt),
 				command.rd, command.sa >> 1);
@@ -876,8 +979,11 @@ char * RSPCop2Name ( DWORD OpCode, DWORD PC ) {
 			sprintf(CommandName,"RSP: Unknown\t%02X %02X %02X %02X",
 				command.Ascii[3],command.Ascii[2],command.Ascii[1],command.Ascii[0]);
 		}
-	} else {
-		switch (command.funct) {
+	}
+	else
+	{
+		switch (command.funct)
+		{
 		case RSP_VECTOR_VMULF:
 			sprintf(CommandName,"VMULF\t$v%d, $v%d, $v%d%s",command.sa, command.rd, 
 				command.rt, ElementSpecifier(command.rs & 0xF));
@@ -1061,13 +1167,15 @@ char * RSPCop2Name ( DWORD OpCode, DWORD PC ) {
 	return CommandName;
 }
 
-char * RSPLc2Name ( DWORD OpCode, DWORD PC ) {
+char * RSPLc2Name ( DWORD OpCode, DWORD PC )
+{
 	OPCODE command;
 	command.Hex = OpCode;
 
 	PC = PC; // unused
 
-	switch (command.rd) {
+	switch (command.rd)
+	{
 	case RSP_LSC2_BV:
 		sprintf(CommandName,"LBV\t$v%d [%d], 0x%04X (%s)",command.rt, command.del, 
 			command.voffset, GPR_Name(command.base));
@@ -1123,13 +1231,15 @@ char * RSPLc2Name ( DWORD OpCode, DWORD PC ) {
 	return CommandName;
 }
 
-char * RSPSc2Name ( DWORD OpCode, DWORD PC ) {
+char * RSPSc2Name ( DWORD OpCode, DWORD PC )
+{
 	OPCODE command;
 	command.Hex = OpCode;
 
 	PC = PC; // unused
 
-	switch (command.rd) {
+	switch (command.rd)
+	{
 	case RSP_LSC2_BV:
 		sprintf(CommandName,"SBV\t$v%d [%d], 0x%04X (%s)",command.rt, command.del, 
 			command.voffset, GPR_Name(command.base));
@@ -1185,11 +1295,13 @@ char * RSPSc2Name ( DWORD OpCode, DWORD PC ) {
 	return CommandName;
 }
 
-char * RSPOpcodeName ( DWORD OpCode, DWORD PC ) {
+char * RSPOpcodeName ( DWORD OpCode, DWORD PC )
+{
 	OPCODE command;
 	command.Hex = OpCode;
-		
-	switch (command.op) {
+
+	switch (command.op)
+	{
 	case RSP_SPECIAL:
 		return RSPSpecialName(OpCode,PC);
 		break;
@@ -1203,12 +1315,17 @@ char * RSPOpcodeName ( DWORD OpCode, DWORD PC ) {
 		sprintf(CommandName,"JAL\t0x%03X",(command.target << 2) & 0xFFC);
 		break;
 	case RSP_BEQ:
-		if (command.rs == 0 && command.rt == 0) {
+		if (command.rs == 0 && command.rt == 0)
+		{
 			sprintf(CommandName,"B\t0x%03X",(PC + ((short)command.offset << 2) + 4) & 0xFFC);
-		} else if (command.rs == 0 || command.rt == 0){
+		}
+		else if (command.rs == 0 || command.rt == 0)
+		{
 			sprintf(CommandName,"BEQZ\t%s, 0x%03X",GPR_Name(command.rs == 0 ? command.rt : command.rs),
 				(PC + ((short)command.offset << 2) + 4) & 0xFFC);
-		} else {
+		}
+		else
+		{
 			sprintf(CommandName,"BEQ\t%s, %s, 0x%03X",GPR_Name(command.rs),GPR_Name(command.rt),
 				(PC + ((short)command.offset << 2) + 4) & 0xFFC);
 		}
@@ -1305,7 +1422,8 @@ char * RSPOpcodeName ( DWORD OpCode, DWORD PC ) {
 	return CommandName;
 }
 
-void SetRSPCommandToRunning ( void ) { 	
+void SetRSPCommandToRunning ( void )
+{
 	Stepping_Commands = FALSE;
 	if (InRSPCommandsWindow == FALSE) { return; }
 	EnableWindow(hGoButton,    FALSE);
@@ -1318,7 +1436,8 @@ void SetRSPCommandToRunning ( void ) {
 	SetFocus(hBreakButton);
 }
 
-void SetRSPCommandToStepping ( void ) { 	
+void SetRSPCommandToStepping ( void )
+{
 	if (InRSPCommandsWindow == FALSE) { return; }
 	EnableWindow(hGoButton,    TRUE);
 	EnableWindow(hBreakButton, FALSE);
@@ -1331,7 +1450,8 @@ void SetRSPCommandToStepping ( void ) {
 	Stepping_Commands = TRUE;
 }
 
-void SetRSPCommandViewto ( UINT NewLocation ) {
+void SetRSPCommandViewto ( UINT NewLocation )
+{
 	unsigned int location;
 	char Value[20];
 
@@ -1340,10 +1460,13 @@ void SetRSPCommandViewto ( UINT NewLocation ) {
 	GetWindowText(hAddress,Value,sizeof(Value));
 	location = AsciiToHex(Value) & ~3;
 
-	if ( NewLocation < location || NewLocation >= location + 120 ) {
+	if ( NewLocation < location || NewLocation >= location + 120 )
+	{
 		sprintf(Value,"%03X",NewLocation);
 		SetWindowText(hAddress,Value);
-	} else {
+	}
+	else
+	{
 		RefreshRSPCommands();
 	}
 }

--- a/Source/RSP/RSP Registers.h
+++ b/Source/RSP/RSP Registers.h
@@ -147,5 +147,3 @@ void UpdateRSPRegistersScreen ( void );
 extern UWORD32   RSP_GPR[32], RSP_Flags[4];
 extern UDWORD  RSP_ACCUM[8];
 extern VECTOR  RSP_Vect[32];
-
-

--- a/Source/RSP/Types.h
+++ b/Source/RSP/Types.h
@@ -24,8 +24,8 @@
  *
  */
 
-#ifndef __Types_h 
-#define __Types_h 
+#ifndef __Types_h
+#define __Types_h
 
 /*
  * Some versions of Microsoft Visual C/++ compilers before Visual Studio 2010

--- a/Source/RSP/Version.h
+++ b/Source/RSP/Version.h
@@ -23,6 +23,7 @@
 * should be forwarded to them so if they want them.
 *
 */
+
 #define STRINGIZE2(s) #s
 #define STRINGIZE(s) STRINGIZE2(s)
 

--- a/Source/RSP/breakpoint.c
+++ b/Source/RSP/breakpoint.c
@@ -33,7 +33,8 @@
 #define IDC_LOCATION_EDIT		105
 HWND BPoint_Win_hDlg, hRSPLocation = NULL;
 
-void Add_BPoint ( void ) {
+void Add_BPoint ( void )
+{
 	char Title[10];
 
 	GetWindowText(hRSPLocation,Title,sizeof(Title));
@@ -43,29 +44,35 @@ void Add_BPoint ( void ) {
 	}
 }
 
-int AddRSP_BPoint( DWORD Location, int Confirm ) {
+int AddRSP_BPoint( DWORD Location, int Confirm )
+{
 	int count;
 
-	if (NoOfBpoints == MaxBPoints) { 
+	if (NoOfBpoints == MaxBPoints)
+	{
 		DisplayError("Max amount of Break Points set");
 		return FALSE;
 	}
 
-	for (count = 0; count < NoOfBpoints; count ++) {
-		if (BPoint[count].Location == Location) {
+	for (count = 0; count < NoOfBpoints; count ++)
+	{
+		if (BPoint[count].Location == Location)
+		{
 			DisplayError("You already have this Break Point");
 			return FALSE;
 		}
 	}
 
-	if (Confirm) {
+	if (Confirm)
+	{
 		char Message[150];
 		int Response;
 
 		sprintf(Message,"Break when:\n\nRSP's Program Counter = 0x%03X\n\nIs this correct?",
 			Location); 
 		Response = MessageBox(BPoint_Win_hDlg, Message, "Breakpoint", MB_YESNO | MB_ICONINFORMATION);
-		if (Response == IDNO) {
+		if (Response == IDNO)
+		{
 			return FALSE;
 		}
 	}
@@ -78,18 +85,22 @@ int AddRSP_BPoint( DWORD Location, int Confirm ) {
 	return TRUE;
 }
 
-int CheckForRSPBPoint ( DWORD Location ) {
+int CheckForRSPBPoint ( DWORD Location )
+{
 	int count;
 	
-	for (count = 0; count < NoOfBpoints; count ++){
-		if (BPoint[count].Location == Location) {
+	for (count = 0; count < NoOfBpoints; count ++)
+	{
+		if (BPoint[count].Location == Location)
+		{
 			return TRUE;
 		}
 	}
 	return FALSE;
 }
 
-void CreateBPPanel ( HWND hDlg, RECT rcBox ) {
+void CreateBPPanel ( HWND hDlg, RECT rcBox )
+{
 	if (hRSPLocation != NULL) { return; }
 
 	rcBox = rcBox; // remove warning of unused
@@ -97,8 +108,9 @@ void CreateBPPanel ( HWND hDlg, RECT rcBox ) {
 	BPoint_Win_hDlg = hDlg;
 	
 	hRSPLocation = CreateWindowEx(0,"EDIT","", WS_CHILD | WS_BORDER | ES_UPPERCASE | WS_TABSTOP,
-		83,90,100,17,hDlg,(HMENU)IDC_LOCATION_EDIT,RSPInfo.hInst,NULL);		
-	if (hRSPLocation) {
+		83,90,100,17,hDlg,(HMENU)IDC_LOCATION_EDIT,RSPInfo.hInst,NULL);
+	if (hRSPLocation)
+	{
 		char Title[20];
 		SendMessage(hRSPLocation,WM_SETFONT,(WPARAM)GetStockObject(DEFAULT_GUI_FONT),0);
 		SendMessage(hRSPLocation,EM_SETLIMITTEXT,(WPARAM)3,(LPARAM)0);
@@ -107,20 +119,24 @@ void CreateBPPanel ( HWND hDlg, RECT rcBox ) {
 	}
 }
 
-void HideBPPanel ( void ) {
+void HideBPPanel ( void )
+{
 	ShowWindow(hRSPLocation,FALSE);
 }
 
-void PaintBPPanel ( PAINTSTRUCT ps ) {
+void PaintBPPanel ( PAINTSTRUCT ps )
+{
 	TextOut( ps.hdc, 29,60,"Break when the Program Counter equals",37);
 	TextOut( ps.hdc, 59,85,"0x",2);
 }
 
-void ShowBPPanel ( void ) {
+void ShowBPPanel ( void )
+{
 	ShowWindow(hRSPLocation,TRUE);
 }
 
-void RefreshBpoints ( HWND hList ) {
+void RefreshBpoints ( HWND hList )
+{
 	char Message[100];
 	int count, location;
 
@@ -131,29 +147,36 @@ void RefreshBpoints ( HWND hList ) {
 	}
 }
 
-void RemoveAllBpoint ( void ) {
+void RemoveAllBpoint ( void )
+{
 	NoOfBpoints = 0;
 }
 
-void RemoveBpoint ( HWND hList, int index ) {
+void RemoveBpoint ( HWND hList, int index )
+{
 	DWORD location;
 	
 	location = SendMessage(hList,LB_GETITEMDATA,(WPARAM)index,0);	
 	RemoveRSPBreakPoint(location);
 }
 
-void RemoveRSPBreakPoint (DWORD Location) {
+void RemoveRSPBreakPoint (DWORD Location)
+{
 	int count, location = -1;
 	
-	for (count = 0; count < NoOfBpoints; count ++){
-		if (BPoint[count].Location == Location) {
+	for (count = 0; count < NoOfBpoints; count ++)
+	{
+		if (BPoint[count].Location == Location)
+		{
 			location = count;
 			count = NoOfBpoints;
 		}
 	}
 	
-	if (location >= 0) {
-		for (count = location; count < NoOfBpoints - 1; count ++ ){ 
+	if (location >= 0)
+	{
+		for (count = location; count < NoOfBpoints - 1; count ++ )
+		{
 			BPoint[count].Location = BPoint[count + 1].Location;
 		}
 		NoOfBpoints -= 1;

--- a/Source/RSP/dma.c
+++ b/Source/RSP/dma.c
@@ -32,18 +32,21 @@
 
 // #define RSP_SAFE_DMA /* unoptimized dma transfers */
 
-void SP_DMA_READ (void) {
+void SP_DMA_READ (void)
+{
 	DWORD i, j, Length, Skip, Count, End, addr;
 	BYTE *Dest, *Source;
 
     addr = (*RSPInfo.SP_DRAM_ADDR_REG) & 0x00FFFFFF;
 
-	if (addr > 0x800000) {
+	if (addr > 0x800000)
+	{
 		MessageBox(NULL,"SP DMA READ\nSP_DRAM_ADDR_REG not in RDRam space","Error",MB_OK);
 		return;
 	}
 	
-	if ((*RSPInfo.SP_RD_LEN_REG & 0xFFF) + 1  + (*RSPInfo.SP_MEM_ADDR_REG & 0xFFF) > 0x1000) {
+	if ((*RSPInfo.SP_RD_LEN_REG & 0xFFF) + 1  + (*RSPInfo.SP_MEM_ADDR_REG & 0xFFF) > 0x1000)
+	{
 		MessageBox(NULL,"SP DMA READ\ncould not fit copy in memory segement","Error",MB_OK);
 		return;		
 	}
@@ -53,29 +56,40 @@ void SP_DMA_READ (void) {
 	Count = ((*RSPInfo.SP_RD_LEN_REG >> 12) & 0xFF)  + 1;
 	End = ((*RSPInfo.SP_MEM_ADDR_REG & 0x0FFF) & ~7) + (((Count - 1) * Skip) + Length);
 
-	if ((*RSPInfo.SP_MEM_ADDR_REG & 0x1000) != 0) {
+	if ((*RSPInfo.SP_MEM_ADDR_REG & 0x1000) != 0)
+	{
 		Dest = RSPInfo.IMEM + ((*RSPInfo.SP_MEM_ADDR_REG & 0x0FFF) & ~7);
-	} else {
+	}
+	else
+	{
 		Dest = RSPInfo.DMEM + ((*RSPInfo.SP_MEM_ADDR_REG & 0x0FFF) & ~7);
 	}
 	Source = RSPInfo.RDRAM + (addr & ~7);
 
 #if defined(RSP_SAFE_DMA)
-	for (j = 0 ; j < Count; j++) {
-		for (i = 0 ; i < Length; i++) {
+	for (j = 0 ; j < Count; j++)
+	{
+		for (i = 0 ; i < Length; i++)
+		{
 			*(BYTE *)(((DWORD)Dest + j * Length + i) ^ 3) = *(BYTE *)(((DWORD)Source + j * Skip + i) ^ 3);
 		}
 	}
 #else
-	if ((Skip & 0x3) == 0) {
-		for (j = 0; j < Count; j++) {
+	if ((Skip & 0x3) == 0)
+	{
+		for (j = 0; j < Count; j++)
+		{
 			memcpy(Dest, Source, Length);
 			Source += Skip;
 			Dest += Length;
 		}
-	} else {
-		for (j = 0 ; j < Count; j++) {
-			for (i = 0 ; i < Length; i++) {
+	}
+	else
+	{
+		for (j = 0 ; j < Count; j++)
+		{
+			for (i = 0 ; i < Length; i++)
+			{
 				*(BYTE *)(((DWORD)Dest + i) ^ 3) = *(BYTE *)(((DWORD)Source + i) ^ 3);
 			}
 			Source += Skip;
@@ -85,7 +99,8 @@ void SP_DMA_READ (void) {
 #endif
 
 	/* FIXME: could this be a problem DMEM to IMEM (?) */
-	if (CPUCore == RecompilerCPU && (*RSPInfo.SP_MEM_ADDR_REG & 0x1000) != 0) {
+	if (CPUCore == RecompilerCPU && (*RSPInfo.SP_MEM_ADDR_REG & 0x1000) != 0)
+	{
 		SetJumpTable(End);
 	}
 
@@ -93,18 +108,21 @@ void SP_DMA_READ (void) {
 	*RSPInfo.SP_STATUS_REG  &= ~SP_STATUS_DMA_BUSY;
 }
 
-void SP_DMA_WRITE (void) { 
+void SP_DMA_WRITE (void)
+{
 	DWORD i, j, Length, Skip, Count, addr;
 	BYTE *Dest, *Source;
 
     addr = (*RSPInfo.SP_DRAM_ADDR_REG) & 0x00FFFFFF;
 
-	if (addr > 0x800000) {
+	if (addr > 0x800000)
+	{
 		MessageBox(NULL,"SP DMA WRITE\nSP_DRAM_ADDR_REG not in RDRam space","Error",MB_OK);
 		return;
 	}
-	
-	if ((*RSPInfo.SP_WR_LEN_REG & 0xFFF) + 1  + (*RSPInfo.SP_MEM_ADDR_REG & 0xFFF) > 0x1000) {
+
+	if ((*RSPInfo.SP_WR_LEN_REG & 0xFFF) + 1  + (*RSPInfo.SP_MEM_ADDR_REG & 0xFFF) > 0x1000)
+	{
 		MessageBox(NULL,"SP DMA WRITE\ncould not fit copy in memory segement","Error",MB_OK);
 		return;		
 	}
@@ -114,23 +132,31 @@ void SP_DMA_WRITE (void) {
 	Count = ((*RSPInfo.SP_WR_LEN_REG >> 12) & 0xFF)  + 1;
 	Dest = RSPInfo.RDRAM + (addr & ~7);
 	Source = RSPInfo.DMEM + ((*RSPInfo.SP_MEM_ADDR_REG & 0x1FFF) & ~7);
-	
+
 #if defined(RSP_SAFE_DMA)
-	for (j = 0 ; j < Count; j++) {
-		for (i = 0 ; i < Length; i++) {
+	for (j = 0 ; j < Count; j++)
+	{
+		for (i = 0 ; i < Length; i++)
+		{
 			*(BYTE *)(((DWORD)Dest + j * Skip + i) ^ 3) = *(BYTE *)(((DWORD)Source + j * Length + i) ^ 3);
 		}
 	}
 #else
-	if ((Skip & 0x3) == 0) {
-		for (j = 0; j < Count; j++) {
+	if ((Skip & 0x3) == 0)
+	{
+		for (j = 0; j < Count; j++)
+		{
 			memcpy(Dest, Source, Length);
 			Source += Length;
 			Dest += Skip;
 		}
-	} else {
-		for (j = 0 ; j < Count; j++) {
-			for (i = 0 ; i < Length; i++) {
+	}
+	else
+	{
+		for (j = 0 ; j < Count; j++)
+		{
+			for (i = 0 ; i < Length; i++)
+			{
 				*(BYTE *)(((DWORD)Dest + i) ^ 3) = *(BYTE *)(((DWORD)Source + i) ^ 3);
 			}
 			Source += Length;

--- a/Source/RSP/dma.h
+++ b/Source/RSP/dma.h
@@ -26,4 +26,3 @@
 
 void SP_DMA_READ  ( void );
 void SP_DMA_WRITE ( void );
-

--- a/Source/Settings/Settings.cpp
+++ b/Source/Settings/Settings.cpp
@@ -60,7 +60,6 @@ __declspec(dllexport) void SetSettingInfo2 (PLUGIN_SETTINGS2 * info);
 __declspec(dllexport) void SetSettingInfo3 (PLUGIN_SETTINGS3 * info);
 }
 
-
 __declspec(dllexport) void SetSettingInfo (PLUGIN_SETTINGS * info) 
 {
 	g_PluginSettings   = *info;
@@ -97,7 +96,9 @@ void RegisterSetting    ( short SettingID, SETTING_DATA_TYPE Type, const char * 
 	if (Category && Category[0] != 0)
 	{
 		_snprintf(FullCategory,sizeof(FullCategory),"%s\\%s",g_PluginSettingName,Category);
-	} else {
+	}
+	else
+	{
 		_snprintf(FullCategory,sizeof(FullCategory),"%s",g_PluginSettingName);
 	}
 
@@ -209,6 +210,3 @@ void SetSettingSz ( short SettingID, const char * Value )
 {
 	g_PluginSettings.SetSettingSz(g_PluginSettings.handle,SettingID + g_PluginSettings.SettingStartRange, Value);
 }
-
-
-

--- a/Source/Settings/Settings.h
+++ b/Source/Settings/Settings.h
@@ -28,7 +28,6 @@ enum SETTING_DATA_TYPE {
 	Data_String_RDB_Setting = 7, // A string read from the rom database, with config file
 };
 
-
 // set other information about different settings
 BOOL SettingsInitilized ( void );
 void SetModuleName      ( const char * Name );

--- a/Source/nragev20/DirectInput.cpp
+++ b/Source/nragev20/DirectInput.cpp
@@ -497,11 +497,15 @@ bool GetNControllerInput ( const int indexController, LPDWORD pdwData )
 	}
 
 
-	if (pcController->bRapidFireEnabled) {
-		if (pcController->bRapidFireCounter >= pcController->bRapidFireRate) {
+	if (pcController->bRapidFireEnabled)
+	{
+		if (pcController->bRapidFireCounter >= pcController->bRapidFireRate)
+		{
 			w_Buttons = (w_Buttons & 0xFF1F);
 			pcController->bRapidFireCounter = 0;
-		} else{
+		}
+		else
+		{
 			pcController->bRapidFireCounter = pcController->bRapidFireCounter + 1;
 		}
 	}
@@ -545,7 +549,6 @@ bool GetNControllerInput ( const int indexController, LPDWORD pdwData )
 							MAKEWORD(	(BYTE)(min( max( MINAXISVALUE, (long)(lAxisValueX * d_ModifierX )), MAXAXISVALUE) / N64DIVIDER ),
 										(BYTE)(min( max( MINAXISVALUE, (long)(lAxisValueY * d_ModifierY )), MAXAXISVALUE) / N64DIVIDER )));
 	}
-	
 
 	return true;
 }
@@ -745,7 +748,7 @@ BOOL CALLBACK EnumSetObjectsAxis( LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef
 	diprg.diph.dwObj        = lpddoi->dwType;
 	diprg.lMin              = MINAXISVALUE;
 	diprg.lMax              = MAXAXISVALUE;
-	
+
 	lpDirectInputDevice->SetProperty(DIPROP_RANGE, &diprg.diph); // HACK: Usually works, but not all devices support setting range.
 
 	return DIENUM_CONTINUE;
@@ -788,7 +791,6 @@ bool GetInputDevice( HWND hWnd, LPDIRECTINPUTDEVICE8 &lpDirectInputDevice, GUID 
 
 	switch( LOBYTE(dwDevType) )
 	{
-		
 	case DI8DEVTYPE_KEYBOARD:
 		ppDiDataFormat = &c_dfDIKeyboard;
 		break;
@@ -1130,7 +1132,7 @@ HRESULT DirectRumbleCommand( LPDIRECTINPUTDEVICE8 lpDirectInputDevice, DWORD cmd
     esc.dwCommand = ADAPT_RUMBLE;   // send rumble command
     esc.lpvInBuffer = &cmd;  // 1=go, 0=stop
     esc.cbInBuffer = 4;
-    esc.lpvOutBuffer = NULL;   
+    esc.lpvOutBuffer = NULL;
     esc.cbOutBuffer = 0;
 
 	HRESULT hr = lpDirectInputDevice->Escape(&esc);

--- a/Source/nragev20/FileAccess.cpp
+++ b/Source/nragev20/FileAccess.cpp
@@ -604,7 +604,6 @@ bool ProcessKey( DWORD dwKey, DWORD dwSection, LPCSTR pszLine, LPTSTR pszFFDevic
 
 		}
 		break;
-
 	}
 
 	return bReturn;
@@ -1146,7 +1145,8 @@ bool BrowseFile( HWND hDlg, TCHAR *pszFileName, DWORD dwType, bool fSave )
 		return false;
 	}
 
-	for ( ; nFilters > 0; nFilters--) {
+	for ( ; nFilters > 0; nFilters--)
+	{
 		pszTemp += _tcslen(pszTemp);
 		pszTemp += 1;
 		pszTemp += _tcslen(pszTemp);
@@ -1159,7 +1159,6 @@ bool BrowseFile( HWND hDlg, TCHAR *pszFileName, DWORD dwType, bool fSave )
 	TCHAR szFileName[MAX_PATH+1] = _T(""),
 		  szInitialDir[MAX_PATH+1] = _T(""),
 		  *pcSlash;
-
 
 	if( pszFileName[1] == _T(':') || ( pszFileName[1] == _T('\\') && pszFileName[0] == _T('\\') ))
 	{
@@ -1177,7 +1176,6 @@ bool BrowseFile( HWND hDlg, TCHAR *pszFileName, DWORD dwType, bool fSave )
 			GetDirectory( szInitialDir, DIRECTORY_APPLICATION );
 		lstrcpyn( szFileName, pszFileName, ARRAYSIZE(szFileName) );
 	}
-
 
 	OPENFILENAME oFile;
 

--- a/Source/nragev20/GBCart.cpp
+++ b/Source/nragev20/GBCart.cpp
@@ -32,15 +32,18 @@ bool WriteCartMBC5(LPGBCART Cart, WORD dwAddress, BYTE *Data);
 // Tries to read RTC data from separate file (not integrated into SAV)
 //		success sets the useTDF flag
 //		failure inits the RTC at zero and maybe throws a warning
-void ReadTDF(LPGBCART Cart) {
+void ReadTDF(LPGBCART Cart)
+{
 }
 
-void WriteTDF(LPGBCART Cart) {
+void WriteTDF(LPGBCART Cart)
+{
 	// check useTDF flag
 	// write data from RTC to TDF file
 }
 
-void UpdateRTC(LPGBCART Cart) {
+void UpdateRTC(LPGBCART Cart)
+{
 	time_t now, dif;
 	int days;
 
@@ -57,13 +60,17 @@ void UpdateRTC(LPGBCART Cart) {
 	days = (int)(Cart->TimerData[3] + ((Cart->TimerData[4] & 1) << 8) + dif);
 	Cart->TimerData[3] = (days & 0xFF);
 
-	if(days > 255) {
-		if(days > 511) {
+	if (days > 255)
+	{
+		if (days > 511)
+		{
 			days &= 511;
 			Cart->TimerData[4] |= 0x80;
 		}
 		if (days > 255)
-		Cart->TimerData[4] = (Cart->TimerData[4] & 0xFE) | (days > 255 ? 1 : 0);
+		{
+			Cart->TimerData[4] = (Cart->TimerData[4] & 0xFE) | (days > 255 ? 1 : 0);
+		}
 	}
 
 	Cart->timerLastUpdate = now;
@@ -103,7 +110,9 @@ bool LoadCart(LPGBCART Cart, LPCTSTR RomFileName, LPCTSTR RamFileName, LPCTSTR T
 		dwFilesize = GetFileSize(hTemp, NULL);
 		CloseHandle(hTemp);
 		Cart->RomData = (const unsigned char *)MapViewOfFile( Cart->hRomFile, FILE_MAP_READ, 0, 0, 0 );
-	} else {
+	}
+	else
+	{
 		DebugWriteA("Couldn't load the ROM file, GetLastError returned %08x\n", GetLastError());
 		if (hTemp != INVALID_HANDLE_VALUE)
 			CloseHandle(hTemp);	// if file size was zero, make sure we don't leak the handle
@@ -124,7 +133,8 @@ bool LoadCart(LPGBCART Cart, LPCTSTR RomFileName, LPCTSTR RamFileName, LPCTSTR T
 	DebugWriteA(" Cartridge Type #:");
 	DebugWriteByteA(Cart->RomData[0x147]);
 	DebugWriteA("\n");
-	switch (Cart->RomData[0x147]) {	// if we hadn't checked the file size before, this might have caused an access violation
+	switch (Cart->RomData[0x147])
+	{ // if we hadn't checked the file size before, this might have caused an access violation
 	case 0x00:
 		Cart->iCartType = GB_NORM;
 		Cart->bHasRam = false;
@@ -287,7 +297,8 @@ bool LoadCart(LPGBCART Cart, LPCTSTR RomFileName, LPCTSTR RamFileName, LPCTSTR T
 	}
 
 	// assign read/write handlers
-	switch (Cart->iCartType) {
+	switch (Cart->iCartType)
+	{
 	case GB_NORM: // Raw cartridge
 		Cart->ptrfnReadCart = &ReadCartNorm;
 		Cart->ptrfnWriteCart = &WriteCartNorm;
@@ -318,7 +329,8 @@ bool LoadCart(LPGBCART Cart, LPCTSTR RomFileName, LPCTSTR RamFileName, LPCTSTR T
 
 	// Determine ROM size for paging checks
 	Cart->iNumRomBanks = 2;
-	switch (Cart->RomData[0x148]) {
+	switch (Cart->RomData[0x148])
+	{
 	case 0x01:
 		Cart->iNumRomBanks = 4;
 		break;
@@ -397,11 +409,13 @@ bool LoadCart(LPGBCART Cart, LPCTSTR RomFileName, LPCTSTR RamFileName, LPCTSTR T
 			if( hTemp == INVALID_HANDLE_VALUE )
 			{// test if Read-only access is possible
 				hTemp = CreateFile( RamFileName, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_ALWAYS, 0, NULL );
-				if (Cart->bHasTimer && Cart->bHasBattery) {
+				if (Cart->bHasTimer && Cart->bHasBattery)
+				{
 					Cart->RamData = (LPBYTE)P_malloc(NumQuarterBlocks * 0x0800 + sizeof(gbCartRTC));
 					ClearData(Cart->RamData, NumQuarterBlocks * 0x0800 + sizeof(gbCartRTC));
 				}
-				else {
+				else
+				{
 					Cart->RamData = (LPBYTE)P_malloc(NumQuarterBlocks * 0x0800);
 					ClearData(Cart->RamData, NumQuarterBlocks * 0x0800);
 				}
@@ -421,7 +435,9 @@ bool LoadCart(LPGBCART Cart, LPCTSTR RomFileName, LPCTSTR RamFileName, LPCTSTR T
 					WarningMessage( IDS_ERR_GBSRAMERR, MB_OK | MB_ICONWARNING);
 					return true;
 				}
-			} else { // file is OK, use a mapping
+			}
+			else
+			{ // file is OK, use a mapping
 				if (Cart->bHasTimer && Cart->bHasBattery)
 					Cart->hRamFile = CreateFileMapping( hTemp, NULL, PAGE_READWRITE, 0, NumQuarterBlocks * 0x0800 + sizeof(gbCartRTC), NULL);
 				else
@@ -430,15 +446,21 @@ bool LoadCart(LPGBCART Cart, LPCTSTR RomFileName, LPCTSTR RamFileName, LPCTSTR T
 				if (Cart->hRamFile != NULL)
 				{
 					Cart->RamData = (LPBYTE)MapViewOfFile( Cart->hRamFile, FILE_MAP_ALL_ACCESS, 0, 0, 0 );
-				} else { // could happen, if the file isn't big enough AND can't be grown to fit
+				}
+				else
+				{ // could happen, if the file isn't big enough AND can't be grown to fit
 					DWORD dwBytesRead;
-					if (Cart->bHasTimer && Cart->bHasBattery) {
+					if (Cart->bHasTimer && Cart->bHasBattery)
+					{
 						Cart->RamData = (LPBYTE)P_malloc(NumQuarterBlocks * 0x0800 + sizeof(gbCartRTC));
 						ReadFile(hTemp, Cart->RamData, NumQuarterBlocks * 0x0800 + sizeof(gbCartRTC), &dwBytesRead, NULL);
-					} else {
+					}
+					else
+					{
 						Cart->RamData = (LPBYTE)P_malloc(NumQuarterBlocks * 0x0800);
 						ReadFile(hTemp, Cart->RamData, NumQuarterBlocks * 0x0800, &dwBytesRead, NULL);
 					}
+
 					if (dwBytesRead < NumQuarterBlocks * 0x0800 + ((Cart->bHasTimer && Cart->bHasBattery) ? sizeof(gbCartRTC) : 0))
 					{
 						ClearData(Cart->RamData, NumQuarterBlocks * 0x0800 + ((Cart->bHasTimer && Cart->bHasBattery) ? sizeof(gbCartRTC) : 0));
@@ -451,9 +473,11 @@ bool LoadCart(LPGBCART Cart, LPCTSTR RomFileName, LPCTSTR RamFileName, LPCTSTR T
 				}
 			}
 
-			if (Cart->bHasTimer && Cart->bHasBattery) {
+			if (Cart->bHasTimer && Cart->bHasBattery)
+			{
 				dwFilesize = GetFileSize(hTemp, 0);
-				if (dwFilesize >= (NumQuarterBlocks * 0x0800 + sizeof(gbCartRTC) ) ) {
+				if (dwFilesize >= (NumQuarterBlocks * 0x0800 + sizeof(gbCartRTC) ) )
+				{
 					// Looks like there is extra data in the SAV file than just RAM data... assume it is RTC data.
 					gbCartRTC RTCTimer;
 					CopyMemory( &RTCTimer, &Cart->RamData[NumQuarterBlocks * 0x0800], sizeof(RTCTimer) );
@@ -470,13 +494,16 @@ bool LoadCart(LPGBCART Cart, LPCTSTR RomFileName, LPCTSTR RamFileName, LPCTSTR T
 					Cart->timerLastUpdate = RTCTimer.mapperLastTime;
 					UpdateRTC(Cart);
 				}
-				else {
+				else
+				{
 					ReadTDF(Cart);	// try to open TDF format, clear/init Cart->TimerData if that fails
 				}
 			}
 
 			CloseHandle(hTemp);
-		} else {
+		}
+		else
+		{
 			// no battery; just allocate some RAM
 			Cart->RamData = (LPBYTE)P_malloc(Cart->iNumRamBanks * 0x2000);
 		}
@@ -582,8 +609,8 @@ bool ReadCartMBC1(LPGBCART Cart, WORD dwAddress, BYTE *Data)
 	}
 	else if ((dwAddress >= 0xA000) && (dwAddress <= 0xBFFF))
 	{
-		if (Cart->bHasRam)
-		{ // && Cart->bRamEnableState) {
+		if (Cart->bHasRam/* && Cart->bRamEnableState)*/)
+		{
 			if (Cart->iCurrentRamBankNo >= Cart->iNumRamBanks)
 			{
 				ZeroMemory(Data, 32);
@@ -742,7 +769,8 @@ bool WriteCartMBC2(LPGBCART Cart, WORD dwAddress, BYTE *Data)
 	else if ((dwAddress >= 0x2000) && (dwAddress <= 0x3FFF)) // ROM bank select
 	{
 		Cart->iCurrentRomBankNo = Data[0] & 0x0F;
-		if (Cart->iCurrentRomBankNo == 0) {
+		if (Cart->iCurrentRomBankNo == 0)
+		{
 			Cart->iCurrentRomBankNo = 1;
 		}
 		DebugWriteA("Set ROM Bank: %02X\n", Cart->iCurrentRomBankNo);
@@ -820,12 +848,13 @@ bool ReadCartMBC3(LPGBCART Cart, WORD dwAddress, BYTE *Data)
 			{
 				CopyMemory(Data, &Cart->RamData[dwAddress - 0xA000 + (Cart->iCurrentRamBankNo * 0x2000)], 32);
 				DebugWriteA("RAM read: Bank %02X\n", Cart->iCurrentRamBankNo);
-			}
-			//else {
-			//	ZeroMemory(Data, 32);
-			//	//for (i=0; i<32; i++) Data[i] = 0;
-			//	DebugWriteA("Failed RAM read: (RAM not active)\n");
-			//}
+			}/*
+			else
+			{
+				ZeroMemory(Data, 32);
+				//for (i=0; i<32; i++) Data[i] = 0;
+				DebugWriteA("Failed RAM read: (RAM not active)\n");
+			}*/
 		}
 		else 
 		{
@@ -918,7 +947,6 @@ bool WriteCartMBC3(LPGBCART Cart, WORD dwAddress, BYTE *Data)
 // Done
 bool ReadCartMBC5(LPGBCART Cart, WORD dwAddress, BYTE *Data)
 {
-	
 	if ((dwAddress < 0x4000)) //Rom Bank 0
 	{
 		CopyMemory(Data, &Cart->RomData[dwAddress], 32);
@@ -1029,9 +1057,10 @@ bool SaveCart(LPGBCART Cart, LPTSTR SaveFile, LPTSTR TimeFile)
 	DWORD NumQuarterBlocks = 0;
 	gbCartRTC RTCTimer;
 
-	if (Cart->bHasRam && Cart->bHasBattery) {
-		// Write only the bytes that NEED writing!
-		switch (Cart->RomData[0x149]) {
+	if (Cart->bHasRam && Cart->bHasBattery)
+	{ // Write only the bytes that NEED writing!
+		switch (Cart->RomData[0x149])
+		{
 		case 1:
 			NumQuarterBlocks = 1;
 			break;
@@ -1046,7 +1075,8 @@ bool SaveCart(LPGBCART Cart, LPTSTR SaveFile, LPTSTR TimeFile)
 			break;
 		}
 		FlushViewOfFile( Cart->RamData, NumQuarterBlocks * 0x0800 );
-		if (Cart->bHasTimer) {
+		if (Cart->bHasTimer)
+		{
 			// Save RTC in VisualBoy Advance format
 			// TODO: Check if VBA saves are compatible with other emus.
 			// TODO: Only write RTC data if VBA RTC data was originaly present
@@ -1063,8 +1093,7 @@ bool SaveCart(LPGBCART Cart, LPTSTR SaveFile, LPTSTR TimeFile)
 			RTCTimer.mapperLastTime = Cart->timerLastUpdate;
 
 			CopyMemory(Cart->RamData + NumQuarterBlocks * 0x0800, &RTCTimer, sizeof(RTCTimer));
-
-			FlushViewOfFile( Cart->RamData + NumQuarterBlocks * 0x0800, sizeof(gbCartRTC));
+			FlushViewOfFile(Cart->RamData + NumQuarterBlocks * 0x0800, sizeof(gbCartRTC));
 		}
 	}
 	return true;
@@ -1105,10 +1134,14 @@ void ClearData(BYTE *Data, int Length)
 {
 	int i;
 
-	for (i=0; i<Length; i++) {
-		if ((i & 0x80) != 0x80) {
+	for (i = 0; i < Length; i++)
+	{
+		if ((i & 0x80) != 0x80)
+		{
 			Data[i] = 0x00;
-		} else {
+		}
+		else
+		{
 			Data[i] = 0xFF;
 		}
 	}

--- a/Source/nragev20/Interface.cpp
+++ b/Source/nragev20/Interface.cpp
@@ -558,11 +558,13 @@ BOOL CALLBACK ControllerTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 		CheckDlgButton( hDlg, IDC_XINPUT_ENABLER, pcController->fXInput ? BST_CHECKED : BST_UNCHECKED );
 
 		if( hTabControl )
-				DestroyWindow( hTabControl );
+			DestroyWindow( hTabControl );
+
 		if( pcController->fXInput )
 			hTabControl = CreateDialog ( g_hResourceDLL, MAKEINTRESOURCE( IDD_XCONTROLS ), hDlg, XControlsTabProc );
 		else
 			hTabControl = CreateDialog( g_hResourceDLL, MAKEINTRESOURCE( IDD_CONTROLS ), hDlg, ControlsTabProc );
+
 		{
 			hDlgItem = GetDlgItem( hDlg, IDC_CONTROLLERTAB );
 
@@ -583,7 +585,6 @@ BOOL CALLBACK ControllerTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 		if( hTabControl )
 			SendMessage( hTabControl, WM_USER_UPDATE, 0, 0 );
 		return TRUE;
-
 	default:
 		return FALSE; //false means the msg didn't got processed
 	}
@@ -718,7 +719,6 @@ BOOL CALLBACK ControlsTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 
 				LeaveCriticalSection(&g_critical);
 
-
 				GetButtonText( aButtons[dwButtonID[2]], szBuffer );
 				SendMessage( GetDlgItem( hDlg, dwButtonID[1] ), WM_SETTEXT , 0, (LPARAM)szBuffer );
 				if( hFocus != NULL )
@@ -770,7 +770,6 @@ BOOL CALLBACK ControlsTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 		aButtons = g_ivConfig->Controllers[g_ivConfig->ChosenTab].aButton;
 		LeaveCriticalSection(&g_critical);
 
-
 		if( wParam == 0 )
 		{
 			CheckDlgButton( hDlg, IDC_N64RANGE, g_ivConfig->Controllers[g_ivConfig->ChosenTab].fRealN64Range ? BST_CHECKED : BST_UNCHECKED );
@@ -778,7 +777,6 @@ BOOL CALLBACK ControlsTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 			CheckDlgButton( hDlg, IDC_CONFIG1, ( g_ivConfig->Controllers[g_ivConfig->ChosenTab].bAxisSet == 0 ) ? BST_CHECKED : BST_UNCHECKED );
 			CheckDlgButton( hDlg, IDC_CONFIG2, ( g_ivConfig->Controllers[g_ivConfig->ChosenTab].bAxisSet == 1 ) ? BST_CHECKED : BST_UNCHECKED );
 			CheckDlgButton( hDlg, IDC_CONFIG3, ( g_ivConfig->Controllers[g_ivConfig->ChosenTab].bAxisSet == 2 ) ? BST_CHECKED : BST_UNCHECKED );
-
 
 			SendMessage( GetDlgItem( hDlg, IDC_CTRRANGE ), TBM_SETPOS, TRUE, g_ivConfig->Controllers[g_ivConfig->ChosenTab].bStickRange );
 			LoadString( g_hResourceDLL, IDS_C_RANGE, szTemp, 40 );
@@ -842,7 +840,6 @@ BOOL CALLBACK XControlsTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPar
 		if( !ReadXInputControllerKeys( hDlg, gController ))
 			for( int i = IDC_XC_A; i <= IDC_XC_RTS; i++ )
 				SendDlgItemMessage( hDlg, i, CB_SETCURSEL, 0, ( LPARAM )0 );
-		
 		return TRUE;
 
 	case WM_COMMAND:
@@ -980,10 +977,12 @@ BOOL CALLBACK DevicesTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
 			CheckDlgButton( hDlg, IDC_DEADPANMOUSEX, BST_CHECKED );
 		else
 			CheckDlgButton( hDlg, IDC_DEADPANMOUSEX, BST_UNCHECKED );
+
 		if( pcController->bMouseMoveX == MM_BUFF )
 			CheckDlgButton( hDlg, IDC_BUFFEREDMOUSEX, BST_CHECKED );
 		else
 			CheckDlgButton( hDlg, IDC_BUFFEREDMOUSEX, BST_UNCHECKED );
+
 		if( pcController->bMouseMoveX == MM_ABS )
 			CheckDlgButton( hDlg, IDC_ABSOLUTEMOUSEX, BST_CHECKED );
 		else
@@ -993,10 +992,12 @@ BOOL CALLBACK DevicesTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
 			CheckDlgButton( hDlg, IDC_DEADPANMOUSEY, BST_CHECKED );
 		else
 			CheckDlgButton( hDlg, IDC_DEADPANMOUSEY, BST_UNCHECKED );
+
 		if( pcController->bMouseMoveY == MM_BUFF )
 			CheckDlgButton( hDlg, IDC_BUFFEREDMOUSEY, BST_CHECKED );
 		else
 			CheckDlgButton( hDlg, IDC_BUFFEREDMOUSEY, BST_UNCHECKED );
+
 		if( pcController->bMouseMoveY == MM_ABS )
 			CheckDlgButton( hDlg, IDC_ABSOLUTEMOUSEY, BST_CHECKED );
 		else
@@ -1030,7 +1031,6 @@ BOOL CALLBACK DevicesTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
 
 BOOL CALLBACK MoveModifierDialog( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
-
 	HWND hDlgItem;
 	long i,j;
 	DWORD dwValue;
@@ -1065,20 +1065,18 @@ BOOL CALLBACK MoveModifierDialog( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lP
 	case WM_VSCROLL:
 		switch (GetWindowLong( (HWND)lParam, GWL_ID ))
 		{
-		case IDC_XMODIFIER:		
+		case IDC_XMODIFIER:
 			i = SendMessage( (HWND)lParam, TBM_GETPOS, 0, 0 );
 			LoadString( g_hResourceDLL, IDS_M_MOVEVALUE, szTemp, DEFAULT_BUFFER );
 			wsprintf( szBuffer, szTemp, i );
 			SendMessage( GetDlgItem( hDlg, IDT_XMODIFIER ), WM_SETTEXT , 0, (LPARAM)szBuffer );
 			return TRUE;
-
-		case IDC_YMODIFIER:		
+		case IDC_YMODIFIER:
 			i = SendMessage( (HWND)lParam, TBM_GETPOS, 0, 0 );
 			LoadString( g_hResourceDLL, IDS_M_MOVEVALUE, szTemp, DEFAULT_BUFFER );
 			wsprintf( szBuffer, szTemp, i );
 			SendMessage( GetDlgItem( hDlg, IDT_YMODIFIER ), WM_SETTEXT , 0, (LPARAM)szBuffer );
 			return TRUE;
-
 		default:
 			return FALSE;
 		}
@@ -1399,7 +1397,6 @@ void ModDescription( HWND hListView, int iEntry, const LPMODIFIER pModifier )
 		szBuffer[0] = '\0';
 	}
 	ListView_SetItemText( hListView, iEntry, 2, szBuffer );
-
 }
 
 BOOL CALLBACK ModifierTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
@@ -2571,7 +2568,6 @@ BOOL CALLBACK RumblePakProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam 
 						bMatch = true;
 			}
 
-
 			if (!bMatch && g_devList[i].bEffType != 0 )
 			{
 				if( g_devList[i].bProductCounter == 0 )
@@ -2667,10 +2663,12 @@ BOOL CALLBACK RumblePakProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam 
 			CheckDlgButton( hDlg, IDC_RUMBLE1, BST_CHECKED );
 		else
 			CheckDlgButton( hDlg, IDC_RUMBLE1, BST_UNCHECKED );
+
 		if( pcController->bRumbleTyp == RUMBLE_EFF2 )
 			CheckDlgButton( hDlg, IDC_RUMBLE2, BST_CHECKED );
 		else
 			CheckDlgButton( hDlg, IDC_RUMBLE2, BST_UNCHECKED );
+
 		if( pcController->bRumbleTyp == RUMBLE_EFF3 )
 			CheckDlgButton( hDlg, IDC_RUMBLE3, BST_CHECKED );
 		else
@@ -2785,7 +2783,6 @@ BOOL CALLBACK ShortcutsTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPar
 	switch(uMsg)
 	{
 	case WM_INITDIALOG:
-
 		bScanRunning = false;
 		iPlayer = 5;
 
@@ -3069,7 +3066,6 @@ BOOL CALLBACK FoldersDialogProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 
 		if( szBuffer[0] != 0 && ( szBuffer[1] == ':' || ( szBuffer[1] == '\\' &&  szBuffer[0] == '\\' )))
 		{
-
 			CheckDlgButton( hDlg, IDC_MEMPAK_ABS, BST_CHECKED );
 
 			GetDirectory( szBuffer, DIRECTORY_MEMPAK );
@@ -3092,7 +3088,6 @@ BOOL CALLBACK FoldersDialogProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 			else
 				SendMessage( GetDlgItem( hDlg, IDC_MEMPAK_REL_EDIT ), WM_SETTEXT, 0, (LPARAM)STRING_DEF_MEMPAKFILE );
 		}
-
 
 		GetDirectory( szBuffer, DIRECTORY_MEMPAK );
 		pcSlash = _tcsrchr( szBuffer, '\\' );
@@ -3132,7 +3127,6 @@ BOOL CALLBACK FoldersDialogProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 		if( pcSlash && ( pcSlash[1] == _T('\0') )) *pcSlash = '\0';
 		SendMessage( GetDlgItem( hDlg, IDC_GBROM_ABS_EDIT ), WM_SETTEXT, 0, (LPARAM)szBuffer );
 
-
 		// GBSave Directory
 		lstrcpyn(szBuffer, g_aszDefFolders[DIRECTORY_GBSAVES], MAX_PATH);
 
@@ -3171,12 +3165,10 @@ BOOL CALLBACK FoldersDialogProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 			}
 		}
 
-
 		GetDirectory( szBuffer, DIRECTORY_GBSAVES );
 		pcSlash = _tcsrchr( szBuffer, _T('\\') );
 		if( pcSlash && ( pcSlash[1] == _T('\0') )) *pcSlash = '\0';
 		SendMessage( GetDlgItem( hDlg, IDC_GBSAVE_ABS_EDIT ), WM_SETTEXT, 0, (LPARAM)szBuffer );
-
 
 		return FALSE; // don't give it focus
 
@@ -3311,8 +3303,6 @@ BOOL CALLBACK FoldersDialogProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 		return FALSE; //false means the msg didn't got processed
 	}
 }
-
-
 
 ///////////////////////////////////////////////////////////////////////////////
 // A wonderful n squared algorithm to store the key names in a string... what for???
@@ -3486,7 +3476,6 @@ bool GetButtonText( const BUTTON& btnButton, LPTSTR Buffer )
 		wsprintf(Text[1], buff, btnButton.bOffset - 7 );
 		Text[2] = AxeID[2 + btnButton.bAxisID];
 		break;
-
 	case DT_KEYBUTTON:
 		LoadString( g_hResourceDLL, iDevice[2], Text[0], 16 );
 		//TODO: this is great! can we do this for all of them?
@@ -3496,20 +3485,17 @@ bool GetButtonText( const BUTTON& btnButton, LPTSTR Buffer )
 		LoadString( g_hResourceDLL, IDS_C_UNKNOWN, Text[1], 16 );
 		Text[2] = TEXT( "" );
 		break;
-
 	case DT_MOUSEBUTTON:
 		LoadString( g_hResourceDLL, iDevice[3], Text[0], 16 );
 		LoadString( g_hResourceDLL, iMouse[3], Text[1], 16 );
 		Text[2] = Btn;
 		wsprintf( Btn, TEXT( "%02u" ), btnButton.bOffset );
 		break;
-
 	case DT_MOUSEAXE:
 		LoadString( g_hResourceDLL, iDevice[3], Text[0], 16 );
 		LoadString( g_hResourceDLL, iMouse[btnButton.bOffset], Text[1], 16 );
 		Text[2] = AxeID[btnButton.bAxisID];
 		break;
-
 	case DT_UNASSIGNED:
 	default:
 		LoadString( g_hResourceDLL, iDevice[0], Text[0], 16 );
@@ -3573,7 +3559,6 @@ DWORD ScanMouse( LPDEVICE lpDevice, LPDWORD lpdwCounter, LPBUTTON pButton )
 		lpDevice->didHandle->Acquire();
 		return FALSE;
 	}
-
 
 	if ( bFirstScan )
 	{
@@ -3650,8 +3635,8 @@ DWORD ScanGamePad ( LPDEVICE lpDevice, LPDWORD lpdwCounter, LPBUTTON pButton, in
 	hr = lpDevice->didHandle->GetDeviceState( sizeof(DIJOYSTATE), &lpDevice->stateAs.joyState );
 	if ( FAILED(hr) )
 	{
-			hr = lpDevice->didHandle->Acquire();
-			return FALSE;
+		hr = lpDevice->didHandle->Acquire();
+		return FALSE;
 	}
 
 	if ( bFirstScan )
@@ -3971,7 +3956,6 @@ void UpdateControllerStructures()
 			g_pcControllers[i].guidFFDevice = GUID_NULL;
 		}
 
-
 		g_pcControllers[i].fPakCRCError = false;
 		g_pcControllers[i].fPakInitialized = false;
 
@@ -3986,7 +3970,8 @@ LRESULT CALLBACK BlockerProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	PAINTSTRUCT ps;
 
-	switch (msg) {
+	switch (msg)
+	{
 		case WM_CREATE:
 			return 0;
 		case WM_PAINT:
@@ -4027,7 +4012,6 @@ BOOL InitOverlay(void)
 HWND MakeOverlay()
 {
 	HWND hwnd;
-
 	RECT size;
 
 	GetWindowRect(g_hMainDialog, &size);
@@ -4046,8 +4030,8 @@ HWND MakeOverlay()
 		g_hMainDialog,			// owner window
 		(HMENU) NULL,			// menu
 		g_strEmuInfo.hinst,		// handle to application instance
-		(LPVOID) NULL);			// window-creation data
-
+		(LPVOID) NULL			// window-creation data
+	);
 	if (!hwnd)
 		return NULL;
 

--- a/Source/nragev20/International.cpp
+++ b/Source/nragev20/International.cpp
@@ -49,9 +49,10 @@ HMODULE		LoadLanguageDLL(LANGID DesiredLanguage)
 	hDLL = LoadLibraryEx(SatellitePath, 0, 0);
 	if( hDLL )
 		return hDLL;
-	else {   // try the primary language ID
+	else
+	{   // try the primary language ID
 		DesiredLanguage = PRIMARYLANGID(DesiredLanguage);
-	_stprintf(SatellitePath, _T("NRage-Language-%u.dll"), DesiredLanguage);
+		_stprintf(SatellitePath, _T("NRage-Language-%u.dll"), DesiredLanguage);
 		hDLL = LoadLibraryEx(SatellitePath, 0, 0);
 		if( hDLL )
 			return hDLL;
@@ -83,25 +84,25 @@ BOOL CALLBACK EnumLangProc(HANDLE hModule, LPCTSTR lpszType, LPCTSTR lpszName,
 // the Hongkong SAR version
 LANGID GetNTDLLNativeLangID()
 {
-
     LANGINFO LangInfo;
-	LPCTSTR Type = (LPCTSTR) ((LPVOID)((WORD)16));
+    LPCTSTR Type = (LPCTSTR) ((LPVOID)((WORD)16));
     LPCTSTR Name = (LPCTSTR) 1;
 
     ZeroMemory(&LangInfo,sizeof(LangInfo));
-    
+
     // Get the HModule for ntdll.
     HMODULE hMod = GetModuleHandle(_T("ntdll.dll"));
-    if (hMod==NULL) {
+    if (hMod==NULL)
+    {
         return(0);
     }
 
     BOOL result = EnumResourceLanguages(hMod, Type, Name, (ENUMRESLANGPROC)EnumLangProc, (LONG_PTR) &LangInfo);
-    
-    if (!result || (LangInfo.Count > 2) || (LangInfo.Count < 1) ) {
+
+    if (!result || (LangInfo.Count > 2) || (LangInfo.Count < 1) )
+    {
         return (0);
     }
-    
     return (LangInfo.LangID);
 }
 
@@ -114,7 +115,8 @@ BOOL IsHongKongVersion()
     IMMRELEASECONTEXT pImmReleaseContext;
 
     hMod = LoadLibrary(_T("imm32.dll"));
-    if (hMod) {
+    if (hMod)
+    {
         pImmReleaseContext = (IMMRELEASECONTEXT)GetProcAddress(hMod,"ImmReleaseContext");
         if (pImmReleaseContext) {
             bRet = pImmReleaseContext(NULL,0);
@@ -137,12 +139,12 @@ LANGID DetectLanguage()
 	DWORD				Type, BuffLen = MAX_KEY_BUFFER;
 	TCHAR				LangKeyValue[MAX_KEY_BUFFER];
 
-
 	VersionInfo.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
 	if( !GetVersionEx(&VersionInfo) )
 		return(0);
 
-	switch( VersionInfo.dwPlatformId ) {
+	switch( VersionInfo.dwPlatformId )
+	{
 		// On Windows NT, Windows 2000 or higher
 		case VER_PLATFORM_WIN32_NT:
 			if( VersionInfo.dwMajorVersion >= 5)   // Windows 2000 or higher
@@ -156,10 +158,13 @@ LANGID DetectLanguage()
 					uiLangID = fpGetLang();
 				} // and if we couldn't load kernel32.dll, just fall back to default language
 			}
-			else {   // for NT4 check the language of ntdll.dll
+			else
+			{   // for NT4 check the language of ntdll.dll
 				uiLangID = GetNTDLLNativeLangID();   
-				if (uiLangID == 1033) {		// special processing for Honkong SAR version of NT4
-					if (IsHongKongVersion()) {
+				if (uiLangID == 1033)
+				{		// special processing for Honkong SAR version of NT4
+					if (IsHongKongVersion())
+					{
 						uiLangID = 3076;
 					}
 				}
@@ -169,13 +174,15 @@ LANGID DetectLanguage()
 		case VER_PLATFORM_WIN32_WINDOWS:
 			// Open the registry key for the UI language
 			if( RegOpenKeyEx(HKEY_CURRENT_USER,_T("Default\\Control Panel\\Desktop\\ResourceLocale"), 0,
-				KEY_QUERY_VALUE, &hKey) == ERROR_SUCCESS ) {
+				KEY_QUERY_VALUE, &hKey) == ERROR_SUCCESS )
+			{
 				// Get the type of the default key
 				if( RegQueryValueEx(hKey, NULL, NULL, &Type, NULL, NULL) == ERROR_SUCCESS 
-					&& Type == REG_SZ ) {
-					// Read the key value
+					&& Type == REG_SZ )
+				{ // Read the key value
 					if( RegQueryValueEx(hKey, NULL, NULL, &Type, (LPBYTE)LangKeyValue, &BuffLen) 
-						== ERROR_SUCCESS ) {
+						== ERROR_SUCCESS )
+					{
 						uiLangID = _ttoi(LangKeyValue);
 					}
 				}
@@ -184,7 +191,8 @@ LANGID DetectLanguage()
 			break;
 	}
 
-    if (uiLangID == 0) {
+    if (uiLangID == 0)
+    {
         uiLangID = GetUserDefaultLangID();
     }
     // Return the found language ID.

--- a/Source/nragev20/International.h
+++ b/Source/nragev20/International.h
@@ -27,7 +27,8 @@
 #ifndef _NRINTERNATIONAL_
 #define _NRINTERNATIONAL_
 
-typedef struct LANGINFO_DEF {
+typedef struct LANGINFO_DEF
+{
 	int		Count;
 	LANGID	LangID;
 } LANGINFO;

--- a/Source/nragev20/NRagePluginV2.cpp
+++ b/Source/nragev20/NRagePluginV2.cpp
@@ -236,7 +236,8 @@ EXPORT void CALL DllConfig ( HWND hParent )
 		}
 		
 		EnterCriticalSection( &g_critical );
-		if( g_sysMouse.didHandle ) { // unlock mouse while configuring
+		if( g_sysMouse.didHandle )
+		{ // unlock mouse while configuring
 			g_sysMouse.didHandle->SetCooperativeLevel( g_strEmuInfo.hMainWindow, DIB_DEVICE );
 			g_sysMouse.didHandle->Acquire();
 		}
@@ -258,8 +259,10 @@ EXPORT void CALL DllConfig ( HWND hParent )
 				InitiatePaks( false );	// only re-init the mempaks and such if the user clicked Save or Use
 			}
 			
-			if( g_sysMouse.didHandle ) {
-				if ( g_bExclusiveMouse ) { // if we have exclusive mouse, we need to relock mouse after closing the config
+			if( g_sysMouse.didHandle )
+			{
+				if ( g_bExclusiveMouse )
+				{ // if we have exclusive mouse, we need to relock mouse after closing the config
 					g_sysMouse.didHandle->SetCooperativeLevel( g_strEmuInfo.hMainWindow, DIB_MOUSE );
 					g_sysMouse.didHandle->Acquire();
 					if (g_strEmuInfo.fDisplayShortPop)
@@ -270,7 +273,8 @@ EXPORT void CALL DllConfig ( HWND hParent )
 						CreateThread(NULL, 0, MsgThreadFunction, g_pszThreadMessage, 0, NULL);
 					}
 				}
-				else {
+				else
+				{
 					g_sysMouse.didHandle->SetCooperativeLevel( g_strEmuInfo.hMainWindow, DIB_KEYBOARD );
 					g_sysMouse.didHandle->Acquire();
 				}
@@ -413,7 +417,8 @@ EXPORT void CALL InitiateControllers (CONTROL_INFO * ControlInfo)
 
 	PrepareInputDevices();
 
-	if( g_bExclusiveMouse ) {
+	if( g_bExclusiveMouse )
+	{
 		// g_sysMouse.didHandle->Unacquire();
 		// g_sysMouse.didHandle->SetCooperativeLevel( g_strEmuInfo.hMainWindow, DIB_MOUSE ); // PrepareInputDevices does this.
 		g_sysMouse.didHandle->Acquire();
@@ -448,7 +453,7 @@ EXPORT void CALL RomOpen (void)
 		ErrorMessage(IDS_ERR_NOINIT, 0, false);
 		return;
 	}
-	
+
 	EnterCriticalSection( &g_critical );
 	// re-init our paks and shortcuts
 	InitiatePaks( true );
@@ -517,7 +522,8 @@ EXPORT void CALL GetKeys(int Control, BUTTONS * Keys )
 	{
 		EnterCriticalSection( &g_critical );
 		
-		if( g_pcControllers[Control].fPlugged ) {
+		if( g_pcControllers[Control].fPlugged )
+		{
 			if (Control == g_iFirstController )
 			{
 				GetDeviceDatas();
@@ -667,8 +673,6 @@ EXPORT void CALL ReadController( int Control, BYTE * Command )
 				GetNControllerInput( Control, (DWORD*)&Command[3] );
 		}
 		break;
-		
-
 	case RD_READPAK:
 #ifdef ENABLE_RAWPAK_DEBUG
 		WriteDatasA( "ReadPak-PreProcessing", Control, Command, 0);
@@ -688,7 +692,6 @@ EXPORT void CALL ReadController( int Control, BYTE * Command )
 		DebugWriteA( NULL );
 #endif
 		break;
-
 	case RD_WRITEPAK:
 #ifdef ENABLE_RAWPAK_DEBUG
 		WriteDatasA( "WritePak-PreProcessing", Control, Command, 0);
@@ -707,7 +710,6 @@ EXPORT void CALL ReadController( int Control, BYTE * Command )
 		DebugWriteA( NULL );
 #endif
 		break;
-
 	case RD_READEEPROM:
 		// Should be handled by the Emulator
 		WriteDatasA( "ReadEeprom-PreProcessing", Control, Command, 0);
@@ -720,7 +722,6 @@ EXPORT void CALL ReadController( int Control, BYTE * Command )
 		WriteDatasA( "WriteEeprom-PostProcessing", Control, Command, 0);
 		DebugWriteA( NULL );
 		break;
-
 	default:
 		// only accessible if the Emulator has bugs.. or maybe the Rom is flawed
 		WriteDatasA( "ReadController: Bad read", Control, Command, 0);
@@ -1003,7 +1004,6 @@ void DoShortcut( int iControl, int iShortcut )
 			LoadString( g_hResourceDLL, IDS_P_NONE, pszMessage, ARRAYSIZE(pszMessage) );
 			LeaveCriticalSection( &g_critical );
 			break;
-
 		case SC_MEMPAK:
 			if (PAK_NONE == g_pcControllers[iControl].PakType)
 			{
@@ -1018,7 +1018,6 @@ void DoShortcut( int iControl, int iShortcut )
 				bEjectFirst = true;
 			}
 			break;
-		
 		case SC_RUMBPAK:
 			if (PAK_NONE == g_pcControllers[iControl].PakType)
 			{
@@ -1060,7 +1059,6 @@ void DoShortcut( int iControl, int iShortcut )
 				bEjectFirst = true;
 			}
 			break;
-		
 		case SC_VOICEPAK:
 			if (PAK_NONE == g_pcControllers[iControl].PakType)
 			{
@@ -1076,7 +1074,6 @@ void DoShortcut( int iControl, int iShortcut )
 				bEjectFirst = true;
 			}
 			break;
-
 		case SC_ADAPTPAK:
 			if (PAK_NONE == g_pcControllers[iControl].PakType)
 			{
@@ -1092,7 +1089,6 @@ void DoShortcut( int iControl, int iShortcut )
 				bEjectFirst = true;
 			}
 			break;
-
 		case SC_SWMEMRUMB:
 			bEjectFirst = true;
 			if( g_pcControllers[iControl].PakType == PAK_MEM )
@@ -1104,7 +1100,6 @@ void DoShortcut( int iControl, int iShortcut )
 				iShortcut = PAK_MEM;
 			}
 			break;
-
 		case SC_SWMEMADAPT:
 			bEjectFirst = true;
 			if( g_pcControllers[iControl].PakType == PAK_MEM )
@@ -1116,7 +1111,6 @@ void DoShortcut( int iControl, int iShortcut )
 				iShortcut = PAK_MEM;
 			}
 			break;
-
 		default:
 			DebugWriteA("Invalid iShortcut passed to DoShortcut\n");
 			EnterCriticalSection( &g_critical );
@@ -1144,7 +1138,7 @@ void DoShortcut( int iControl, int iShortcut )
 		CreateThread(NULL, 0, DelayedShortcut, lpmNextShortcut, 0, NULL);
 		iControl = -2;	// this is just a hack to get around the check that appends "Changing Pak X to ..."
 	}
-	
+
 	if( g_strEmuInfo.fDisplayShortPop && _tcslen(pszMessage) > 0 )
 	{
 		if( iControl >= 0 )

--- a/Source/nragev20/PakIO.cpp
+++ b/Source/nragev20/PakIO.cpp
@@ -199,7 +199,6 @@ bool InitControllerPak( const int iControl )
 			}			
 		}
 		break;
-
 	case PAK_RUMBLE:
 		{
 			g_pcControllers[iControl].pPakData = P_malloc( sizeof(RUMBLEPAK));
@@ -233,7 +232,6 @@ bool InitControllerPak( const int iControl )
 			 * Here, both files should be opened and the handles stored in tPak ( modify the struct for Your own purposes, only bPakType must stay at first )
 			 */
 
-
 			//CreateFile( g_pcControllers[iControl].szTransferSave, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_ALWAYS, 0, NULL );
 			tPak->iCurrentAccessMode = 0;
 			tPak->iCurrentBankNo = 0;
@@ -242,16 +240,18 @@ bool InitControllerPak( const int iControl )
 
 			tPak->bPakInserted = LoadCart( &tPak->gbCart, g_pcControllers[iControl].szTransferRom, g_pcControllers[iControl].szTransferSave, _T("") );
 
-			if (tPak->bPakInserted) {
+			if (tPak->bPakInserted)
+			{
 				DebugWriteA( "*** Init Transfer Pak - Success***\n" );
-			} else {
+			}
+			else
+			{
 				DebugWriteA( "*** Init Transfer Pak - FAILURE***\n" );
 			}
 
 			bReturn = true;
 		}
 		break;
-
 	/*case PAK_VOICE:
 		{
 			g_pcControllers[iControl].pPakData = P_malloc( sizeof(VOICEPAK));
@@ -261,7 +261,6 @@ bool InitControllerPak( const int iControl )
 			bReturn = true;
 		}
 		break;*/
-	
 	case PAK_ADAPTOID:
 		if( !g_pcControllers[iControl].fIsAdaptoid )
 			g_pcControllers[iControl].PakType = PAK_NONE;
@@ -281,8 +280,6 @@ bool InitControllerPak( const int iControl )
 			bReturn = true;
 		}
 		break;
-
-	
 	/*case PAK_NONE:
 		break;*/
 	}
@@ -338,7 +335,7 @@ BYTE ReadControllerPak( const int iControl, LPBYTE Command )
 				FillMemory( Data, 32, 0x80 );
 			else
 				ZeroMemory( Data, 32 );
-			
+
 			if( g_pcControllers[iControl].fXInput )	// xinput controller rumble --tecnicors
 				VibrateXInputController( g_pcControllers[iControl].xiController.nControl, 0, 0);
 			else if (g_apFFDevice[iControl])
@@ -369,18 +366,25 @@ BYTE ReadControllerPak( const int iControl, LPBYTE Command )
 					FillMemory(Data, 32, 0x84);
 				break;
 			case 0xB: //	if ((dwAddress >= 0xB000) && (dwAddress <= 0xBFFF))
-				if (tPak->iEnableState == true) {
+				if (tPak->iEnableState == true)
+				{
 					DebugWriteA( "Query Cart. State:" );
-					if (tPak->bPakInserted) {
-						if (tPak->iCurrentAccessMode == 1) {
+					if (tPak->bPakInserted)
+					{
+						if (tPak->iCurrentAccessMode == 1)
+						{
 							FillMemory(Data, 32, 0x89);
 							DebugWriteA( " Inserted, Access Mode 1\n" );
-						} else {
+						}
+						else
+						{
 							FillMemory(Data, 32, 0x80);
 							DebugWriteA( " Inserted, Access Mode 0\n" );
 						}
 						Data[0] = Data[0] | tPak->iAccessModeChanged;
-					} else {
+					}
+					else
+					{
 						FillMemory(Data, 32, 0x40); // Cart not inserted.
 						DebugWriteA( " Not Inserted\n" );
 					}
@@ -391,7 +395,8 @@ BYTE ReadControllerPak( const int iControl, LPBYTE Command )
 			case 0xD:
 			case 0xE:
 			case 0xF: //	if ((dwAddress >= 0xC000))
-				if (tPak->iEnableState == true) {
+				if (tPak->iEnableState == true)
+				{
 					DebugWriteA( "Cart Read: Bank:%i\n", tPak->iCurrentBankNo );
 					DebugWriteA( "    Address:%04X\n", ((dwAddress & 0xFFE0) - 0xC000) + ((tPak->iCurrentBankNo & 3) * 0x4000) );
 
@@ -406,10 +411,12 @@ BYTE ReadControllerPak( const int iControl, LPBYTE Command )
 #ifdef ENABLE_RAWPAK_DEBUG
 			DebugWriteA( "TPak Data: " );
 
-			for (int i = 0; i < 32; i ++) {
+			for (int i = 0; i < 32; i ++)
+			{
 				if ((i < 31) && ((i & 7) == 0)) DebugWriteA( "\n  " );
 				DebugWriteByteA(Data[i]);
-				if (i < 31) {
+				if (i < 31)
+				{
 					DebugWriteA( ", ");
 				}
 			}
@@ -421,16 +428,14 @@ BYTE ReadControllerPak( const int iControl, LPBYTE Command )
 			bReturn = RD_OK;
 		}
 		break;
-
 	/*case PAK_VOICE:
 		break;*/
-	
 	case PAK_ADAPTOID:
 		if( ReadAdaptoidPak( iControl, dwAddress, Data ) == DI_OK )
 		{
 			Data[32] = DataCRC( Data, 32 );
 			bReturn = RD_OK;
-			
+
 			if( ((ADAPTOIDPAK*)g_pcControllers[iControl].pPakData)->fRumblePak )
 			{
 				BYTE bId = ((ADAPTOIDPAK*)g_pcControllers[iControl].pPakData)->bIdentifier;
@@ -444,7 +449,7 @@ BYTE ReadControllerPak( const int iControl, LPBYTE Command )
 			}
 		}
 		break;
-	
+
 	/*case PAK_NONE:
 		break;*/
 	}
@@ -480,7 +485,7 @@ BYTE WriteControllerPak( const int iControl, LPBYTE Command )
 			// Switched to memory-mapped file
 			// That way, if the computer dies due to power loss or something mid-play, the savegame is still there.
 			MEMPAK *mPak = (MEMPAK*)g_pcControllers[iControl].pPakData;
-			
+
 			if( dwAddress < 0x8000 )
 			{
 				CopyMemory( &mPak->aMemPakData[dwAddress], Data, 32 );
@@ -552,7 +557,6 @@ end_rumble:		// added so after xinput controller rumbles, gets here --tecnicors
 		Data[32] = DataCRC( Data, 32 );
 		bReturn = RD_OK;
 		break;
-
 	case PAK_TRANSFER:
 		{
 			LPTRANSFERPAK tPak = (LPTRANSFERPAK)g_pcControllers[iControl].pPakData;
@@ -563,10 +567,15 @@ end_rumble:		// added so after xinput controller rumbles, gets here --tecnicors
 #ifdef ENABLE_RAWPAK_DEBUG
 			DebugWriteA( "  Data: ");
 
-			for (int i = 0; i < 32; i++) {
-				if ((i < 31) && ((i & 7) == 0)) DebugWriteA( "\n    " );
+			for (int i = 0; i < 32; i++)
+			{
+				if ((i < 31) && ((i & 7) == 0))
+				{
+					DebugWriteA( "\n    " );
+				}
 				DebugWriteByteA( Data[i]);
-				if (i < 31) {
+				if (i < 31)
+				{
 					DebugWriteA( ", " );
 				}
 			}
@@ -577,15 +586,18 @@ end_rumble:		// added so after xinput controller rumbles, gets here --tecnicors
 			switch (dwAddress >> 12)
 			{
 			case 0x8: //	if ((dwAddress >= 0x8000) && (dwAddress <= 0x8FFF))
-				if (Data[0] == 0xFE) {
+				if (Data[0] == 0xFE)
+				{
 					DebugWriteA("Cart Disable\n" );
 					tPak->iEnableState = false;
 				}
-				else if (Data[0] == 0x84) {
+				else if (Data[0] == 0x84)
+				{
 					DebugWriteA("Cart Enable\n" );
 					tPak->iEnableState = true;
 				}
-				else {
+				else
+				{
 					DebugWriteA("WARNING: Unusual Cart Enable/Disable\n" );
 					DebugWriteA("  Address: " );
 					DebugWriteWordA(dwAddress);
@@ -596,17 +608,20 @@ end_rumble:		// added so after xinput controller rumbles, gets here --tecnicors
 				}
 				break;
 			case 0xA: //	if ((dwAddress >= 0xA000) && (dwAddress <= 0xAFFF))
-				if (tPak->iEnableState == true) {
+				if (tPak->iEnableState == true)
+				{
 					tPak->iCurrentBankNo = Data[0];
 					DebugWriteA("Set TPak Bank No:%02X\n", Data[0] );
 				}
 				break;
 			case 0xB: //	if ((dwAddress >= 0xB000) && (dwAddress <= 0xBFFF))
-				if (tPak->iEnableState == true) {
+				if (tPak->iEnableState == true)
+				{
 					tPak->iCurrentAccessMode = Data[0] & 1;
 					tPak->iAccessModeChanged = 4;
 					DebugWriteA("Set TPak Access Mode: %04X\n", tPak->iCurrentAccessMode);
-					if ((Data[0] != 1) && (Data[0] != 0)) {
+					if ((Data[0] != 1) && (Data[0] != 0))
+					{
 						DebugWriteA("WARNING: Unusual Access Mode Change\n" );
 						DebugWriteA("  Address: " );
 						DebugWriteWordA(dwAddress);
@@ -634,10 +649,8 @@ end_rumble:		// added so after xinput controller rumbles, gets here --tecnicors
 			bReturn = RD_OK; 
 		}
 		break;
-
 	/*case PAK_VOICE:
 		break;*/
-	
 	case PAK_ADAPTOID:
 		if(( dwAddress == PAK_IO_RUMBLE ) && ((ADAPTOIDPAK*)g_pcControllers[iControl].pPakData)->fRumblePak )
 		{
@@ -659,7 +672,6 @@ end_rumble:		// added so after xinput controller rumbles, gets here --tecnicors
 			}
 		}
 		break;
-
 	/*case PAK_NONE:
 		break;*/
 	}
@@ -700,7 +712,6 @@ void SaveControllerPak( const int iControl )
 		break;
 	case PAK_ADAPTOID:
 		break;
-
 	/*case PAK_NONE:
 		break;*/
 	}
@@ -750,10 +761,8 @@ void CloseControllerPak( const int iControl )
 		break;
 	case PAK_VOICE:
 		break;
-	
 	case PAK_ADAPTOID:
 		break;
-
 	/*case PAK_NONE:
 		break;*/
 	}
@@ -789,12 +798,10 @@ inline WORD CountBlocks( const unsigned char * bMemPakBinary, LPBYTE aNoteSizes 
 	return wRemainingBlocks;
 }
 
-
-
 void FormatMemPak( LPBYTE aMemPak )
 {
 	FillMemory( aMemPak, 0x100, 0xFF );
-	
+
 	aMemPak[0] = 0x81;
 
 	// generate a valid code( i hope i can calculate it one day)
@@ -825,8 +832,6 @@ void FormatMemPak( LPBYTE aMemPak )
 	aMemPak[0x30+14] = aMemPak[0x70+14] = aMemPak[0x90+14] = aMemPak[0xD0+14] = aCode[6];
 	aMemPak[0x30+15] = aMemPak[0x70+15] = aMemPak[0x90+15] = aMemPak[0xD0+15] = aCode[7];
 
-
-
 	// Index
 	ZeroMemory( &aMemPak[0x100], 0x400 );
 
@@ -834,9 +839,7 @@ void FormatMemPak( LPBYTE aMemPak )
 	for( int i = 0x00b; i < 0x100; i += 2 )
 		aMemPak[0x100+i] = aMemPak[0x200+i] = 03;
 
-	
 	FillMemory( &aMemPak[0x500], 0x7B00, 0xFF );
-
 }
 
 // Translates a mempak header into a real Unicode string, for display in the Mempaks window
@@ -1404,20 +1407,16 @@ bool RemoveNote( LPBYTE aMemPak, const int iNote )
 		bBlock = aMemPak[iPos];
 		aMemPak[iPos] = 0x03;
 	}
+
 	int i = 0, iSum = 0;
 	for( i = 0x10A; i < 0x200; i++ )
 		iSum += aMemPak[i];
 
 	aMemPak[0x101] = iSum % 256;
-
 	CopyMemory( &aMemPak[0x200], &aMemPak[0x100], 0x100 );
-
 	ZeroMemory( &aMemPak[0x300 + iNote*32], 32 );
-
 	return true;
 }
-
-
 
 BYTE AddressCRC( const unsigned char * Address )
 {
@@ -1433,7 +1432,6 @@ BYTE AddressCRC( const unsigned char * Address )
 		Remainder = (Remainder << 1) & 0x1E;
 
 		Remainder += ( bBit < 11 && Data & (0x8000 >> bBit )) ? 1 : 0;
-
 		Remainder ^= (HighBit) ? 0x15 : 0;
 		
 		bBit++;

--- a/Source/nragev20/XInputController.cpp
+++ b/Source/nragev20/XInputController.cpp
@@ -418,7 +418,7 @@ TCHAR * GetN64ButtonFromXInputControl( LPXCONTROLLER gController, int XInputButt
 	N64ButtonCode |= gController->stButtons.iR & XInputButton ? R : 0;
 	N64ButtonCode |= gController->stButtons.iStart & XInputButton ? Start : 0;
 	N64ButtonCode |= gController->stButtons.iZ & XInputButton ? Z : 0;
-	
+
 	return GetN64ButtonNameFromButtonCode( N64ButtonCode );
 }
 


### PR DESCRIPTION
More often now, it seems habitual to make commits that simultaneously change both the braces style and spacing, which makes the actual purpose behind the commits a bit more buried (as far as the part of the algorithm that actually gets changed).  Since it can feel a bit too weird to have separate commits for changing braces style preceding adjacent changes right after, I thought I would try to just get it over with.

I guess I was partially successful.  It's too complex to do all of it in one pull request due to the size of all the changes combined, so I left the following things alone for the time being:
* the interpreter CPU and op-code functions to the RSP
* the RSP compiler
* the entire Project64 core component (turns out this should have its own PR)
* PJ64 Glide64 (seems to already be in Allman, possibly get replaced with GLideN64 anyway)
* external things like the SortRDB utility, third-party libraries, and any copyrighted components that I have no clue about the licensing or whether I should change any of their code at all
* all `do {` [...] while loops ... I never did decide for myself whether I should permanently prefer K&R- or Allman-style braces for do { } while loops, due to linguistics and such.  So I don't know what we want.
* `__asm {`, `try {`, `} __catch {`, `finally {` ... None of these things should even exist in C code, and I am not familiar with the compiler-syntactical linguistics of them or whether it's more accurate to use K&R for them in some special case.  They seem to still be a matter of block scope, but they have no branch prediction or special allocation, similar to my uncertainty with do { ... } while loops.
* Some code was neither in K&R nor Allman, like for example, `if (condition) { break; }`, or, `enum { single_constant = 0; }`.  I don't know whether to change them, so didn't decide.  Personally I wouldn't even use braces at all for the `if (condition) { statement; }` example, as I believe it would be more style-neutral to put the single-line branch to its own line after the "if (condition)" without braces.

I did on the other hand read through and update PJ64 N-Rage, Common, the basic RSP core components, the "Settings" component file....  I also removed excess whitespace and removed/adding some newlines if there were too many or not enough and unrelated code was looking too crammed together.