### PR TITLE
[RSP] using standard library function `strtoul` instead of `AsciiToHex`

### DIFF
--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -96,48 +96,6 @@ const char * AboutMsg ( void )
 }
 
 /************ Functions ***********/
-DWORD AsciiToHex (char * HexValue)
-{
-	DWORD Count, Finish, Value = 0;
-
-	Finish = strlen(HexValue);
-	if (Finish > 8 ) { Finish = 8; }
-
-	for (Count = 0; Count < Finish; Count++)
-	{
-		Value = (Value << 4);
-		switch( HexValue[Count] )
-		{
-		case '0': break;
-		case '1': Value += 1; break;
-		case '2': Value += 2; break;
-		case '3': Value += 3; break;
-		case '4': Value += 4; break;
-		case '5': Value += 5; break;
-		case '6': Value += 6; break;
-		case '7': Value += 7; break;
-		case '8': Value += 8; break;
-		case '9': Value += 9; break;
-		case 'A': Value += 10; break;
-		case 'a': Value += 10; break;
-		case 'B': Value += 11; break;
-		case 'b': Value += 11; break;
-		case 'C': Value += 12; break;
-		case 'c': Value += 12; break;
-		case 'D': Value += 13; break;
-		case 'd': Value += 13; break;
-		case 'E': Value += 14; break;
-		case 'e': Value += 14; break;
-		case 'F': Value += 15; break;
-		case 'f': Value += 15; break;
-		default: 
-			Value = (Value >> 4);
-			Count = Finish;
-		}
-	}
-	return Value;
-}
-
 void DisplayError (char * Message, ...)
 {
 	char Msg[400];

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -432,7 +432,7 @@ void RefreshRSPCommands ( void )
 	if (InRSPCommandsWindow == FALSE) { return; }
 
 	GetWindowText(hAddress,AsciiAddress,sizeof(AsciiAddress));
-	location = strtoul(AsciiAddress, NULL, 16) & 0xFFFFFFFCul;
+	location = strtoul(AsciiAddress, NULL, 16) & ~3u;
 
 	if (location > 0xF88) { location = 0xF88; }
 	for (count = 0 ; count < RSP_MaxCommandLines; count += LinesUsed )
@@ -545,7 +545,7 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 			SCROLLINFO si;
 
 			GetWindowText(hAddress,Value,sizeof(Value));
-			location = strtoul(Value, NULL, 16) & 0xFFFFFFFCul;
+			location = strtoul(Value, NULL, 16) & ~3u;
 
 			switch (LOWORD(wParam))
 			{
@@ -1459,7 +1459,7 @@ void SetRSPCommandViewto ( UINT NewLocation )
 	if (InRSPCommandsWindow == FALSE) { return; }
 
 	GetWindowText(hAddress,Value,sizeof(Value));
-	location = strtoul(Value, NULL, 16) & 0xFFFFFFFCul;
+	location = strtoul(Value, NULL, 16) & ~3u;
 
 	if ( NewLocation < location || NewLocation >= location + 120 )
 	{

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -26,6 +26,7 @@
 
 #include <windows.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "opcode.h"
 #include "RSP.h"
 #include "CPU.h"
@@ -431,7 +432,7 @@ void RefreshRSPCommands ( void )
 	if (InRSPCommandsWindow == FALSE) { return; }
 
 	GetWindowText(hAddress,AsciiAddress,sizeof(AsciiAddress));
-	location = AsciiToHex(AsciiAddress) & ~3;
+	location = strtoul(AsciiAddress, NULL, 16) & 0xFFFFFFFCul;
 
 	if (location > 0xF88) { location = 0xF88; }
 	for (count = 0 ; count < RSP_MaxCommandLines; count += LinesUsed )
@@ -544,7 +545,7 @@ LRESULT CALLBACK RSP_Commands_Proc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
 			SCROLLINFO si;
 
 			GetWindowText(hAddress,Value,sizeof(Value));
-			location = AsciiToHex(Value) & ~3;
+			location = strtoul(Value, NULL, 16) & 0xFFFFFFFCul;
 
 			switch (LOWORD(wParam))
 			{
@@ -1458,7 +1459,7 @@ void SetRSPCommandViewto ( UINT NewLocation )
 	if (InRSPCommandsWindow == FALSE) { return; }
 
 	GetWindowText(hAddress,Value,sizeof(Value));
-	location = AsciiToHex(Value) & ~3;
+	location = strtoul(Value, NULL, 16) & 0xFFFFFFFCul;
 
 	if ( NewLocation < location || NewLocation >= location + 120 )
 	{

--- a/Source/RSP/Rsp.h
+++ b/Source/RSP/Rsp.h
@@ -135,7 +135,6 @@ __declspec(dllexport) void DllConfig (HWND hWnd);
 __declspec(dllexport) void EnableDebugging (BOOL Enabled);
 __declspec(dllexport) void PluginLoaded (void);
 
-DWORD AsciiToHex (char * HexValue);
 void DisplayError (char * Message, ...);
 int  GetStoredWinPos( char * WinName, DWORD * X, DWORD * Y );
 

--- a/Source/RSP/breakpoint.c
+++ b/Source/RSP/breakpoint.c
@@ -26,6 +26,7 @@
 
 #include <windows.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "rsp.h"
 #include "CPU.h"
 #include "breakpoint.h"
@@ -36,9 +37,12 @@ HWND BPoint_Win_hDlg, hRSPLocation = NULL;
 void Add_BPoint ( void )
 {
 	char Title[10];
+	unsigned long location;
 
 	GetWindowText(hRSPLocation,Title,sizeof(Title));
-	if (!AddRSP_BPoint(AsciiToHex(Title),TRUE )) {
+	location = strtoul(Title, NULL, 16) & 0xFFFFFFFFul;
+	if (!AddRSP_BPoint(location, TRUE))
+	{
 		SendMessage(hRSPLocation,EM_SETSEL,(WPARAM)0,(LPARAM)-1);
 		SetFocus(hRSPLocation);	
 	}

--- a/Source/RSP/breakpoint.c
+++ b/Source/RSP/breakpoint.c
@@ -40,7 +40,7 @@ void Add_BPoint ( void )
 	unsigned long location;
 
 	GetWindowText(hRSPLocation,Title,sizeof(Title));
-	location = strtoul(Title, NULL, 16) & 0xFFFFFFFFul;
+	location = strtoul(Title, NULL, 16);
 	if (!AddRSP_BPoint(location, TRUE))
 	{
 		SendMessage(hRSPLocation,EM_SETSEL,(WPARAM)0,(LPARAM)-1);


### PR DESCRIPTION
It was decided in an earlier pull request that it may be better to just use the standard C library function, `strtoul`, instead of multiply defining our own `AsciiToHex` function.

In essence,
```c
#include "rsp.h"
DWORD = AsciiToHex(string);
```
... has the rough equivalent of ...
```c
#include <stdlib.h>
unsigned long = strtoul(string, NULL, 16) & 0xFFFFFFFFul;
```

The `... & 0xFFFFFFFFul` is necessary because @project64 designed the AsciiToHex function to have a maximum string length of 8 characters, so it reads up to only 8 ASCII characters and therefore returns a 32-bit-or-less number.  If you pass a string longer than 8 characters to `strtoul` and `AsciiToHex`, the result could very well be different, if `sizeof(long) != sizeof(DWORD)`, in which case the internal C library implementation of `strtoul` might be working with something else like 64-bit numbers.

So this really is a preventative measure to help portability later down the road.  I'd strongly recommend against the "wait and see" approach of waiting until the end to know a problem should be fixed, because then things just pile up if you want to allow flexibility in your design--both to your benefit as well as everyone else's.  So it's best to prevent portability issues now, not wait until the last minute to solve them.

I only did this change for the RSP because I am waiting for feedback against what I have done here.  Otherwise I was planning on making the same basic changes throughout the rest of the Project64 source, so if I have something wrong in my approach for some reason then please strike now, not later.

Sanity test on the RSP commands stepper after this commit to make sure I didn't break anything:
![sp_commands](https://cloud.githubusercontent.com/assets/1396303/7340061/ad1e7e7c-ec52-11e4-8666-fa9af8f8fe77.png)
