### PR TITLE
Revert "Disable Aidyn Chronicles FAT."

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -310,6 +310,7 @@ Internal Name=AIDYN_CHRONICLES
 Status=Compatible
 AiCountPerBytes=200
 Culling=1
+Fixed Audio=1
 RDRAM Size=8
 
 [E6A95A4F-BAD2EA23-C:45]
@@ -318,6 +319,7 @@ Internal Name=AIDYN_CHRONICLES
 Status=Compatible
 AiCountPerBytes=200
 Culling=1
+Fixed Audio=1
 RDRAM Size=8
 
 [112051D2-68BEF8AC-C:45]
@@ -326,6 +328,7 @@ Internal Name=AIDYN_CHRONICLES
 Status=Compatible
 AiCountPerBytes=200
 Culling=1
+Fixed Audio=1
 RDRAM Size=8
 
 [27C425D0-8C2D99C1-C:50]


### PR DESCRIPTION
Reverts project64/project64#317
this commit over writes and reverses the fix I did, see Commit #116 

My PJ64 setup:
EXE : v2.2.0.2
GFX : PJ64Glide64 (v2.0.0.4)
SPU : Shunyuan's HLE Audio Plugin (v1.82u1)     <-- has given me the most stable audio playback....
INPUT: NRage (v2.4.0.3) or Jabo_DInput (v1.7.0.12)
RSP : RSP (v1.7.0.12) 


AmbientMalice, if its having it on is not causing issues for what ever plugin you are using please leave it on for now....