### PR TITLE
copy Sin and Punishment RDB settings to English trans.

### DIFF
--- a/Config/Glide64.rdb
+++ b/Config/Glide64.rdb
@@ -2965,8 +2965,6 @@ Good Name=Shadow Man (U)
 Internal Name=Shadowman
 depthmode=0
 
-// added 2015.04.11:  "Tsumi to Batsu:  Hoshi no Keishousha" English translation
-// [B6BC0FB0-E3812198-C:4A]
 [B73AB6F6-296267DD-C:45]
 Good Name=Sin & Punishment (J) [T]
 Internal Name=Sin and Punishment

--- a/Config/Glide64.rdb
+++ b/Config/Glide64.rdb
@@ -2965,6 +2965,15 @@ Good Name=Shadow Man (U)
 Internal Name=Shadowman
 depthmode=0
 
+// added 2015.04.11:  "Tsumi to Batsu:  Hoshi no Keishousha" English translation
+// [B6BC0FB0-E3812198-C:4A]
+[B73AB6F6-296267DD-C:45]
+Good Name=Sin & Punishment (J) [T]
+Internal Name=Sin and Punishment
+depthmode=1
+fb_clear=1
+filtering=1
+
 [C2751D1A-F8C19BFF-C:50]
 Good Name=Snowboard Kids 2 (E)
 Internal Name=SNOWBOARD KIDS2


### PR DESCRIPTION
Have a complaint [here](https://github.com/project64/project64/issues/367) that `Project64.rdb` supports both the Japanese release as well as the English translation ROM to _Sin and Punishment_, while `Glide64.rdb` supports only the non-translated, original ROM.  So I used `Project64.rdb` to copy the settings into a new entry for the translated one.