### PR TITLE
RSP: Fix a typo in Compile_ADDI

### DIFF
--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -447,7 +447,7 @@ void Compile_ADDI ( void ) {
 		AddConstToVariable(Immediate, &RSP_GPR[RSPOpC.rt].UW, GPR_Name(RSPOpC.rt));
 	} else if (RSPOpC.rs == 0) {
 		MoveConstToVariable(Immediate, &RSP_GPR[RSPOpC.rt].UW, GPR_Name(RSPOpC.rt));
-	} else if ((IsRegConst(RSPOpC.rs) && 1) != 0) {
+	} else if ((IsRegConst(RSPOpC.rs) & 1) != 0) {
 		MoveConstToVariable(MipsRegConst(RSPOpC.rs) + Immediate, &RSP_GPR[RSPOpC.rt].UW, GPR_Name(RSPOpC.rt));
 	} else {
 		MoveVariableToX86reg(&RSP_GPR[RSPOpC.rs].UW, GPR_Name(RSPOpC.rs), x86_EAX);


### PR DESCRIPTION
Previously it was treating all regs as const regs whenever execution reached this branch.