### PR TITLE
Add missing 32bit=No for Doom 64 (1.1)

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1540,6 +1540,7 @@ Good Name=Doom 64 (U) (V1.1)
 Internal Name=Doom64
 Status=Compatible
 Plugin Note=[video] (see GameFAQ)
+32bit=No
 Culling=1
 
 [BFF7B1C2-AEBF148E-C:4A]


### PR DESCRIPTION
This fixes corrupt graphics.