### PR TITLE
Remove '/' from Good Names

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -6322,7 +6322,7 @@ Plugin Note=[video] (see GameFAQ)
 AiCountPerBytes=800
 
 [2F700DCD-176CC5C9-C:50]
-Good Name=Turok - Dinosaur Hunter (E) (V1.1)/(V1.2)
+Good Name=Turok - Dinosaur Hunter (E) (V1.1) (V1.2)
 Internal Name=TUROK_DINOSAUR_HUNTE
 Status=Compatible
 Core Note=(see GameFAQ)
@@ -6338,7 +6338,7 @@ Plugin Note=[video] (see GameFAQ)
 AiCountPerBytes=800
 
 [665FC793-6934A73B-C:44]
-Good Name=Turok - Dinosaur Hunter (G) (V1.1)/(V1.2)
+Good Name=Turok - Dinosaur Hunter (G) (V1.1) (V1.2)
 Internal Name=TUROK_DINOSAUR_HUNTE
 Status=Compatible
 Core Note=(see GameFAQ)
@@ -6354,7 +6354,7 @@ Plugin Note=[video] (see GameFAQ)
 AiCountPerBytes=800
 
 [2F700DCD-176CC5C9-C:45]
-Good Name=Turok - Dinosaur Hunter (U) (V1.1)/(V1.2)
+Good Name=Turok - Dinosaur Hunter (U) (V1.1) (V1.2)
 Internal Name=TUROK_DINOSAUR_HUNTE
 Status=Compatible
 Core Note=(see GameFAQ)


### PR DESCRIPTION
Save filename uses the Good Name, so need to remove '/' for save to work.