### PR TITLE
Fix losing audio while loading a save state

### DIFF
--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -1571,7 +1571,7 @@ bool CN64System::LoadState(void)
 bool CN64System::LoadState(LPCSTR FileName) 
 {
 	DWORD dwRead, Value,SaveRDRAMSize, NextVITimer = 0;
-	bool LoadedZipFile = false;
+	bool LoadedZipFile = false, AudioResetOnLoad;
 
 	WriteTraceF((TraceType)(TraceDebug | TraceRecompiler),__FUNCTION__ "(%s): Start",FileName);
 
@@ -1727,8 +1727,12 @@ bool CN64System::LoadState(LPCSTR FileName)
 	}
 	
 	//Fix losing audio in certain games with certain plugins
-	m_Reg.m_AudioIntrReg |= MI_INTR_AI;
-	m_Reg.AI_STATUS_REG &= ~AI_STATUS_FIFO_FULL;
+	AudioResetOnLoad = g_Settings->LoadBool(Game_AudioResetOnLoad);
+	if (AudioResetOnLoad)
+	{
+		m_Reg.m_AudioIntrReg |= MI_INTR_AI;
+		m_Reg.AI_STATUS_REG &= ~AI_STATUS_FIFO_FULL;
+	}
 	
 	//Fix Random Register
 	while ((int)m_Reg.RANDOM_REGISTER < (int)m_Reg.WIRED_REGISTER)

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -1725,7 +1725,11 @@ bool CN64System::LoadState(LPCSTR FileName)
 		ReadFile( hSaveFile,m_MMU_VM.Imem(),0x1000,&dwRead,NULL);
 		CloseHandle(hSaveFile);
 	}
-
+	
+	//Fix losing audio in certain games with certain plugins
+	m_Reg.m_AudioIntrReg |= MI_INTR_AI;
+	m_Reg.AI_STATUS_REG &= ~AI_STATUS_FIFO_FULL;
+	
 	//Fix Random Register
 	while ((int)m_Reg.RANDOM_REGISTER < (int)m_Reg.WIRED_REGISTER)
     {

--- a/Source/Project64/Settings.h
+++ b/Source/Project64/Settings.h
@@ -95,6 +95,7 @@ enum SettingID {
 	Rdb_GameCheatFixPlugin,
 	Rdb_ViRefreshRate,
 	Rdb_AiCountPerBytes,
+	Rdb_AudioResetOnLoad,
 
 	//Individual Game Settings
 	Game_IniKey,
@@ -139,6 +140,7 @@ enum SettingID {
 	Game_LoadRomToMemory,
 	Game_ViRefreshRate,
 	Game_AiCountPerBytes,
+	Game_AudioResetOnLoad,
 
 	// General Game running info
 	GameRunning_LoadingInProgress,

--- a/Source/Project64/Settings/Settings Class.cpp
+++ b/Source/Project64/Settings/Settings Class.cpp
@@ -167,6 +167,7 @@ void CSettings::AddHowToHandleSetting ()
 	AddHandler(Rdb_GameCheatFixPlugin,  new CSettingTypeRomDatabaseIndex("CheatPlugin","",""));
 	AddHandler(Rdb_ViRefreshRate,       new CSettingTypeRomDatabase("ViRefresh",1500));
 	AddHandler(Rdb_AiCountPerBytes,     new CSettingTypeRomDatabase("AiCountPerBytes",400));
+	AddHandler(Rdb_AudioResetOnLoad,    new CSettingTypeRDBYesNo("AudioResetOnLoad", false));
 	
 	AddHandler(Game_IniKey,             new CSettingTypeTempString(""));
 	AddHandler(Game_GameName,           new CSettingTypeTempString(""));
@@ -210,6 +211,7 @@ void CSettings::AddHowToHandleSetting ()
 	AddHandler(Game_SMM_ValidFunc,      new CSettingTypeGame("SMM-FUNC",Rdb_SMM_ValidFunc));
 	AddHandler(Game_ViRefreshRate,      new CSettingTypeGame("ViRefresh",Rdb_ViRefreshRate));
 	AddHandler(Game_AiCountPerBytes,    new CSettingTypeGame("AiCountPerBytes",Rdb_AiCountPerBytes));
+	AddHandler(Game_AudioResetOnLoad,   new CSettingTypeGame("AudioResetOnLoad", Rdb_AudioResetOnLoad));
 
 	//User Interface
 	AddHandler(UserInterface_BasicMode,        new CSettingTypeApplication("","Basic Mode",          (DWORD)true));


### PR DESCRIPTION
This fixes the losing audio after loading a save state issue with
certain plugins in certain games. I was hesitant to submit this, since
the fault is the audio plugin itself, but this also fixes bad save
states. This will not fix games like Top Gear Rally.

Any plugin that initially had this problem, can still lose audio at any
given time, due to flaws in the audio plugin itself. It is best to
simply use a plugin that doesn't have this issue to begin with, for such
games.