### PR TITLE
N64 Class: Initialize variable before passing in initializer list

### DIFF
--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -30,6 +30,7 @@ CN64System::CN64System ( CPlugins * Plugins, bool SavesReadOnly ) :
 	m_EndEmulation(false),
 	m_bCleanFrameBox(true),
 	m_bInitilized(false),
+	m_NextTimer(0),
 	m_SystemTimer(m_NextTimer),
 	m_DMAUsed(false),
 	m_CPU_Handle(NULL),

--- a/Source/Project64/N64 System/N64 Class.h
+++ b/Source/Project64/N64 System/N64 Class.h
@@ -137,11 +137,11 @@ private:
 	CAudio          m_Audio;
 	CSpeedLimitor   m_Limitor;
 	bool            m_InReset;
+	int             m_NextTimer;
 	CSystemTimer    m_SystemTimer;
 	bool            m_bCleanFrameBox;
 	bool            m_bInitilized;
 	bool            m_RspBroke;
-	int             m_NextTimer;
 	bool            m_DMAUsed;
 	DWORD           m_Buttons[4];
 	BOOL            m_TestTimer;


### PR DESCRIPTION
Silences an uninitialized variable warning.