### PR TITLE
Fixed Audio Timing Improvements

### DIFF
--- a/Source/Project64/N64 System/Mips/Audio.cpp
+++ b/Source/Project64/N64 System/Mips/Audio.cpp
@@ -59,17 +59,20 @@ void CAudio::LenChanged ( void )
 		} else {
 			m_Status |= ai_busy;
 			DWORD AudioLeft = g_SystemTimer->GetTimer(CSystemTimer::AiTimerInterrupt);
-			if (AudioLeft == 0 && m_SecondBuff == 0)
+			if (m_SecondBuff == 0)
 			{
-				WriteTraceF(TraceAudio,__FUNCTION__ ": Set Timer  AI_LEN_REG: %d m_CountsPerByte: %d",g_Reg->AI_LEN_REG,m_CountsPerByte);
-				g_SystemTimer->SetTimer(CSystemTimer::AiTimerInterrupt,g_Reg->AI_LEN_REG * m_CountsPerByte,false);
+				if (AudioLeft == 0)
+				{
+					WriteTraceF(TraceAudio, __FUNCTION__ ": Set Timer  AI_LEN_REG: %d m_CountsPerByte: %d", g_Reg->AI_LEN_REG, m_CountsPerByte);
+					g_SystemTimer->SetTimer(CSystemTimer::AiTimerInterrupt, g_Reg->AI_LEN_REG * m_CountsPerByte, false);
+				}
+				else
+				{
+					WriteTraceF(TraceAudio, __FUNCTION__ ": Increasing Second Buffer (m_SecondBuff %d Increase: %d)", m_SecondBuff, g_Reg->AI_LEN_REG);
+					m_SecondBuff += g_Reg->AI_LEN_REG;
+					m_Status |= ai_full;
+				}
 			}
-			else if (m_SecondBuff == 0)
-			{
-				WriteTraceF(TraceAudio,__FUNCTION__ ": Increasing Second Buffer (m_SecondBuff %d Increase: %d)",m_SecondBuff,g_Reg->AI_LEN_REG);
-				m_SecondBuff += g_Reg->AI_LEN_REG;
-				m_Status |= ai_full;
-			} 
 			else
 			{
 				g_Notify->BreakPoint(__FILEW__, __LINE__);


### PR DESCRIPTION
- A user-defined FAT value of 0 will cause it to calculate dynamically
- The second buffer shouldn't be part of the GetLegth returned value
- Rounded the GetLength values up and aligned to 4 bytes (16 bit stereo sample size)
- Implemented ai_busy and changed the behavior of ai_full
- Changed the second buffer behavior

I wanted to keep the default behavior the default where if the FAT value is set by the user, that is what will be used.  If we determine the calculated method is better, setting this value to 0 will cause it to calculate.

The DMA registers were handled incorrectly.  The first write triggers AI_DMA_BUSY and the second write triggers AI_FIFO_FULL.  Once the first DMA is complete, AI_FIFO_FULL is unset and an interrupt occurs.  AI_DMA_BUSY is only unset when there are no AI DMAs going.

I rounded the return on GetLength.  I've noticed in some games (Top Gear Rally) if the number of bytes returned are not a multiple of 4 it will corrupt graphics.

Let me know if you have any questions or request any changes.