### PR TITLE
Fixed Windows XP Compatibility with VS2013

### DIFF
--- a/Lang/Spanish.pj.Lang
+++ b/Lang/Spanish.pj.Lang
@@ -231,7 +231,7 @@
 #464#  "Desactivar Protector de Pantalla cuando un rom esté en ejecución"
 #465#  "Mostrar Frecuencia de Cuadros"
 #466#  "Cambiar Tipo de Frecuencia de Cuadros"
-#467#  "Comprobar si project64 ya esta en ejecución"
+#467#  "Comprobar si project64 ya está en ejecución"
 
 //Rom Browser Tab
 #480#  "Máx # de Roms Recordados (Máx 10):"

--- a/PropertySheets/Win32.props
+++ b/PropertySheets/Win32.props
@@ -143,7 +143,7 @@
       <LinkErrorReporting>PromptImmediately</LinkErrorReporting>
       <CLRUnmanagedCodeCheck>false</CLRUnmanagedCodeCheck>
       <SubSystem>Windows</SubSystem>
-      <MinimumRequiredVersion />
+      <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
     </Link>
     <Midl>
       <AdditionalIncludeDirectories>.;$(SRC);$(SRC)\3rd Party;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
MinimumRequiredVersion is now 5.01, otherwise VS2013 uses default 6.00,
making PJ64 incompatible with Windows XP.

it solve the following issue: https://github.com/project64/project64/issues/263#issuecomment-78684177

also fixed a minor thing in spanish lang file.