### PR TITLE
Fix Fushigi no Dungeon crash.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -2015,6 +2015,7 @@ Internal Name=F3 Ì³×²É¼ÚÝ2
 Status=Uncertain
 Core Note=?
 Plugin Note=[video] (see GameFAQ)
+32bit=No
 Clear Frame=2
 Counter Factor=1
 Culling=1


### PR DESCRIPTION
32 bit mode causes crash with recompiler.