### PR TITLE
Re-Volt CF=1 framerate improvement.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -4744,6 +4744,7 @@ Plugin Note=[video] slow in options menu
 RDRAM Size=8
 ViRefresh=1500
 AiCountPerBytes=530
+Counter Factor=1
 Fixed Audio=1
 Sync Audio=0
 
@@ -4755,6 +4756,7 @@ Plugin Note=[video] slow in options menu
 RDRAM Size=8
 ViRefresh=1500
 AiCountPerBytes=530
+Counter Factor=1
 Fixed Audio=1
 Sync Audio=0
 


### PR DESCRIPTION
I had avoided this in the past since it seemed unstable. But with @Frank-74's changes, the game now seems stable with CF=1, and it runs at 60fps with occasional dips instead of all over the place with dips into the teens as it does with CF=2.