### PR TITLE
Indy Racing enable FAT.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -2586,6 +2586,7 @@ Good Name=Indy Racing 2000 (U)
 Internal Name=INDY RACING 2000
 Status=Compatible
 Core Note=high system requirement
+Fixed Audio=1
 RDRAM Size=8
 
 [F41B6343-C10661E6-C:50]


### PR DESCRIPTION
@dsx- pointed out that the game works with register caching so long as FAT is enabled. Game still has some problems, though.