### PR TITLE
Remove the extra border around the ROM browser

### DIFF
--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -379,7 +379,7 @@ void CRomBrowser::CreateRomListControl (void)
 {
 	m_hRomList = (HWND)CreateWindowEx( WS_EX_CLIENTEDGE,WC_LISTVIEW,NULL,
 					WS_TABSTOP | WS_VISIBLE | WS_CHILD | LVS_OWNERDRAWFIXED |
-					WS_BORDER | LVS_SINGLESEL | LVS_REPORT,
+					LVS_SINGLESEL | LVS_REPORT,
 					0,0,0,0,m_MainWindow,(HMENU)IDC_ROMLIST,GetModuleHandle(NULL),NULL);	
 	ResetRomBrowserColomuns();
 	LoadRomList();


### PR DESCRIPTION
This style may have been appropriate in the days of Win9x, but looks out of place in WinXP and newer.

**Before**
![project64 2 2 0 2 2](https://cloud.githubusercontent.com/assets/11582193/6840566/4a174744-d340-11e4-99f8-6550733b6298.png)
**After**
![project64 2 2 0 2 1](https://cloud.githubusercontent.com/assets/11582193/6840567/4a2764c6-d340-11e4-9001-2d4dd439c398.png)
