### PR TITLE
Indy Racing 2000 Work Real Good.

### DIFF
--- a/Config/Glide64.rdb
+++ b/Config/Glide64.rdb
@@ -1452,6 +1452,12 @@ depthmode=1
 fix_tex_coord=1
 swapmode=2
 
+[E436467A-82DE8F9B-C:45]
+Good Name=Indy Racing 2000 (U)
+Internal Name=INDY RACING 2000
+fb_render=0
+fb_smart=0
+
 [336364A0-06C8D5BF-C:58]
 Good Name=International Superstar Soccer 2000 (E) (M2) (Eng-Ger)
 Internal Name=I.S.S.2000

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -2585,6 +2585,7 @@ ViRefresh=2050
 Good Name=Indy Racing 2000 (U)
 Internal Name=INDY RACING 2000
 Status=Compatible
+Core Note=high system requirement
 RDRAM Size=8
 
 [F41B6343-C10661E6-C:50]


### PR DESCRIPTION
Disabled register caching and disabled framebuffer for Glide64. This game runs terribly, and doesn't work at all with Interpreter. But at least it "works" again, like it did with 1.6