### PR TITLE
standardize exception-prone x86 behavior to normal C division

### DIFF
--- a/Source/Glide64/DepthBufferRender.cpp
+++ b/Source/Glide64/DepthBufferRender.cpp
@@ -87,7 +87,7 @@ static int left_z, left_dzdy;
 
 extern "C" int imul16(int x, int y);
 extern "C" int imul14(int x, int y);
-extern "C" int idiv16(int x, int y);
+extern int idiv16(int x, int y);
 
 __inline int iceil(int x)
 {

--- a/Source/Glide64/FixedPoint.asm.cpp
+++ b/Source/Glide64/FixedPoint.asm.cpp
@@ -35,6 +35,12 @@
 ;
 ;****************************************************************/
 
+#if defined(_MSC_VER) && !defined(_STDINT)
+typedef signed __int64          int64_t;
+#else
+#include <stdint.h>
+#endif
+
 // (x * y) >> 16
 extern "C" int __declspec(naked) imul16(int x, int y)
 {
@@ -65,19 +71,12 @@ extern "C" int  __declspec(naked) imul14(int x, int y)
 	}
 }
 
-//(x << 16) / y
-extern "C" int __declspec(naked) idiv16(int x, int y)
+int idiv16(int x, int y)
 {
-	_asm {
-		push ebp
-		mov ebp,esp
-		mov   eax, [x]
-		mov   ebx, [y]
-		mov   edx,eax   
-		sar   edx,16
-		shl   eax,16    
-		idiv  ebx  
-		leave
-		ret
-	}
+    int64_t result;
+    const int64_t m = (int64_t)(x);
+    const int64_t n = (int64_t)(y);
+
+    result = (m << 16) / n;
+    return (int)(result);
 }


### PR DESCRIPTION
fixes issue:  https://github.com/project64/project64/issues/283

I checked against how we are maintaining the OpenGL rewrite of Glide64 in RetroArch mupen64plus-libretro, and this new C algorithm is in essence how we are replacing the old in-line assembly code used to do the division here.  So if this commit introduces some kind of bug in Project64 Glide64, then it was a bug to the libretro fork of it as well which, all things factored here, I find to be unlikely.