### PR TITLE
optimized `AsciiToHex` performance and code size

### DIFF
--- a/Source/Project64/N64 System/Cheat Class.cpp
+++ b/Source/Project64/N64 System/Cheat Class.cpp
@@ -488,7 +488,7 @@ static const signed char ASCII_to_hex[128] = {
      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
-DWORD CCheats::AsciiToHex (const char * HexValue)
+DWORD CCheats::AsciiToHex(const char * HexValue)
 {
 	DWORD Count, Value;
 

--- a/Source/Project64/N64 System/Cheat Class.cpp
+++ b/Source/Project64/N64 System/Cheat Class.cpp
@@ -476,42 +476,36 @@ int CCheats::ApplyCheatEntry (CMipsMemory * MMU, const CODES & CodeEntry, int Cu
 	return 1;
 }
 
+static const signed char ASCII_to_hex[128] = {
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    0x0,0x1,0x2,0x3,0x4,0x5,0x6,0x7,0x8,0x9, -1, -1, -1, -1, -1, -1,
 
-DWORD CCheats::AsciiToHex (const char * HexValue) {
-	DWORD Count, Finish, Value = 0;
+     -1,0xA,0xB,0xC,0xD,0xE,0xF, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1,0xa,0xb,0xc,0xd,0xe,0xf, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+};
+
+DWORD CCheats::AsciiToHex (const char * HexValue)
+{
+	DWORD Count, Finish, Value;
 
 	Finish = strlen(HexValue);
-	if (Finish > 8 ) { Finish = 8; }
+	if (Finish > 8 )
+	{
+		Finish = 8;
+	}
 
-	for (Count = 0; Count < Finish; Count++){
-		Value = (Value << 4);
-		switch( HexValue[Count] ) {
-		case '0': break;
-		case '1': Value += 1; break;
-		case '2': Value += 2; break;
-		case '3': Value += 3; break;
-		case '4': Value += 4; break;
-		case '5': Value += 5; break;
-		case '6': Value += 6; break;
-		case '7': Value += 7; break;
-		case '8': Value += 8; break;
-		case '9': Value += 9; break;
-		case 'A': Value += 10; break;
-		case 'a': Value += 10; break;
-		case 'B': Value += 11; break;
-		case 'b': Value += 11; break;
-		case 'C': Value += 12; break;
-		case 'c': Value += 12; break;
-		case 'D': Value += 13; break;
-		case 'd': Value += 13; break;
-		case 'E': Value += 14; break;
-		case 'e': Value += 14; break;
-		case 'F': Value += 15; break;
-		case 'f': Value += 15; break;
-		default: 
-			Value = (Value >> 4);
-			Count = Finish;
-		}
+	Value = 0x00000000;
+	for (Count = 0; Count < Finish; Count++)
+	{
+		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
+			return (Value);
+		if (ASCII_to_hex[HexValue[Count]] < 0)
+			return (Value);
+		Value = (Value << 4) + ASCII_to_hex[HexValue[Count]];
 	}
 	return Value;
 }

--- a/Source/Project64/N64 System/Cheat Class.cpp
+++ b/Source/Project64/N64 System/Cheat Class.cpp
@@ -496,9 +496,9 @@ DWORD CCheats::AsciiToHex (const char * HexValue)
 	for (Count = 0; Count < 8; Count++)
 	{
 		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
-			return (Value);
+			break;
 		if (ASCII_to_hex[HexValue[Count]] < 0)
-			return (Value);
+			break;
 		Value = (Value << 4) + ASCII_to_hex[HexValue[Count]];
 	}
 	return Value;

--- a/Source/Project64/N64 System/Cheat Class.cpp
+++ b/Source/Project64/N64 System/Cheat Class.cpp
@@ -490,16 +490,10 @@ static const signed char ASCII_to_hex[128] = {
 
 DWORD CCheats::AsciiToHex (const char * HexValue)
 {
-	DWORD Count, Finish, Value;
-
-	Finish = strlen(HexValue);
-	if (Finish > 8 )
-	{
-		Finish = 8;
-	}
+	DWORD Count, Value;
 
 	Value = 0x00000000;
-	for (Count = 0; Count < Finish; Count++)
+	for (Count = 0; Count < 8; Count++)
 	{
 		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
 			return (Value);

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
@@ -383,7 +383,7 @@ static const signed char ASCII_to_hex[128] = {
      -1,0xa,0xb,0xc,0xd,0xe,0xf, -1, -1, -1, -1, -1, -1, -1, -1, -1,
      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
-DWORD CDumpMemory::AsciiToHex (const char * HexValue)
+DWORD CDumpMemory::AsciiToHex(const char * HexValue)
 {
 	DWORD Count, Value;
 

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
@@ -372,9 +372,20 @@ void CDumpMemory::DisplayDump(HWND & hParent)
 			(HWND)hParent, (DLGPROC)WinProc,(LPARAM)this);
 }
 
+static const signed char ASCII_to_hex[128] = {
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    0x0,0x1,0x2,0x3,0x4,0x5,0x6,0x7,0x8,0x9, -1, -1, -1, -1, -1, -1,
+
+     -1,0xA,0xB,0xC,0xD,0xE,0xF, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1,0xa,0xb,0xc,0xd,0xe,0xf, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+};
 DWORD CDumpMemory::AsciiToHex (const char * HexValue)
 {
-	DWORD Count, Finish, Value = 0;
+	DWORD Count, Finish, Value;
 
 	Finish = strlen(HexValue);
 	if (Finish > 8 )
@@ -382,37 +393,14 @@ DWORD CDumpMemory::AsciiToHex (const char * HexValue)
 		Finish = 8;
 	}
 
+	Value = 0x00000000;
 	for (Count = 0; Count < Finish; Count++)
 	{
-		Value = (Value << 4);
-		switch ( HexValue[Count] )
-		{
-		case '0': break;
-		case '1': Value += 1; break;
-		case '2': Value += 2; break;
-		case '3': Value += 3; break;
-		case '4': Value += 4; break;
-		case '5': Value += 5; break;
-		case '6': Value += 6; break;
-		case '7': Value += 7; break;
-		case '8': Value += 8; break;
-		case '9': Value += 9; break;
-		case 'A': Value += 10; break;
-		case 'a': Value += 10; break;
-		case 'B': Value += 11; break;
-		case 'b': Value += 11; break;
-		case 'C': Value += 12; break;
-		case 'c': Value += 12; break;
-		case 'D': Value += 13; break;
-		case 'd': Value += 13; break;
-		case 'E': Value += 14; break;
-		case 'e': Value += 14; break;
-		case 'F': Value += 15; break;
-		case 'f': Value += 15; break;
-		default:
-			Value = (Value >> 4);
-			Count = Finish;
-		}
+		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
+			return (Value);
+		if (ASCII_to_hex[HexValue[Count]] < 0)
+			return (Value);
+		Value = (Value << 4) + ASCII_to_hex[HexValue[Count]];
 	}
 	return Value;
 }

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
@@ -355,241 +355,243 @@ bool CDumpMemory::DumpMemory ( LPCSTR FileName,DumpFormat Format, DWORD StartPC,
 	}
 	return false;
 }
-//
-//CDumpMemory::CDumpMemory(CMipsMemory * MMU) :
-//	m_Window(NULL), g_MMU(MMU)
-//{
-//}
-//
-//CDumpMemory::~CDumpMemory()
-//{
-//}
-//
-//void CDumpMemory::DisplayDump(HWND & hParent)
-//{
-//	DialogBoxParam(GetModuleHandle(NULL), MAKEINTRESOURCE(IDD_Cheats_DumpMemory), 
-//			(HWND)hParent, (DLGPROC)WinProc,(LPARAM)this);
-//}
-//
-//DWORD CDumpMemory::AsciiToHex (const char * HexValue)
-//{
-//	DWORD Count, Finish, Value = 0;
-//
-//	Finish = strlen(HexValue);
-//	if (Finish > 8 )
-//	{
-//		Finish = 8;
-//	}
-//
-//	for (Count = 0; Count < Finish; Count++)
-//	{
-//		Value = (Value << 4);
-//		switch ( HexValue[Count] )
-//		{
-//		case '0': break;
-//		case '1': Value += 1; break;
-//		case '2': Value += 2; break;
-//		case '3': Value += 3; break;
-//		case '4': Value += 4; break;
-//		case '5': Value += 5; break;
-//		case '6': Value += 6; break;
-//		case '7': Value += 7; break;
-//		case '8': Value += 8; break;
-//		case '9': Value += 9; break;
-//		case 'A': Value += 10; break;
-//		case 'a': Value += 10; break;
-//		case 'B': Value += 11; break;
-//		case 'b': Value += 11; break;
-//		case 'C': Value += 12; break;
-//		case 'c': Value += 12; break;
-//		case 'D': Value += 13; break;
-//		case 'd': Value += 13; break;
-//		case 'E': Value += 14; break;
-//		case 'e': Value += 14; break;
-//		case 'F': Value += 15; break;
-//		case 'f': Value += 15; break;
-//		default: 
-//			Value = (Value >> 4);
-//			Count = Finish;
-//		}
-//	}
-//	return Value;
-//}
-//
-//int CALLBACK CDumpMemory::WinProc (HWND hDlg,DWORD uMsg,DWORD wParam, DWORD lParam) 
-//{
-//	switch (uMsg)
-//	{
-//	case WM_INITDIALOG:
-//		{
-//			CDumpMemory * _this = (CDumpMemory *)lParam;
-//			SetProp(hDlg,"Class",_this);
-//			_this->m_Window = hDlg;
-//			SetDlgItemText(hDlg,IDC_E_START_ADDR,stdstr("0x%X",m_StartAddress).c_str());
-//			SetDlgItemText(hDlg,IDC_E_END_ADDR,stdstr("0x%X",m_EndAddress).c_str());
-//			SetDlgItemText(hDlg,IDC_E_ALT_PC,"0x80000000");
-//
-//			HWND hFormatList = GetDlgItem(hDlg,IDC_FORMAT);
-//			int pos = SendMessage(hFormatList,CB_ADDSTRING,(WPARAM)0,(LPARAM)"TEXT - Disassembly + PC");
-//			SendMessage(hFormatList,CB_SETITEMDATA,(WPARAM)pos,(LPARAM)DisassemblyWithPC);
-//			SendMessage(hFormatList,CB_SETCURSEL,(WPARAM)0,(LPARAM)0);
-//
-//		}
-//		break;
-//	case WM_COMMAND:
-//		switch (LOWORD(wParam)) 
-//		{
-//		case IDC_E_START_ADDR:
-//		case IDC_E_END_ADDR:
-//		case IDC_E_ALT_PC:
-//			if (HIWORD(wParam) == EN_UPDATE)
-//			{
-//				CDumpMemory * _this = (CDumpMemory *)GetProp(hDlg,"Class");
-//
-//				TCHAR szTmp[20], szTmp2[20];
-//				DWORD Value;
-//
-//				GetDlgItemText(hDlg,LOWORD(wParam),szTmp,sizeof(szTmp));
-//				Value = szTmp[1] =='x'?AsciiToHex(&szTmp[2]):AsciiToHex(szTmp);
-//				//if (Value > Stop) 
-//				//{
-//				//	Value = Stop;
-//				//}
-//				//if (Value < Start)
-//				//{
-//				//	Value = Start;
-//				//}
-//				sprintf(szTmp2,"0x%X",Value);
-//				if (strcmp(szTmp,szTmp2) != 0)
-//				{
-//					SetDlgItemText(hDlg,LOWORD(wParam),szTmp2);
-//					if (_this->SelStop == 0) { _this->SelStop = strlen(szTmp2); _this->SelStart = _this->SelStop; }
-//					SendDlgItemMessage(hDlg,LOWORD(wParam),EM_SETSEL,(WPARAM)_this->SelStart,(LPARAM)_this->SelStop);
-//				}
-//				else
-//				{
-//					WORD NewSelStart, NewSelStop;
-//					SendDlgItemMessage(hDlg,LOWORD(wParam),EM_GETSEL,(WPARAM)&NewSelStart,(LPARAM)&NewSelStop);
-//					if (NewSelStart != 0)
-//					{
-//						_this->SelStart = NewSelStart; _this->SelStop = NewSelStop;
-//					}
-//				}
-//			}
-//			break;
-//		case IDC_BTN_CHOOSE_FILE:
-//			{
-//				CDumpMemory * _this = (CDumpMemory *)GetProp(hDlg,"Class");
-//
-//				OPENFILENAME openfilename;
-//				char FileName[_MAX_PATH],Directory[_MAX_PATH];
-//
-//				memset(&FileName, 0, sizeof(FileName));
-//				memset(&openfilename, 0, sizeof(openfilename));
-//
-//				strcpy(Directory,g_Settings->LoadString(ApplicationDir).c_str());
-//
-//				openfilename.lStructSize  = sizeof( openfilename );
-//				openfilename.hwndOwner    = hDlg;
-//				openfilename.lpstrFilter  = "Text file (*.txt)\0*.txt;\0All files (*.*)\0*.*\0";
-//				openfilename.lpstrFile    = FileName;
-//				openfilename.lpstrInitialDir    = Directory;
-//				openfilename.nMaxFile     = MAX_PATH;
-//				openfilename.Flags        = OFN_HIDEREADONLY;
-//
-//				if (GetOpenFileName (&openfilename)) 
-//				{							
-//					char drive[_MAX_DRIVE], dir[_MAX_DIR], fname[_MAX_FNAME], ext[_MAX_EXT];
-//
-//					_splitpath( FileName, drive, dir, fname, ext );
-//					if (strlen(ext) == 0)
-//					{
-//                        strcat(FileName,".txt");
-//					}
-//					SetDlgItemText(hDlg,IDC_FILENAME,FileName);
-//				}	
-//			}
-//			break;
-//		case IDCANCEL:
-//			RemoveProp(hDlg,"Class");
-//			EndDialog(hDlg,0);
-//			break;
-//		case IDOK:
-//			{
-//				CDumpMemory * _this = (CDumpMemory *)GetProp(hDlg,"Class");
-//				TCHAR szTmp[20], FileName[MAX_PATH];
-//
-//				int CurrentFormatSel = SendDlgItemMessage(hDlg,IDC_FORMAT,CB_GETCURSEL,0,0);
-//				DumpFormat Format = (DumpFormat)SendDlgItemMessage(hDlg,IDC_FORMAT,CB_GETITEMDATA,CurrentFormatSel,0);
-//
-//				GetDlgItemText(hDlg,IDC_E_START_ADDR,szTmp,sizeof(szTmp));
-//				DWORD StartPC = szTmp[1] =='x'?AsciiToHex(&szTmp[2]):AsciiToHex(szTmp);
-//				GetDlgItemText(hDlg,IDC_E_END_ADDR,szTmp,sizeof(szTmp));
-//				DWORD EndPC = szTmp[1] =='x'?AsciiToHex(&szTmp[2]):AsciiToHex(szTmp);
-//				GetDlgItemText(hDlg,IDC_E_ALT_PC,szTmp,sizeof(szTmp));
-//				DWORD DumpPC = szTmp[1] =='x'?AsciiToHex(&szTmp[2]):AsciiToHex(szTmp);
-//				GetDlgItemText(hDlg,IDC_FILENAME,FileName,sizeof(FileName));
-//
-//				if (strlen(FileName) == 0) 
-//				{
-//					g_Notify->DisplayError(L"Please Choose target file");
-//					SetFocus(GetDlgItem(hDlg,IDC_FILENAME));
-//					return false;
-//				}
-//
-//				if (SendDlgItemMessage(hDlg,IDC_USE_ALT_PC,BM_GETSTATE, 0,0) != BST_CHECKED)
-//				{
-//					DumpPC = _this->g_MMU->SystemRegisters()->PROGRAM_COUNTER;
-//				}
-//				//disable buttons
-//				EnableWindow(GetDlgItem(hDlg,IDC_E_START_ADDR),FALSE);
-//				EnableWindow(GetDlgItem(hDlg,IDC_E_END_ADDR),FALSE);
-//				EnableWindow(GetDlgItem(hDlg,IDC_E_ALT_PC),FALSE);
-//				EnableWindow(GetDlgItem(hDlg,IDC_USE_ALT_PC),FALSE);
-//				EnableWindow(GetDlgItem(hDlg,IDC_FILENAME),FALSE);
-//				EnableWindow(GetDlgItem(hDlg,IDC_BTN_CHOOSE_FILE),FALSE);
-//				EnableWindow(GetDlgItem(hDlg,IDC_FORMAT),FALSE);
-//				EnableWindow(GetDlgItem(hDlg,IDOK),FALSE);
-//				EnableWindow(GetDlgItem(hDlg,IDCANCEL),FALSE);
-//				if (!_this->DumpMemory(FileName,Format,StartPC,EndPC,DumpPC))
-//				{
-//					//enable buttons
-//					return false;
-//				}
-//			}
-//			RemoveProp(hDlg,"Class");
-//			EndDialog(hDlg,0);
-//			break;
-//		}
-//		break;
-//	default:
-//		return false;
-//	}
-//	return true;
-//}
-//
-//bool CDumpMemory::DumpMemory ( LPCSTR FileName,DumpFormat Format, DWORD StartPC, DWORD EndPC, DWORD DumpPC )
-//{
-//	switch (Format)
-//	{
-//	case DisassemblyWithPC:
-//		{
-//			CLog LogFile(FileName);
-//			if (!LogFile.IsOpen())
-//			{
-//				g_Notify->DisplayError(L"Failed to open\n%s",FileName);
-//				return false;
-//			}
-//
-//			for (COpcode OpCode(g_MMU,StartPC);  OpCode.PC() < EndPC; OpCode.Next())
-//			{
-//				LogFile.Log("%X: %s",OpCode.PC(),OpCode.Name().c_str());
-//			}
-//			m_StartAddress = StartPC;
-//			m_EndAddress   = EndPC;
-//			return true;
-//		}
-//		break;
-//	}
-//	return false;
-//}
+
+#if 0
+CDumpMemory::CDumpMemory(CMipsMemory * MMU) :
+	m_Window(NULL), g_MMU(MMU)
+{
+}
+
+CDumpMemory::~CDumpMemory()
+{
+}
+
+void CDumpMemory::DisplayDump(HWND & hParent)
+{
+	DialogBoxParam(GetModuleHandle(NULL), MAKEINTRESOURCE(IDD_Cheats_DumpMemory),
+			(HWND)hParent, (DLGPROC)WinProc,(LPARAM)this);
+}
+
+DWORD CDumpMemory::AsciiToHex (const char * HexValue)
+{
+	DWORD Count, Finish, Value = 0;
+
+	Finish = strlen(HexValue);
+	if (Finish > 8 )
+	{
+		Finish = 8;
+	}
+
+	for (Count = 0; Count < Finish; Count++)
+	{
+		Value = (Value << 4);
+		switch ( HexValue[Count] )
+		{
+		case '0': break;
+		case '1': Value += 1; break;
+		case '2': Value += 2; break;
+		case '3': Value += 3; break;
+		case '4': Value += 4; break;
+		case '5': Value += 5; break;
+		case '6': Value += 6; break;
+		case '7': Value += 7; break;
+		case '8': Value += 8; break;
+		case '9': Value += 9; break;
+		case 'A': Value += 10; break;
+		case 'a': Value += 10; break;
+		case 'B': Value += 11; break;
+		case 'b': Value += 11; break;
+		case 'C': Value += 12; break;
+		case 'c': Value += 12; break;
+		case 'D': Value += 13; break;
+		case 'd': Value += 13; break;
+		case 'E': Value += 14; break;
+		case 'e': Value += 14; break;
+		case 'F': Value += 15; break;
+		case 'f': Value += 15; break;
+		default:
+			Value = (Value >> 4);
+			Count = Finish;
+		}
+	}
+	return Value;
+}
+
+int CALLBACK CDumpMemory::WinProc (HWND hDlg,DWORD uMsg,DWORD wParam, DWORD lParam)
+{
+	switch (uMsg)
+	{
+	case WM_INITDIALOG:
+		{
+			CDumpMemory * _this = (CDumpMemory *)lParam;
+			SetProp(hDlg,"Class",_this);
+			_this->m_Window = hDlg;
+			SetDlgItemText(hDlg,IDC_E_START_ADDR,stdstr("0x%X",m_StartAddress).c_str());
+			SetDlgItemText(hDlg,IDC_E_END_ADDR,stdstr("0x%X",m_EndAddress).c_str());
+			SetDlgItemText(hDlg,IDC_E_ALT_PC,"0x80000000");
+
+			HWND hFormatList = GetDlgItem(hDlg,IDC_FORMAT);
+			int pos = SendMessage(hFormatList,CB_ADDSTRING,(WPARAM)0,(LPARAM)"TEXT - Disassembly + PC");
+			SendMessage(hFormatList,CB_SETITEMDATA,(WPARAM)pos,(LPARAM)DisassemblyWithPC);
+			SendMessage(hFormatList,CB_SETCURSEL,(WPARAM)0,(LPARAM)0);
+
+		}
+		break;
+	case WM_COMMAND:
+		switch (LOWORD(wParam))
+		{
+		case IDC_E_START_ADDR:
+		case IDC_E_END_ADDR:
+		case IDC_E_ALT_PC:
+			if (HIWORD(wParam) == EN_UPDATE)
+			{
+				CDumpMemory * _this = (CDumpMemory *)GetProp(hDlg,"Class");
+
+				TCHAR szTmp[20], szTmp2[20];
+				DWORD Value;
+
+				GetDlgItemText(hDlg,LOWORD(wParam),szTmp,sizeof(szTmp));
+				Value = szTmp[1] =='x'?AsciiToHex(&szTmp[2]):AsciiToHex(szTmp);
+				//if (Value > Stop)
+				//{
+				//	Value = Stop;
+				//}
+				//if (Value < Start)
+				//{
+				//	Value = Start;
+				//}
+				sprintf(szTmp2,"0x%X",Value);
+				if (strcmp(szTmp,szTmp2) != 0)
+				{
+					SetDlgItemText(hDlg,LOWORD(wParam),szTmp2);
+					if (_this->SelStop == 0) { _this->SelStop = strlen(szTmp2); _this->SelStart = _this->SelStop; }
+					SendDlgItemMessage(hDlg,LOWORD(wParam),EM_SETSEL,(WPARAM)_this->SelStart,(LPARAM)_this->SelStop);
+				}
+				else
+				{
+					WORD NewSelStart, NewSelStop;
+					SendDlgItemMessage(hDlg,LOWORD(wParam),EM_GETSEL,(WPARAM)&NewSelStart,(LPARAM)&NewSelStop);
+					if (NewSelStart != 0)
+					{
+						_this->SelStart = NewSelStart; _this->SelStop = NewSelStop;
+					}
+				}
+			}
+			break;
+		case IDC_BTN_CHOOSE_FILE:
+			{
+				CDumpMemory * _this = (CDumpMemory *)GetProp(hDlg,"Class");
+
+				OPENFILENAME openfilename;
+				char FileName[_MAX_PATH],Directory[_MAX_PATH];
+
+				memset(&FileName, 0, sizeof(FileName));
+				memset(&openfilename, 0, sizeof(openfilename));
+
+				strcpy(Directory,g_Settings->LoadString(ApplicationDir).c_str());
+
+				openfilename.lStructSize  = sizeof( openfilename );
+				openfilename.hwndOwner    = hDlg;
+				openfilename.lpstrFilter  = "Text file (*.txt)\0*.txt;\0All files (*.*)\0*.*\0";
+				openfilename.lpstrFile    = FileName;
+				openfilename.lpstrInitialDir    = Directory;
+				openfilename.nMaxFile     = MAX_PATH;
+				openfilename.Flags        = OFN_HIDEREADONLY;
+
+				if (GetOpenFileName (&openfilename))
+				{
+					char drive[_MAX_DRIVE], dir[_MAX_DIR], fname[_MAX_FNAME], ext[_MAX_EXT];
+
+					_splitpath( FileName, drive, dir, fname, ext );
+					if (strlen(ext) == 0)
+					{
+                        strcat(FileName,".txt");
+					}
+					SetDlgItemText(hDlg,IDC_FILENAME,FileName);
+				}
+			}
+			break;
+		case IDCANCEL:
+			RemoveProp(hDlg,"Class");
+			EndDialog(hDlg,0);
+			break;
+		case IDOK:
+			{
+				CDumpMemory * _this = (CDumpMemory *)GetProp(hDlg,"Class");
+				TCHAR szTmp[20], FileName[MAX_PATH];
+
+				int CurrentFormatSel = SendDlgItemMessage(hDlg,IDC_FORMAT,CB_GETCURSEL,0,0);
+				DumpFormat Format = (DumpFormat)SendDlgItemMessage(hDlg,IDC_FORMAT,CB_GETITEMDATA,CurrentFormatSel,0);
+
+				GetDlgItemText(hDlg,IDC_E_START_ADDR,szTmp,sizeof(szTmp));
+				DWORD StartPC = szTmp[1] =='x'?AsciiToHex(&szTmp[2]):AsciiToHex(szTmp);
+				GetDlgItemText(hDlg,IDC_E_END_ADDR,szTmp,sizeof(szTmp));
+				DWORD EndPC = szTmp[1] =='x'?AsciiToHex(&szTmp[2]):AsciiToHex(szTmp);
+				GetDlgItemText(hDlg,IDC_E_ALT_PC,szTmp,sizeof(szTmp));
+				DWORD DumpPC = szTmp[1] =='x'?AsciiToHex(&szTmp[2]):AsciiToHex(szTmp);
+				GetDlgItemText(hDlg,IDC_FILENAME,FileName,sizeof(FileName));
+
+				if (strlen(FileName) == 0)
+				{
+					g_Notify->DisplayError(L"Please Choose target file");
+					SetFocus(GetDlgItem(hDlg,IDC_FILENAME));
+					return false;
+				}
+
+				if (SendDlgItemMessage(hDlg,IDC_USE_ALT_PC,BM_GETSTATE, 0,0) != BST_CHECKED)
+				{
+					DumpPC = _this->g_MMU->SystemRegisters()->PROGRAM_COUNTER;
+				}
+				//disable buttons
+				EnableWindow(GetDlgItem(hDlg,IDC_E_START_ADDR),FALSE);
+				EnableWindow(GetDlgItem(hDlg,IDC_E_END_ADDR),FALSE);
+				EnableWindow(GetDlgItem(hDlg,IDC_E_ALT_PC),FALSE);
+				EnableWindow(GetDlgItem(hDlg,IDC_USE_ALT_PC),FALSE);
+				EnableWindow(GetDlgItem(hDlg,IDC_FILENAME),FALSE);
+				EnableWindow(GetDlgItem(hDlg,IDC_BTN_CHOOSE_FILE),FALSE);
+				EnableWindow(GetDlgItem(hDlg,IDC_FORMAT),FALSE);
+				EnableWindow(GetDlgItem(hDlg,IDOK),FALSE);
+				EnableWindow(GetDlgItem(hDlg,IDCANCEL),FALSE);
+				if (!_this->DumpMemory(FileName,Format,StartPC,EndPC,DumpPC))
+				{
+					//enable buttons
+					return false;
+				}
+			}
+			RemoveProp(hDlg,"Class");
+			EndDialog(hDlg,0);
+			break;
+		}
+		break;
+	default:
+		return false;
+	}
+	return true;
+}
+
+bool CDumpMemory::DumpMemory ( LPCSTR FileName,DumpFormat Format, DWORD StartPC, DWORD EndPC, DWORD DumpPC )
+{
+	switch (Format)
+	{
+	case DisassemblyWithPC:
+		{
+			CLog LogFile(FileName);
+			if (!LogFile.IsOpen())
+			{
+				g_Notify->DisplayError(L"Failed to open\n%s",FileName);
+				return false;
+			}
+
+			for (COpcode OpCode(g_MMU,StartPC);  OpCode.PC() < EndPC; OpCode.Next())
+			{
+				LogFile.Log("%X: %s",OpCode.PC(),OpCode.Name().c_str());
+			}
+			m_StartAddress = StartPC;
+			m_EndAddress   = EndPC;
+			return true;
+		}
+		break;
+	}
+	return false;
+}
+#endif

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
@@ -452,14 +452,18 @@ int CALLBACK CDumpMemory::WinProc (HWND hDlg,DWORD uMsg,DWORD wParam, DWORD lPar
 
 				GetDlgItemText(hDlg,LOWORD(wParam),szTmp,sizeof(szTmp));
 				Value = szTmp[1] =='x'?AsciiToHex(&szTmp[2]):AsciiToHex(szTmp);
-				//if (Value > Stop)
-				//{
-				//	Value = Stop;
-				//}
-				//if (Value < Start)
-				//{
-				//	Value = Start;
-				//}
+
+				/*
+				if (Value > Stop)
+				{
+					Value = Stop;
+				}
+				if (Value < Start)
+				{
+					Value = Start;
+				}
+				*/
+
 				sprintf(szTmp2,"0x%X",Value);
 				if (strcmp(szTmp,szTmp2) != 0)
 				{

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
@@ -391,9 +391,9 @@ DWORD CDumpMemory::AsciiToHex (const char * HexValue)
 	for (Count = 0; Count < 8; Count++)
 	{
 		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
-			return (Value);
+			break;
 		if (ASCII_to_hex[HexValue[Count]] < 0)
-			return (Value);
+			break;
 		Value = (Value << 4) + ASCII_to_hex[HexValue[Count]];
 	}
 	return Value;

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
@@ -385,16 +385,10 @@ static const signed char ASCII_to_hex[128] = {
 };
 DWORD CDumpMemory::AsciiToHex (const char * HexValue)
 {
-	DWORD Count, Finish, Value;
-
-	Finish = strlen(HexValue);
-	if (Finish > 8 )
-	{
-		Finish = 8;
-	}
+	DWORD Count, Value;
 
 	Value = 0x00000000;
-	for (Count = 0; Count < Finish; Count++)
+	for (Count = 0; Count < 8; Count++)
 	{
 		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
 			return (Value);

--- a/Source/Project64/N64 System/Mips/Memory Labels Class.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Labels Class.cpp
@@ -22,7 +22,7 @@ static const signed char ASCII_to_hex[128] = {
      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
-DWORD CMemoryLabel::AsciiToHex (char * HexValue)
+DWORD CMemoryLabel::AsciiToHex(const char * HexValue)
 {
 	DWORD Count, Value;
 

--- a/Source/Project64/N64 System/Mips/Memory Labels Class.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Labels Class.cpp
@@ -10,9 +10,21 @@
 ****************************************************************************/
 #include "stdafx.h"
 
+static const signed char ASCII_to_hex[128] = {
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    0x0,0x1,0x2,0x3,0x4,0x5,0x6,0x7,0x8,0x9, -1, -1, -1, -1, -1, -1,
+
+     -1,0xA,0xB,0xC,0xD,0xE,0xF, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1,0xa,0xb,0xc,0xd,0xe,0xf, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+};
+
 DWORD CMemoryLabel::AsciiToHex (char * HexValue)
 {
-	DWORD Count, Finish, Value = 0;
+	DWORD Count, Finish, Value;
 
 	Finish = strlen(HexValue);
 	if (Finish > 8 )
@@ -20,37 +32,14 @@ DWORD CMemoryLabel::AsciiToHex (char * HexValue)
 		Finish = 8;
 	}
 
+	Value = 0x00000000;
 	for (Count = 0; Count < Finish; Count++)
 	{
-		Value = (Value << 4);
-		switch ( HexValue[Count] )
-		{
-		case '0': break;
-		case '1': Value += 1; break;
-		case '2': Value += 2; break;
-		case '3': Value += 3; break;
-		case '4': Value += 4; break;
-		case '5': Value += 5; break;
-		case '6': Value += 6; break;
-		case '7': Value += 7; break;
-		case '8': Value += 8; break;
-		case '9': Value += 9; break;
-		case 'A': Value += 10; break;
-		case 'a': Value += 10; break;
-		case 'B': Value += 11; break;
-		case 'b': Value += 11; break;
-		case 'C': Value += 12; break;
-		case 'c': Value += 12; break;
-		case 'D': Value += 13; break;
-		case 'd': Value += 13; break;
-		case 'E': Value += 14; break;
-		case 'e': Value += 14; break;
-		case 'F': Value += 15; break;
-		case 'f': Value += 15; break;
-		default: 
-			Value = (Value >> 4);
-			Count = Finish;
-		}
+		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
+			return (Value);
+		if (ASCII_to_hex[HexValue[Count]] < 0)
+			return (Value);
+		Value = (Value << 4) + ASCII_to_hex[HexValue[Count]];
 	}
 	return Value;
 }

--- a/Source/Project64/N64 System/Mips/Memory Labels Class.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Labels Class.cpp
@@ -30,9 +30,9 @@ DWORD CMemoryLabel::AsciiToHex (char * HexValue)
 	for (Count = 0; Count < 8; Count++)
 	{
 		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
-			return (Value);
+			break;
 		if (ASCII_to_hex[HexValue[Count]] < 0)
-			return (Value);
+			break;
 		Value = (Value << 4) + ASCII_to_hex[HexValue[Count]];
 	}
 	return Value;

--- a/Source/Project64/N64 System/Mips/Memory Labels Class.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Labels Class.cpp
@@ -24,16 +24,10 @@ static const signed char ASCII_to_hex[128] = {
 
 DWORD CMemoryLabel::AsciiToHex (char * HexValue)
 {
-	DWORD Count, Finish, Value;
-
-	Finish = strlen(HexValue);
-	if (Finish > 8 )
-	{
-		Finish = 8;
-	}
+	DWORD Count, Value;
 
 	Value = 0x00000000;
-	for (Count = 0; Count < Finish; Count++)
+	for (Count = 0; Count < 8; Count++)
 	{
 		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
 			return (Value);

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -333,47 +333,39 @@ void CRomBrowser::AllocateBrushs (void)
 	}
 }
 
+static const signed char ASCII_to_hex[128] = {
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    0x0,0x1,0x2,0x3,0x4,0x5,0x6,0x7,0x8,0x9, -1, -1, -1, -1, -1, -1,
+
+     -1,0xA,0xB,0xC,0xD,0xE,0xF, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1,0xa,0xb,0xc,0xd,0xe,0xf, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+};
+
 DWORD CRomBrowser::AsciiToHex (char * HexValue)
 {
-	DWORD Count, Finish, Value = 0;
+	DWORD Count, Finish, Value;
 
 	Finish = strlen(HexValue);
-	if (Finish > 8 ) { Finish = 8; }
+	if (Finish > 8 )
+	{
+		Finish = 8;
+	}
 
+	Value = 0x00000000;
 	for (Count = 0; Count < Finish; Count++)
 	{
-		Value = (Value << 4);
-		switch( HexValue[Count] ) {
-		case '0': break;
-		case '1': Value += 1; break;
-		case '2': Value += 2; break;
-		case '3': Value += 3; break;
-		case '4': Value += 4; break;
-		case '5': Value += 5; break;
-		case '6': Value += 6; break;
-		case '7': Value += 7; break;
-		case '8': Value += 8; break;
-		case '9': Value += 9; break;
-		case 'A': Value += 10; break;
-		case 'a': Value += 10; break;
-		case 'B': Value += 11; break;
-		case 'b': Value += 11; break;
-		case 'C': Value += 12; break;
-		case 'c': Value += 12; break;
-		case 'D': Value += 13; break;
-		case 'd': Value += 13; break;
-		case 'E': Value += 14; break;
-		case 'e': Value += 14; break;
-		case 'F': Value += 15; break;
-		case 'f': Value += 15; break;
-		default: 
-			Value = (Value >> 4);
-			Count = Finish;
-		}
+		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
+			return (Value);
+		if (ASCII_to_hex[HexValue[Count]] < 0)
+			return (Value);
+		Value = (Value << 4) + ASCII_to_hex[HexValue[Count]];
 	}
 	return Value;
 }
-
 
 void CRomBrowser::CreateRomListControl (void) 
 {

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -353,9 +353,9 @@ DWORD CRomBrowser::AsciiToHex (char * HexValue)
 	for (Count = 0; Count < 8; Count++)
 	{
 		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
-			return (Value);
+			break;
 		if (ASCII_to_hex[HexValue[Count]] < 0)
-			return (Value);
+			break;
 		Value = (Value << 4) + ASCII_to_hex[HexValue[Count]];
 	}
 	return Value;

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -347,16 +347,10 @@ static const signed char ASCII_to_hex[128] = {
 
 DWORD CRomBrowser::AsciiToHex (char * HexValue)
 {
-	DWORD Count, Finish, Value;
-
-	Finish = strlen(HexValue);
-	if (Finish > 8 )
-	{
-		Finish = 8;
-	}
+	DWORD Count, Value;
 
 	Value = 0x00000000;
-	for (Count = 0; Count < Finish; Count++)
+	for (Count = 0; Count < 8; Count++)
 	{
 		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
 			return (Value);

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -345,7 +345,7 @@ static const signed char ASCII_to_hex[128] = {
      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
-DWORD CRomBrowser::AsciiToHex (char * HexValue)
+DWORD CRomBrowser::AsciiToHex(const char * HexValue)
 {
 	DWORD Count, Value;
 

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -108,7 +108,7 @@ static const signed char ASCII_to_hex[128] = {
 };
 
 /************ Functions ***********/
-DWORD AsciiToHex (char * HexValue)
+DWORD AsciiToHex(const char * HexValue)
 {
 	DWORD Count, Value;
 

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -116,9 +116,9 @@ DWORD AsciiToHex (char * HexValue)
 	for (Count = 0; Count < 8; Count++)
 	{
 		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
-			return (Value);
+			break;
 		if (ASCII_to_hex[HexValue[Count]] < 0)
-			return (Value);
+			break;
 		Value = (Value << 4) + ASCII_to_hex[HexValue[Count]];
 	}
 	return Value;

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -95,45 +95,37 @@ const char * AboutMsg ( void )
 	return Msg.c_str();
 }
 
+static const signed char ASCII_to_hex[128] = {
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    0x0,0x1,0x2,0x3,0x4,0x5,0x6,0x7,0x8,0x9, -1, -1, -1, -1, -1, -1,
+
+     -1,0xA,0xB,0xC,0xD,0xE,0xF, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1,0xa,0xb,0xc,0xd,0xe,0xf, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+};
+
 /************ Functions ***********/
 DWORD AsciiToHex (char * HexValue)
 {
-	DWORD Count, Finish, Value = 0;
+	DWORD Count, Finish, Value;
 
 	Finish = strlen(HexValue);
-	if (Finish > 8 ) { Finish = 8; }
+	if (Finish > 8 )
+	{
+		Finish = 8;
+	}
 
+	Value = 0x00000000;
 	for (Count = 0; Count < Finish; Count++)
 	{
-		Value = (Value << 4);
-		switch( HexValue[Count] )
-		{
-		case '0': break;
-		case '1': Value += 1; break;
-		case '2': Value += 2; break;
-		case '3': Value += 3; break;
-		case '4': Value += 4; break;
-		case '5': Value += 5; break;
-		case '6': Value += 6; break;
-		case '7': Value += 7; break;
-		case '8': Value += 8; break;
-		case '9': Value += 9; break;
-		case 'A': Value += 10; break;
-		case 'a': Value += 10; break;
-		case 'B': Value += 11; break;
-		case 'b': Value += 11; break;
-		case 'C': Value += 12; break;
-		case 'c': Value += 12; break;
-		case 'D': Value += 13; break;
-		case 'd': Value += 13; break;
-		case 'E': Value += 14; break;
-		case 'e': Value += 14; break;
-		case 'F': Value += 15; break;
-		case 'f': Value += 15; break;
-		default: 
-			Value = (Value >> 4);
-			Count = Finish;
-		}
+		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
+			return (Value);
+		if (ASCII_to_hex[HexValue[Count]] < 0)
+			return (Value);
+		Value = (Value << 4) + ASCII_to_hex[HexValue[Count]];
 	}
 	return Value;
 }

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -110,16 +110,10 @@ static const signed char ASCII_to_hex[128] = {
 /************ Functions ***********/
 DWORD AsciiToHex (char * HexValue)
 {
-	DWORD Count, Finish, Value;
-
-	Finish = strlen(HexValue);
-	if (Finish > 8 )
-	{
-		Finish = 8;
-	}
+	DWORD Count, Value;
 
 	Value = 0x00000000;
-	for (Count = 0; Count < Finish; Count++)
+	for (Count = 0; Count < 8; Count++)
 	{
 		if (HexValue[Count] & 0x80) /* no eighth bit in ASCII */
 			return (Value);


### PR DESCRIPTION
A few places in the RSP debugger and Project64 debuggers/other stuff is the function `AsciiToHex`.  I decided that a switch jump table was not as optimal as a 128-byte look-up table.

Unfortunately I am telling the truth when I say that I don't understand anything about C++ classes or class members (used to know them when I was like 16 but not anymore), so the obvious problem of the re-definition of this function copy-pasted across 4 or 5 different modules of Project64 is not one which I have the C++ knowledge to address.

Also I forgot to create a new branch first, so this ended up being my master branch.  Oh well.