### PR TITLE
Changed Duck Dodgers Audio Sync.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1661,6 +1661,8 @@ Good Name=Duck Dodgers Starring Daffy Duck (U) (M3)
 Internal Name=LT DUCK DODGERS
 Status=Compatible
 Counter Factor=1
+Dsound-SyncAudio=1
+Sync Audio=0
 
 [DC36626A-3F3770CB-C:50]
 Good Name=Duke Nukem - ZER0 H0UR (E)
@@ -3161,6 +3163,8 @@ ViRefresh=1400
 Good Name=Looney Tunes - Duck Dodgers (E) (M6)
 Internal Name=DAFFY DUCK STARRING
 Status=Compatible
+Dsound-SyncAudio=1
+Sync Audio=0
 RDRAM Size=8
 
 [2483F22B-136E025E-C:55]


### PR DESCRIPTION
When using PJ64's audio sync, the game feels "off". Daffy's movement is jerky. So I've disabled it and enabled Jabo audio sync. Azimer's seems to work fine with these settings.