### PR TITLE
Convert BOOL to bool where possible.

### DIFF
--- a/Source/Project64/N64 System/Cheat Class.cpp
+++ b/Source/Project64/N64 System/Cheat Class.cpp
@@ -219,7 +219,7 @@ void CCheats::ApplyCheats(CMipsMemory * MMU)
 		const CODES & CodeEntry = m_Codes[CurrentCheat];
 		for (size_t CurrentEntry = 0; CurrentEntry < CodeEntry.size();)
 		{
-			CurrentEntry += ApplyCheatEntry(MMU, CodeEntry,CurrentEntry,TRUE);
+			CurrentEntry += ApplyCheatEntry(MMU, CodeEntry,CurrentEntry, true);
 		}
 	}
 }
@@ -335,7 +335,7 @@ bool CCheats::IsValid16BitCode (LPCSTR CheatString) const
 	return true;
 }
 
-int CCheats::ApplyCheatEntry (CMipsMemory * MMU, const CODES & CodeEntry, int CurrentEntry, BOOL Execute )
+int CCheats::ApplyCheatEntry (CMipsMemory * MMU, const CODES & CodeEntry, int CurrentEntry, bool Execute )
 {
 	if (CurrentEntry < 0 || CurrentEntry >= (int)CodeEntry.size())
 	{
@@ -405,22 +405,22 @@ int CCheats::ApplyCheatEntry (CMipsMemory * MMU, const CODES & CodeEntry, int Cu
 	case 0xD0000000:													// Added by Witten (witten@pj64cheats.net)
 		Address = 0x80000000 | (Code.Command & 0xFFFFFF);
 		MMU->LB_VAddr(Address,bMemory);
-		if (bMemory != Code.Value) { Execute = FALSE; }
+		if (bMemory != Code.Value) { Execute = false; }
 		return ApplyCheatEntry(MMU,CodeEntry,CurrentEntry + 1,Execute) + 1;
 	case 0xD1000000:													// Added by Witten (witten@pj64cheats.net)
 		Address = 0x80000000 | (Code.Command & 0xFFFFFF);
 		MMU->LH_VAddr(Address,wMemory);
-		if (wMemory != Code.Value) { Execute = FALSE; }
+		if (wMemory != Code.Value) { Execute = false; }
 		return ApplyCheatEntry(MMU,CodeEntry,CurrentEntry + 1,Execute) + 1;
 	case 0xD2000000:													// Added by Witten (witten@pj64cheats.net)
 		Address = 0x80000000 | (Code.Command & 0xFFFFFF);
 		MMU->LB_VAddr(Address,bMemory);
-		if (bMemory == Code.Value) { Execute = FALSE; }
+		if (bMemory == Code.Value) { Execute = false; }
 		return ApplyCheatEntry(MMU,CodeEntry,CurrentEntry + 1,Execute) + 1;
 	case 0xD3000000:													// Added by Witten (witten@pj64cheats.net)
 		Address = 0x80000000 | (Code.Command & 0xFFFFFF);
 		MMU->LH_VAddr(Address,wMemory);
-		if (wMemory == Code.Value) { Execute = FALSE; }
+		if (wMemory == Code.Value) { Execute = false; }
 		return ApplyCheatEntry(MMU,CodeEntry,CurrentEntry + 1,Execute) + 1;
 
 	// Xplorer64 (Author: Witten)
@@ -455,22 +455,22 @@ int CCheats::ApplyCheatEntry (CMipsMemory * MMU, const CODES & CodeEntry, int Cu
 	case 0xB8000000:
 		Address = 0x80000000 | (ConvertXP64Address(Code.Command) & 0xFFFFFF);
 		MMU->LB_VAddr(Address,bMemory);
-		if (bMemory != ConvertXP64Value(Code.Value)) { Execute = FALSE; }
+		if (bMemory != ConvertXP64Value(Code.Value)) { Execute = false; }
 		return ApplyCheatEntry(MMU,CodeEntry,CurrentEntry + 1,Execute) + 1;
 	case 0xB9000000:
 		Address = 0x80000000 | (ConvertXP64Address(Code.Command) & 0xFFFFFF);
 		MMU->LH_VAddr(Address,wMemory);
-		if (wMemory != ConvertXP64Value(Code.Value)) { Execute = FALSE; }
+		if (wMemory != ConvertXP64Value(Code.Value)) { Execute = false; }
 		return ApplyCheatEntry(MMU,CodeEntry,CurrentEntry + 1,Execute) + 1;
 	case 0xBA000000:
 		Address = 0x80000000 | (ConvertXP64Address(Code.Command) & 0xFFFFFF);
 		MMU->LB_VAddr(Address,bMemory);
-		if (bMemory == ConvertXP64Value(Code.Value)) { Execute = FALSE; }
+		if (bMemory == ConvertXP64Value(Code.Value)) { Execute = false; }
 		return ApplyCheatEntry(MMU,CodeEntry,CurrentEntry + 1,Execute) + 1;
 	case 0xBB000000:
 		Address = 0x80000000 | (ConvertXP64Address(Code.Command) & 0xFFFFFF);
 		MMU->LH_VAddr(Address,wMemory);
-		if (wMemory == ConvertXP64Value(Code.Value)) { Execute = FALSE; }
+		if (wMemory == ConvertXP64Value(Code.Value)) { Execute = false; }
 		return ApplyCheatEntry(MMU,CodeEntry,CurrentEntry + 1,Execute) + 1;
 	case 0: return MaxGSEntries; break;
 	}

--- a/Source/Project64/N64 System/Cheat Class.h
+++ b/Source/Project64/N64 System/Cheat Class.h
@@ -69,7 +69,7 @@ private:
 	void CheckParentStatus         ( HWND hParent );
 	static stdstr ReadCodeString   ( HWND hDlg, bool &validcodes, bool &validoption, bool &nooptions, int &codeformat );
 	static stdstr ReadOptionsString( HWND hDlg, bool &validcodes, bool &validoptions, bool &nooptions, int &codeformat );
-	int ApplyCheatEntry (CMipsMemory * MMU,const CODES & CodeEntry, int CurrentEntry, BOOL Execute );
+	int ApplyCheatEntry (CMipsMemory * MMU,const CODES & CodeEntry, int CurrentEntry, bool Execute );
 	void RecordCheatValues ( HWND hDlg );
 	bool CheatChanged ( HWND hDlg );
 	bool IsValid16BitCode ( LPCSTR CheatString ) const;

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Search.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Search.cpp
@@ -306,7 +306,7 @@ void CDebugMemorySearch::SearchForValue( void )
 			SearchResultItem & Result = m_SearchResult[ItemId];
 			
 			DWORD NewValue = 0;
-			BOOL valid = false;
+			bool valid = false;
 
 			switch (Size)
 			{
@@ -441,7 +441,7 @@ void CDebugMemorySearch::SearchForUnknown()
 			
 			bool UpdateResult = false;
 			DWORD NewValue = 0;
-			BOOL valid = false;
+			bool valid = false;
 
 			switch (Size)
 			{

--- a/Source/Project64/N64 System/Interpreter/Interpreter CPU.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter CPU.cpp
@@ -25,7 +25,7 @@ bool DelaySlotEffectsCompare (DWORD PC, DWORD Reg1, DWORD Reg2)
 	{
 		//g_Notify->DisplayError(L"Failed to load word 2");
 		//ExitThread(0);
-		return TRUE;
+		return true;
 	}
 
 	switch (Command.op)
@@ -68,15 +68,11 @@ bool DelaySlotEffectsCompare (DWORD PC, DWORD Reg1, DWORD Reg2)
 		case R4300i_SPECIAL_DSRA32:
 			if (Command.rd == 0)
 			{
-				return FALSE;
+				return false;
 			}
-			if (Command.rd == Reg1)
+			if (Command.rd == Reg1 || Command.rd == Reg2)
 			{
-				return TRUE;
-			}
-			if (Command.rd == Reg2)
-			{
-				return TRUE;
+				return true;
 			}
 			break;
 		case R4300i_SPECIAL_MULT:
@@ -93,7 +89,7 @@ bool DelaySlotEffectsCompare (DWORD PC, DWORD Reg1, DWORD Reg2)
 			{
 				g_Notify->DisplayError(L"Does %s effect Delay slot at %X?",R4300iOpcodeName(Command.Hex,PC+4), PC);
 			}
-			return TRUE;
+			return true;
 		}
 		break;
 	case R4300i_CP0:
@@ -103,21 +99,17 @@ bool DelaySlotEffectsCompare (DWORD PC, DWORD Reg1, DWORD Reg2)
 		case R4300i_COP0_MF:
 			if (Command.rt == 0)
 			{
-				return FALSE;
+				return false;
 			}
-			if (Command.rt == Reg1)
+			if (Command.rt == Reg1 || Command.rt == Reg2)
 			{
-				return TRUE;
-			}
-			if (Command.rt == Reg2)
-			{
-				return TRUE;
+				return true;
 			}
 			break;
 		default:
 			if ( (Command.rs & 0x10 ) != 0 )
 			{
-				switch ( Command.funct )
+				switch (Command.funct)
 				{
 				case R4300i_COP0_CO_TLBR: break;
 				case R4300i_COP0_CO_TLBWI: break;
@@ -128,7 +120,7 @@ bool DelaySlotEffectsCompare (DWORD PC, DWORD Reg1, DWORD Reg2)
 					{
 						g_Notify->DisplayError(L"Does %s effect Delay slot at %X?\n6",R4300iOpcodeName(Command.Hex,PC+4), PC);
 					}
-					return TRUE;
+					return true;
 				}
 			}
 			else
@@ -137,7 +129,7 @@ bool DelaySlotEffectsCompare (DWORD PC, DWORD Reg1, DWORD Reg2)
 				{
 					g_Notify->DisplayError(L"Does %s effect Delay slot at %X?\n7",R4300iOpcodeName(Command.Hex,PC+4), PC);
 				}
-				return TRUE;
+				return true;
 			}
 		}
 		break;
@@ -147,15 +139,11 @@ bool DelaySlotEffectsCompare (DWORD PC, DWORD Reg1, DWORD Reg2)
 		case R4300i_COP1_MF:
 			if (Command.rt == 0)
 			{
-				return FALSE;
+				return false;
 			}
-			if (Command.rt == Reg1)
+			if (Command.rt == Reg1 || Command.rt == Reg2)
 			{
-				return TRUE;
-			}
-			if (Command.rt == Reg2)
-			{
-				return TRUE;
+				return true;
 			}
 			break;
 		case R4300i_COP1_CF: break;
@@ -170,7 +158,7 @@ bool DelaySlotEffectsCompare (DWORD PC, DWORD Reg1, DWORD Reg2)
 			{
 				g_Notify->DisplayError(L"Does %s effect Delay slot at %X?",R4300iOpcodeName(Command.Hex,PC+4), PC);
 			}
-			return TRUE;
+			return true;
 		}
 		break;
 	case R4300i_ANDI:
@@ -197,15 +185,11 @@ bool DelaySlotEffectsCompare (DWORD PC, DWORD Reg1, DWORD Reg2)
 	case R4300i_LDC1:
 		if (Command.rt == 0)
 		{
-			return FALSE;
+			return false;
 		}
-		if (Command.rt == Reg1)
+		if (Command.rt == Reg1 || Command.rt == Reg2)
 		{
-			return TRUE;
-		}
-		if (Command.rt == Reg2)
-		{
-			return TRUE;
+			return true;
 		}
 		break;
 	case R4300i_CACHE: break;
@@ -222,14 +206,14 @@ bool DelaySlotEffectsCompare (DWORD PC, DWORD Reg1, DWORD Reg2)
 		{
 			g_Notify->DisplayError(L"Does %s effect Delay slot at %X?",R4300iOpcodeName(Command.Hex,PC+4), PC);
 		}
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+	return false;
 }
 
 void CInterpreterCPU::BuildCPU()
 { 
-	R4300iOp::m_TestTimer       = FALSE;
+	R4300iOp::m_TestTimer       = false;
 	R4300iOp::m_NextInstruction = NORMAL;
 	R4300iOp::m_JumpToLocation  = 0;
 	
@@ -283,8 +267,8 @@ void CInterpreterCPU::ExecuteCPU()
 	DWORD  & PROGRAM_COUNTER = *_PROGRAM_COUNTER;
 	OPCODE & Opcode          = R4300iOp::m_Opcode;
 	DWORD  & JumpToLocation  = R4300iOp::m_JumpToLocation;
-	BOOL   & TestTimer       = R4300iOp::m_TestTimer;
-	const BOOL & bDoSomething= g_SystemEvents->DoSomething();
+	bool   & TestTimer       = R4300iOp::m_TestTimer;
+	const bool & bDoSomething= g_SystemEvents->DoSomething();
 	DWORD CountPerOp         = g_System->CountPerOp();
 	int & NextTimer = *g_NextTimer;
 	
@@ -323,7 +307,7 @@ void CInterpreterCPU::ExecuteCPU()
 						R4300iOp::m_NextInstruction = NORMAL;
 						if (CheckTimer)
 						{
-							TestTimer = FALSE;
+							TestTimer = false;
 							if (NextTimer < 0) 
 							{ 
 								g_SystemTimer->TimerDone();
@@ -369,8 +353,8 @@ void CInterpreterCPU::ExecuteOps(int Cycles)
 	DWORD  & PROGRAM_COUNTER = *_PROGRAM_COUNTER;
 	OPCODE & Opcode          = R4300iOp::m_Opcode;
 	DWORD  & JumpToLocation  = R4300iOp::m_JumpToLocation;
-	BOOL   & TestTimer       = R4300iOp::m_TestTimer;
-	const BOOL & DoSomething     = g_SystemEvents->DoSomething();
+	bool   & TestTimer       = R4300iOp::m_TestTimer;
+	const bool & DoSomething = g_SystemEvents->DoSomething();
 	DWORD CountPerOp         = g_System->CountPerOp();
 	
 	__try 
@@ -433,9 +417,9 @@ void CInterpreterCPU::ExecuteOps(int Cycles)
 						R4300iOp::m_NextInstruction = NORMAL;
 						if (CheckTimer)
 						{
-							TestTimer = FALSE;
-							if (*g_NextTimer < 0) 
-							{ 
+							TestTimer = false;
+							if (*g_NextTimer < 0)
+							{
 								g_SystemTimer->TimerDone();
 							}
 							if (DoSomething)

--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops 32.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops 32.cpp
@@ -906,7 +906,7 @@ void R4300iOp32::LH()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 1) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 	if (!g_MMU->LH_VAddr(Address,_GPR[m_Opcode.rt].UHW[0]))
 	{
@@ -948,7 +948,7 @@ void R4300iOp32::LW()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 
 	if (LogOptions.GenerateLog)
@@ -992,7 +992,7 @@ void R4300iOp32::LHU()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 1) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 	if (!g_MMU->LH_VAddr(Address,_GPR[m_Opcode.rt].UHW[0]))
 	{
@@ -1034,7 +1034,7 @@ void R4300iOp32::LWU()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 
 	if (!g_MMU->LW_VAddr(Address,_GPR[m_Opcode.rt].UW[0]))
@@ -1057,7 +1057,7 @@ void R4300iOp32::LL()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 
 	if (!g_MMU->LW_VAddr(Address,_GPR[m_Opcode.rt].UW[0]))
@@ -1111,7 +1111,7 @@ void R4300iOp32::SPECIAL_JALR()
 	m_NextInstruction = DELAY_SLOT;
 	m_JumpToLocation = _GPR[m_Opcode.rs].UW[0];
 	_GPR[m_Opcode.rd].W[0] = (long)((*_PROGRAM_COUNTER) + 8);
-	m_TestTimer = TRUE;
+	m_TestTimer = true;
 }
 
 void R4300iOp32::SPECIAL_ADD()

--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
@@ -14,7 +14,7 @@
 void InPermLoop();
 void TestInterpreterJump(DWORD PC, DWORD TargetPC, int Reg1, int Reg2);
 
-BOOL        R4300iOp::m_TestTimer = false;
+bool        R4300iOp::m_TestTimer = false;
 DWORD       R4300iOp::m_NextInstruction;
 OPCODE      R4300iOp::m_Opcode;
 DWORD       R4300iOp::m_JumpToLocation;
@@ -719,7 +719,7 @@ void TestInterpreterJump (DWORD PC, DWORD TargetPC, int Reg1, int Reg2)
 		return;
 	}
 	R4300iOp::m_NextInstruction = PERMLOOP_DO_DELAY;
-	R4300iOp::m_TestTimer = TRUE;
+	R4300iOp::m_TestTimer = true;
 }
 
 /************************* Opcode functions *************************/
@@ -1071,7 +1071,7 @@ void R4300iOp::LH()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 1) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 	if (!g_MMU->LH_VAddr(Address,_GPR[m_Opcode.rt].UHW[0]))
 	{
@@ -1113,7 +1113,7 @@ void R4300iOp::LW()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 
 	if (LogOptions.GenerateLog)
@@ -1157,7 +1157,7 @@ void R4300iOp::LHU()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 1) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 	if (!g_MMU->LH_VAddr(Address,_GPR[m_Opcode.rt].UHW[0]))
 	{
@@ -1199,7 +1199,7 @@ void R4300iOp::LWU()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 
 	if (!g_MMU->LW_VAddr(Address,_GPR[m_Opcode.rt].UW[0]))
@@ -1237,7 +1237,7 @@ void R4300iOp::SH()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 1) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,FALSE);
+		ADDRESS_ERROR_EXCEPTION(Address, false);
 	}
 	if (!g_MMU->SH_VAddr(Address,_GPR[m_Opcode.rt].UHW[0])) 
 	{
@@ -1294,7 +1294,7 @@ void R4300iOp::SW()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,FALSE);
+		ADDRESS_ERROR_EXCEPTION(Address, false);
 	}
 	if (LogOptions.GenerateLog) 
 	{ 
@@ -1459,7 +1459,7 @@ void R4300iOp::LL()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 
 	if (!g_MMU->LW_VAddr(Address,_GPR[m_Opcode.rt].UW[0])) 
@@ -1483,7 +1483,7 @@ void R4300iOp::LWC1()
 	TEST_COP1_USABLE_EXCEPTION
 	if ((Address & 3) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 	if (!g_MMU->LW_VAddr(Address,*(DWORD *)_FPR_S[m_Opcode.ft]))
 	{
@@ -1500,7 +1500,7 @@ void R4300iOp::SC()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 3) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,FALSE);
+		ADDRESS_ERROR_EXCEPTION(Address, false);
 	}
 	Log_SW((*_PROGRAM_COUNTER),Address,_GPR[m_Opcode.rt].UW[0]);
 	if ((*_LLBit) == 1) 
@@ -1522,7 +1522,7 @@ void R4300iOp::LD()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 7) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 	if (!g_MMU->LD_VAddr(Address,_GPR[m_Opcode.rt].UDW)) 
 	{
@@ -1552,7 +1552,7 @@ void R4300iOp::LDC1()
 	TEST_COP1_USABLE_EXCEPTION
 	if ((Address & 7) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,TRUE);
+		ADDRESS_ERROR_EXCEPTION(Address, true);
 	}
 	if (!g_MMU->LD_VAddr(Address,*(unsigned __int64 *)_FPR_D[m_Opcode.ft]))
 	{
@@ -1573,7 +1573,7 @@ void R4300iOp::SWC1()
 	TEST_COP1_USABLE_EXCEPTION
 	if ((Address & 3) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,FALSE);
+		ADDRESS_ERROR_EXCEPTION(Address, false);
 	}
 
 	if (!g_MMU->SW_VAddr(Address,*(DWORD *)_FPR_S[m_Opcode.ft])) 
@@ -1596,7 +1596,7 @@ void R4300iOp::SDC1()
 	TEST_COP1_USABLE_EXCEPTION
 	if ((Address & 7) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,FALSE);
+		ADDRESS_ERROR_EXCEPTION(Address, false);
 	}
 	if (!g_MMU->SD_VAddr(Address,*(__int64 *)_FPR_D[m_Opcode.ft])) 
 	{
@@ -1616,7 +1616,7 @@ void R4300iOp::SD()
 	DWORD Address =  _GPR[m_Opcode.base].UW[0] + (short)m_Opcode.offset;	
 	if ((Address & 7) != 0)
 	{
-		ADDRESS_ERROR_EXCEPTION(Address,FALSE);
+		ADDRESS_ERROR_EXCEPTION(Address, false);
 	}
 	if (!g_MMU->SD_VAddr(Address,_GPR[m_Opcode.rt].UDW)) 
 	{
@@ -1665,7 +1665,7 @@ void R4300iOp::SPECIAL_JR()
 {
 	m_NextInstruction = DELAY_SLOT;
 	m_JumpToLocation = _GPR[m_Opcode.rs].UW[0];
-	m_TestTimer = TRUE;
+	m_TestTimer = true;
 }
 
 void R4300iOp::SPECIAL_JALR()
@@ -1673,7 +1673,7 @@ void R4300iOp::SPECIAL_JALR()
 	m_NextInstruction = DELAY_SLOT;
 	m_JumpToLocation = _GPR[m_Opcode.rs].UW[0];
 	_GPR[m_Opcode.rd].DW = (long)((*_PROGRAM_COUNTER) + 8);
-	m_TestTimer = TRUE;
+	m_TestTimer = true;
 }
 
 void R4300iOp::SPECIAL_SYSCALL()
@@ -2196,7 +2196,7 @@ void R4300iOp::COP0_CO_TLBWI()
 	{
 		return;
 	}
-	g_TLB->WriteEntry(g_Reg->INDEX_REGISTER & 0x1F,FALSE);
+	g_TLB->WriteEntry(g_Reg->INDEX_REGISTER & 0x1F, false);
 }
 
 void R4300iOp::COP0_CO_TLBWR()
@@ -2232,7 +2232,7 @@ void R4300iOp::COP0_CO_ERET()
 	}
 	(*_LLBit) = 0;
 	g_Reg->CheckInterrupts();
-	m_TestTimer = TRUE;
+	m_TestTimer = true;
 }
 
 /************************** COP1 functions **************************/
@@ -2515,7 +2515,8 @@ void R4300iOp::COP1_S_CVT_L()
 
 void R4300iOp::COP1_S_CMP()
 {
-	int less, equal, unorded, condition;
+	bool less, equal, unorded;
+	int condition;
 	float Temp0, Temp1;
 
 	TEST_COP1_USABLE_EXCEPTION
@@ -2529,9 +2530,9 @@ void R4300iOp::COP1_S_CMP()
 		{
 			g_Notify->DisplayError(__FUNCTIONW__ L": Nan ?");
 		}
-		less = FALSE;
-		equal = FALSE;
-		unorded = TRUE;
+		less = false;
+		equal = false;
+		unorded = true;
 		if ((m_Opcode.funct & 8) != 0) 
 		{
 			if (bHaveDebugger())
@@ -2544,7 +2545,7 @@ void R4300iOp::COP1_S_CMP()
 	{
 		less = Temp0 < Temp1;
 		equal = Temp0 == Temp1;
-		unorded = FALSE;
+		unorded = false;
 	}
 	
 	condition = ((m_Opcode.funct & 4) && less) | ((m_Opcode.funct & 2) && equal) | 
@@ -2710,9 +2711,10 @@ void R4300iOp::COP1_D_CVT_L()
 	Double_RoundToInteger64(&*(unsigned __int64 *)_FPR_D[m_Opcode.fd],&*(double *)_FPR_D[m_Opcode.fs]);
 }
 
-void R4300iOp::COP1_D_CMP() 
+void R4300iOp::COP1_D_CMP()
 {
-	int less, equal, unorded, condition;
+	bool less, equal, unorded;
+	int condition;
 	MIPS_DWORD Temp0, Temp1;
 
 	TEST_COP1_USABLE_EXCEPTION
@@ -2726,9 +2728,9 @@ void R4300iOp::COP1_D_CMP()
 		{
 			g_Notify->DisplayError(__FUNCTIONW__ L": Nan ?");
 		}
-		less = FALSE;
-		equal = FALSE;
-		unorded = TRUE;
+		less = false;
+		equal = false;
+		unorded = true;
 		if ((m_Opcode.funct & 8) != 0) 
 		{
 			if (bHaveDebugger())
@@ -2737,11 +2739,11 @@ void R4300iOp::COP1_D_CMP()
 			}
 		}
 	} 
-    else 
-    {
+	else 
+	{
 		less = Temp0.D < Temp1.D;
 		equal = Temp0.D == Temp1.D;
-		unorded = FALSE;
+		unorded = false;
 	}
 	
 	condition = ((m_Opcode.funct & 4) && less) | ((m_Opcode.funct & 2) && equal) | 
@@ -2754,7 +2756,7 @@ void R4300iOp::COP1_D_CMP()
 	else
 	{
 		_FPCR[31] &= ~FPCSR_C;
-	}	
+	}
 }
 
 /************************** COP1: W functions ************************/

--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops.h
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops.h
@@ -203,7 +203,7 @@ public:
 
 	static Func* BuildInterpreter();
 
-	static BOOL        m_TestTimer;
+	static bool        m_TestTimer;
 	static DWORD       m_NextInstruction;
 	static OPCODE      m_Opcode;
 	static DWORD       m_JumpToLocation;

--- a/Source/Project64/N64 System/Mips/Memory Class.h
+++ b/Source/Project64/N64 System/Mips/Memory Class.h
@@ -25,25 +25,25 @@ public:
 	virtual BYTE * Imem     () = 0;
 	virtual BYTE * PifRam   () = 0;
 	
-	virtual BOOL  LB_VAddr     ( DWORD VAddr, BYTE & Value ) = 0;
-	virtual BOOL  LH_VAddr     ( DWORD VAddr, WORD & Value ) = 0; 
-	virtual BOOL  LW_VAddr     ( DWORD VAddr, DWORD & Value ) = 0;
-	virtual BOOL  LD_VAddr     ( DWORD VAddr, QWORD & Value ) = 0;
+	virtual bool  LB_VAddr     ( DWORD VAddr, BYTE & Value ) = 0;
+	virtual bool  LH_VAddr     ( DWORD VAddr, WORD & Value ) = 0; 
+	virtual bool  LW_VAddr     ( DWORD VAddr, DWORD & Value ) = 0;
+	virtual bool  LD_VAddr     ( DWORD VAddr, QWORD & Value ) = 0;
 
-	virtual BOOL  LB_PAddr     ( DWORD PAddr, BYTE & Value ) = 0;
-	virtual BOOL  LH_PAddr     ( DWORD PAddr, WORD & Value ) = 0; 
-	virtual BOOL  LW_PAddr     ( DWORD PAddr, DWORD & Value ) = 0;
-	virtual BOOL  LD_PAddr     ( DWORD PAddr, QWORD & Value ) = 0;
+	virtual bool  LB_PAddr     ( DWORD PAddr, BYTE & Value ) = 0;
+	virtual bool  LH_PAddr     ( DWORD PAddr, WORD & Value ) = 0; 
+	virtual bool  LW_PAddr     ( DWORD PAddr, DWORD & Value ) = 0;
+	virtual bool  LD_PAddr     ( DWORD PAddr, QWORD & Value ) = 0;
 
-	virtual BOOL  SB_VAddr     ( DWORD VAddr, BYTE Value ) = 0;
-	virtual BOOL  SH_VAddr     ( DWORD VAddr, WORD Value ) = 0;
-	virtual BOOL  SW_VAddr     ( DWORD VAddr, DWORD Value ) = 0;
-	virtual BOOL  SD_VAddr     ( DWORD VAddr, QWORD Value ) = 0;
+	virtual bool  SB_VAddr     ( DWORD VAddr, BYTE Value ) = 0;
+	virtual bool  SH_VAddr     ( DWORD VAddr, WORD Value ) = 0;
+	virtual bool  SW_VAddr     ( DWORD VAddr, DWORD Value ) = 0;
+	virtual bool  SD_VAddr     ( DWORD VAddr, QWORD Value ) = 0;
 
-	virtual BOOL  SB_PAddr     ( DWORD PAddr, BYTE Value ) = 0;
-	virtual BOOL  SH_PAddr     ( DWORD PAddr, WORD Value ) = 0;
-	virtual BOOL  SW_PAddr     ( DWORD PAddr, DWORD Value ) = 0;
-	virtual BOOL  SD_PAddr     ( DWORD PAddr, QWORD Value ) = 0;
+	virtual bool  SB_PAddr     ( DWORD PAddr, BYTE Value ) = 0;
+	virtual bool  SH_PAddr     ( DWORD PAddr, WORD Value ) = 0;
+	virtual bool  SW_PAddr     ( DWORD PAddr, DWORD Value ) = 0;
+	virtual bool  SD_PAddr     ( DWORD PAddr, QWORD Value ) = 0;
 
 	virtual bool  ValidVaddr   ( DWORD VAddr ) const = 0;
 

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -96,7 +96,7 @@ void CMipsMemoryVM::FreeReservedMemory()
 	}
 }
 
-BOOL CMipsMemoryVM::Initialize()
+bool CMipsMemoryVM::Initialize()
 {
 	if (m_RDRAM != NULL)
 	{
@@ -246,27 +246,29 @@ BYTE * CMipsMemoryVM::PifRam()
 	return m_PifRam;
 }
 
-BOOL CMipsMemoryVM::LB_VAddr ( DWORD VAddr, BYTE & Value ) 
+bool CMipsMemoryVM::LB_VAddr(DWORD VAddr, BYTE& Value)
 {
 	if (m_TLB_ReadMap[VAddr >> 12] == 0)
 	{
-		return FALSE;
+		return false;
 	}
-	Value = *(BYTE *)(m_TLB_ReadMap[VAddr >> 12] + (VAddr ^ 3));
-	return TRUE;
+
+	Value = *(BYTE*)(m_TLB_ReadMap[VAddr >> 12] + (VAddr ^ 3));
+	return true;
 }
 
-BOOL CMipsMemoryVM::LH_VAddr ( DWORD VAddr, WORD & Value ) 
+bool CMipsMemoryVM::LH_VAddr(DWORD VAddr, WORD& Value)
 {
 	if (m_TLB_ReadMap[VAddr >> 12] == 0)
 	{
-		return FALSE;
+		return false;
 	}
-	Value = *(WORD *)(m_TLB_ReadMap[VAddr >> 12] + (VAddr ^ 2));
-	return TRUE;
+
+	Value = *(WORD*)(m_TLB_ReadMap[VAddr >> 12] + (VAddr ^ 2));
+	return true;
 }
 
-BOOL CMipsMemoryVM::LW_VAddr ( DWORD VAddr, DWORD & Value ) 
+bool CMipsMemoryVM::LW_VAddr(DWORD VAddr, DWORD& Value)
 {
 	if (VAddr >= 0xA3F00000 && VAddr < 0xC0000000)
 	{
@@ -277,12 +279,14 @@ BOOL CMipsMemoryVM::LW_VAddr ( DWORD VAddr, DWORD & Value )
 			return true;
 		}
 	}
-	BYTE * BaseAddress = (BYTE *)m_TLB_ReadMap[VAddr >> 12];
-	if (BaseAddress == 0)
+
+	BYTE* BaseAddress = (BYTE*)m_TLB_ReadMap[VAddr >> 12];
+	if (BaseAddress == NULL)
 	{
-		return FALSE;
+		return false;
 	}
-	Value = *(DWORD *)(BaseAddress + VAddr);
+
+	Value = *(DWORD*)(BaseAddress + VAddr);
 
 //	if (LookUpMode == FuncFind_ChangeMemory)
 //	{
@@ -295,99 +299,110 @@ BOOL CMipsMemoryVM::LW_VAddr ( DWORD VAddr, DWORD & Value )
 	return true;
 }
 
-BOOL CMipsMemoryVM::LD_VAddr ( DWORD VAddr, QWORD & Value ) 
+bool CMipsMemoryVM::LD_VAddr(DWORD VAddr, QWORD& Value)
 {
 	if (m_TLB_ReadMap[VAddr >> 12] == 0)
 	{
-		return FALSE;
+		return false;
 	}
-	*((DWORD *)(&Value) + 1) = *(DWORD *)(m_TLB_ReadMap[VAddr >> 12] + VAddr);
-	*((DWORD *)(&Value)) = *(DWORD *)(m_TLB_ReadMap[VAddr >> 12] + VAddr + 4);
-	return TRUE;
+
+	*((DWORD*)(&Value) + 1) = *(DWORD*)(m_TLB_ReadMap[VAddr >> 12] + VAddr);
+	*((DWORD*)(&Value) + 0) = *(DWORD*)(m_TLB_ReadMap[VAddr >> 12] + VAddr + 4);
+	return true;
 }
 
-BOOL CMipsMemoryVM::LB_PAddr ( DWORD PAddr, BYTE & Value ) 
+bool CMipsMemoryVM::LB_PAddr(DWORD PAddr, BYTE& Value)
 {
 	if (PAddr < RdramSize())
 	{
-		Value = *(BYTE *)(m_RDRAM + (PAddr ^ 3));
+		Value = *(BYTE*)(m_RDRAM + (PAddr ^ 3));
 		return true;
 	}
+
 	if (PAddr > 0x18000000)
 	{
 		return false;
 	}
+
 	g_Notify->BreakPoint(__FILEW__,__LINE__);
 	return false;
 }
 
-BOOL CMipsMemoryVM::LH_PAddr ( DWORD PAddr, WORD & Value ) 
+bool CMipsMemoryVM::LH_PAddr(DWORD PAddr, WORD& Value)
 {
 	if (PAddr < RdramSize())
 	{
-		Value = *(WORD *)(m_RDRAM + (PAddr ^ 2));
+		Value = *(WORD*)(m_RDRAM + (PAddr ^ 2));
 		return true;
 	}
+
 	if (PAddr > 0x18000000)
 	{
 		return false;
 	}
+
 	g_Notify->BreakPoint(__FILEW__,__LINE__);
 	return false;
 }
 
-BOOL CMipsMemoryVM::LW_PAddr ( DWORD PAddr, DWORD & Value ) 
+bool CMipsMemoryVM::LW_PAddr(DWORD PAddr, DWORD& Value)
 {
 	if (PAddr < RdramSize())
 	{
-		Value = *(DWORD *)(m_RDRAM + PAddr);
+		Value = *(DWORD*)(m_RDRAM + PAddr);
 		return true;
 	}
+
 	if (PAddr > 0x18000000)
 	{
 		return false;
 	}
+
 	g_Notify->BreakPoint(__FILEW__,__LINE__);
 	return false;
 }
 
-BOOL CMipsMemoryVM::LD_PAddr ( DWORD PAddr, QWORD & Value ) 
+bool CMipsMemoryVM::LD_PAddr(DWORD PAddr, QWORD& Value)
 {
 	if (PAddr < RdramSize())
 	{
-		*((DWORD *)(&Value) + 1) = *(DWORD *)(m_RDRAM + PAddr);
-		*((DWORD *)(&Value)) = *(DWORD *)(m_RDRAM + PAddr + 4);
+		*((DWORD*)(&Value) + 1) = *(DWORD*)(m_RDRAM + PAddr);
+		*((DWORD*)(&Value) + 0) = *(DWORD*)(m_RDRAM + PAddr + 4);
 		return true;
 	}
+
 	if (PAddr > 0x18000000)
 	{
 		return false;
 	}
+
 	g_Notify->BreakPoint(__FILEW__,__LINE__);
 	return false;
 }
 
-BOOL CMipsMemoryVM::SB_VAddr ( DWORD VAddr, BYTE Value ) 
+bool CMipsMemoryVM::SB_VAddr(DWORD VAddr, BYTE Value)
 {
 	if (m_TLB_WriteMap[VAddr >> 12] == 0)
 	{
-		return FALSE;
+		return false;
 	}
-	*(BYTE *)(m_TLB_WriteMap[VAddr >> 12] + (VAddr ^ 3)) = Value;
-	return TRUE;
+
+	*(BYTE*)(m_TLB_WriteMap[VAddr >> 12] + (VAddr ^ 3)) = Value;
+	return true;
 }
 
-BOOL CMipsMemoryVM::SH_VAddr ( DWORD VAddr, WORD Value )
+bool CMipsMemoryVM::SH_VAddr(DWORD VAddr, WORD Value)
 {
 	if (m_TLB_WriteMap[VAddr >> 12] == 0)
 	{
-		return FALSE;
+		return false;
 	}
-	*(WORD *)(m_TLB_WriteMap[VAddr >> 12] + (VAddr ^ 2)) = Value;
-	return TRUE;
+
+	*(WORD*)(m_TLB_WriteMap[VAddr >> 12] + (VAddr ^ 2)) = Value;
+	return true;
 }
 
-BOOL CMipsMemoryVM::SW_VAddr ( DWORD VAddr, DWORD Value ) 
+bool CMipsMemoryVM::SW_VAddr(DWORD VAddr, DWORD Value)
 {
 	if (VAddr >= 0xA3F00000 && VAddr < 0xC0000000)
 	{
@@ -398,84 +413,95 @@ BOOL CMipsMemoryVM::SW_VAddr ( DWORD VAddr, DWORD Value )
 			return true;
 		}
 	}
+
 	if (m_TLB_WriteMap[VAddr >> 12] == 0)
 	{
-		return FALSE;
+		return false;
 	}
-	*(DWORD *)(m_TLB_WriteMap[VAddr >> 12] + VAddr) = Value;
-	return TRUE;
+
+	*(DWORD*)(m_TLB_WriteMap[VAddr >> 12] + VAddr) = Value;
+	return true;
 }
 
 
-BOOL CMipsMemoryVM::SD_VAddr ( DWORD VAddr, QWORD Value )
+bool CMipsMemoryVM::SD_VAddr(DWORD VAddr, QWORD Value)
 {
 	if (m_TLB_WriteMap[VAddr >> 12] == 0)
 	{
-		return FALSE;
+		return false;
 	}
-	*(DWORD *)(m_TLB_WriteMap[VAddr >> 12] + VAddr) = *((DWORD *)(&Value) + 1);
-	*(DWORD *)(m_TLB_WriteMap[VAddr >> 12] + VAddr + 4) = *((DWORD *)(&Value));
-	return TRUE;
+
+	*(DWORD*)(m_TLB_WriteMap[VAddr >> 12] + VAddr + 0) = *((DWORD*)(&Value) + 1);
+	*(DWORD*)(m_TLB_WriteMap[VAddr >> 12] + VAddr + 4) = *((DWORD*)(&Value));
+	return true;
 }
 
-BOOL CMipsMemoryVM::SB_PAddr ( DWORD PAddr, BYTE Value ) 
+bool CMipsMemoryVM::SB_PAddr(DWORD PAddr, BYTE Value)
 {
 	if (PAddr < RdramSize())
 	{
-		*(BYTE *)(m_RDRAM + (PAddr ^ 3)) = Value;
+		*(BYTE*)(m_RDRAM + (PAddr ^ 3)) = Value;
 		return true;
 	}
+
 	if (PAddr > 0x18000000)
 	{
 		return false;
 	}
+
 	g_Notify->BreakPoint(__FILEW__,__LINE__);
 	return false;
 }
 
-BOOL CMipsMemoryVM::SH_PAddr ( DWORD PAddr, WORD Value )
+bool CMipsMemoryVM::SH_PAddr(DWORD PAddr, WORD Value)
 {
 	if (PAddr < RdramSize())
 	{
-		*(WORD *)(m_RDRAM + (PAddr ^ 2)) = Value;
+		*(WORD*)(m_RDRAM + (PAddr ^ 2)) = Value;
 		return true;
 	}
+
 	if (PAddr > 0x18000000)
 	{
 		return false;
 	}
+
 	g_Notify->BreakPoint(__FILEW__,__LINE__);
 	return false;
 }
 
-BOOL CMipsMemoryVM::SW_PAddr ( DWORD PAddr, DWORD Value ) 
+bool CMipsMemoryVM::SW_PAddr(DWORD PAddr, DWORD Value)
 {
 	if (PAddr < RdramSize())
 	{
-		*(DWORD *)(m_RDRAM + PAddr) = Value;
+		*(DWORD*)(m_RDRAM + PAddr) = Value;
 		return true;
 	}
+
 	if (PAddr > 0x18000000)
 	{
 		return false;
 	}
+
 	g_Notify->BreakPoint(__FILEW__,__LINE__);
 	return false;
 }
 
 
-BOOL CMipsMemoryVM::SD_PAddr ( DWORD PAddr, QWORD Value )
+bool CMipsMemoryVM::SD_PAddr(DWORD PAddr, QWORD Value)
 {
 	if (PAddr < RdramSize())
 	{
-		*(DWORD *)(m_RDRAM + PAddr) = *((DWORD *)(&Value) + 1);
-		*(DWORD *)(m_RDRAM + PAddr + 4) = *((DWORD *)(&Value));
+		*(DWORD*)(m_RDRAM + PAddr + 0) = *((DWORD*)(&Value) + 1);
+		*(DWORD*)(m_RDRAM + PAddr + 4) = *((DWORD*)(&Value));
 		return true;
 	}
+
 	if (PAddr > 0x18000000)
 	{
 		return false;
 	}
+
 	g_Notify->BreakPoint(__FILEW__,__LINE__);
 	return false;
 }
@@ -506,7 +532,7 @@ bool CMipsMemoryVM::TranslateVaddr ( DWORD VAddr, DWORD &PAddr) const
 	return true;
 }
 
-void  CMipsMemoryVM::Compile_LB ( x86Reg Reg, DWORD VAddr, BOOL SignExtend)
+void CMipsMemoryVM::Compile_LB(x86Reg Reg, DWORD VAddr, bool SignExtend)
 {
 	DWORD PAddr;
 	char VarName[100];
@@ -519,9 +545,9 @@ void  CMipsMemoryVM::Compile_LB ( x86Reg Reg, DWORD VAddr, BOOL SignExtend)
 			return;
 		}
 
-		x86Reg TlbMappReg = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg TlbMappReg = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr >> 12,TlbMappReg);
-		x86Reg AddrReg = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg AddrReg = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr,AddrReg);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TlbMappReg,TlbMappReg,4);
 		CompileReadTLBMiss(AddrReg,TlbMappReg);
@@ -577,7 +603,7 @@ void  CMipsMemoryVM::Compile_LB ( x86Reg Reg, DWORD VAddr, BOOL SignExtend)
 	}
 }
 
-void  CMipsMemoryVM::Compile_LH ( x86Reg Reg, DWORD VAddr, BOOL SignExtend)
+void  CMipsMemoryVM::Compile_LH(x86Reg Reg, DWORD VAddr, bool SignExtend)
 {
 	char VarName[100];
 	DWORD PAddr;
@@ -590,9 +616,9 @@ void  CMipsMemoryVM::Compile_LH ( x86Reg Reg, DWORD VAddr, BOOL SignExtend)
 			return;
 		}
 
-		x86Reg TlbMappReg = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg TlbMappReg = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr >> 12,TlbMappReg);
-		x86Reg AddrReg = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg AddrReg = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr,AddrReg);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TlbMappReg,TlbMappReg,4);
 		CompileReadTLBMiss(AddrReg,TlbMappReg);
@@ -662,7 +688,7 @@ void  CMipsMemoryVM::Compile_LW (x86Reg Reg, DWORD VAddr )
 			return;
 		}
 
-		x86Reg TlbMappReg = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg TlbMappReg = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr >> 12,TlbMappReg);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TlbMappReg,TlbMappReg,4);
 		CompileReadTLBMiss(VAddr,TlbMappReg);
@@ -890,8 +916,8 @@ void  CMipsMemoryVM::Compile_SB_Const ( BYTE Value, DWORD VAddr )
 
 	if (VAddr < 0x80000000 || VAddr >= 0xC0000000)
 	{
-		x86Reg TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
-		x86Reg TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg TempReg1 = Map_TempReg(x86_Any, -1, false);
+		x86Reg TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr, TempReg1);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
@@ -938,8 +964,8 @@ void  CMipsMemoryVM::Compile_SB_Register ( x86Reg Reg, DWORD VAddr )
 	{
 		m_RegWorkingSet.SetX86Protected(Reg,true);
 
-		x86Reg TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
-		x86Reg TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg TempReg1 = Map_TempReg(x86_Any, -1, false);
+		x86Reg TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr, TempReg1);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
@@ -987,8 +1013,8 @@ void  CMipsMemoryVM::Compile_SH_Const ( WORD Value, DWORD VAddr )
 
 	if (VAddr < 0x80000000 || VAddr >= 0xC0000000)
 	{
-		x86Reg TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
-		x86Reg TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg TempReg1 = Map_TempReg(x86_Any, -1, false);
+		x86Reg TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr, TempReg1);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
@@ -1037,8 +1063,8 @@ void CMipsMemoryVM::Compile_SH_Register ( x86Reg Reg, DWORD VAddr )
 	{
 		m_RegWorkingSet.SetX86Protected(Reg,true);
 
-		x86Reg TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
-		x86Reg TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg TempReg1 = Map_TempReg(x86_Any, -1, false);
+		x86Reg TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr, TempReg1);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
@@ -1086,8 +1112,8 @@ void CMipsMemoryVM::Compile_SW_Const ( DWORD Value, DWORD VAddr )
 
 	if (VAddr < 0x80000000 || VAddr >= 0xC0000000)
 	{
-		x86Reg TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
-		x86Reg TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg TempReg1 = Map_TempReg(x86_Any, -1, false);
+		x86Reg TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr, TempReg1);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
@@ -1531,8 +1557,8 @@ void CMipsMemoryVM::Compile_SW_Register (x86Reg Reg, DWORD VAddr )
 	{
 		m_RegWorkingSet.SetX86Protected(Reg,true);
 
-		x86Reg TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
-		x86Reg TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg TempReg1 = Map_TempReg(x86_Any, -1, false);
+		x86Reg TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveConstToX86reg(VAddr, TempReg1);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
@@ -1872,7 +1898,7 @@ void CMipsMemoryVM::ResetMemoryStack()
 	Reg = Get_MemoryStack();
 	if (Reg == x86_Unknown) 
 	{
-		Reg = Map_TempReg(x86_Any, MipsReg, FALSE);
+		Reg = Map_TempReg(x86_Any, MipsReg, false);
 	}
 	else
 	{
@@ -1892,7 +1918,7 @@ void CMipsMemoryVM::ResetMemoryStack()
 
 	if (g_System->bUseTlb()) 
 	{	
-	    TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(Reg,TempReg);
 		ShiftRightUnsignImmed(TempReg,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg,TempReg,4);
@@ -2081,7 +2107,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 		switch (*(TypePos + 1))
 		{
 		case 0xB6:
-			if (!LB_NonMemory(MemAddress,(DWORD *)Reg,FALSE))
+			if (!LB_NonMemory(MemAddress, (DWORD *)Reg, false))
 			{
 				if (g_Settings->LoadDword(Debugger_ShowUnhandledMemory))
 				{
@@ -2091,9 +2117,9 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 				}
 			}
 			lpEP->ContextRecord->Eip = (DWORD)ReadPos;
-			return EXCEPTION_CONTINUE_EXECUTION;		
+			return EXCEPTION_CONTINUE_EXECUTION;
 		case 0xB7:
-			if (!LH_NonMemory(MemAddress,(DWORD *)Reg,FALSE))
+			if (!LH_NonMemory(MemAddress, (DWORD *)Reg, false))
 			{
 				if (g_Settings->LoadDword(Debugger_ShowUnhandledMemory))
 				{
@@ -2103,9 +2129,9 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 				}
 			}
 			lpEP->ContextRecord->Eip = (DWORD)ReadPos;
-			return EXCEPTION_CONTINUE_EXECUTION;		
+			return EXCEPTION_CONTINUE_EXECUTION;
 		case 0xBE:
-			if (!LB_NonMemory(MemAddress,Reg,TRUE))
+			if (!LB_NonMemory(MemAddress, Reg, true))
 			{
 				if (g_Settings->LoadDword(Debugger_ShowUnhandledMemory))
 				{
@@ -2115,9 +2141,9 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 				}
 			}
 			lpEP->ContextRecord->Eip = (DWORD)ReadPos;
-			return EXCEPTION_CONTINUE_EXECUTION;		
+			return EXCEPTION_CONTINUE_EXECUTION;
 		case 0xBF:
-			if (!LH_NonMemory(MemAddress,Reg,TRUE))
+			if (!LH_NonMemory(MemAddress, Reg, true))
 			{
 				if (g_Settings->LoadDword(Debugger_ShowUnhandledMemory))
 				{
@@ -2127,7 +2153,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 				}
 			}
 			lpEP->ContextRecord->Eip = (DWORD)ReadPos;
-			return EXCEPTION_CONTINUE_EXECUTION;		
+			return EXCEPTION_CONTINUE_EXECUTION;
 		default:
 			if (bHaveDebugger())
 			{
@@ -2140,7 +2166,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 		switch (*(TypePos + 1))
 		{
 		case 0x8B:
-			if (!LH_NonMemory(MemAddress,Reg,FALSE))
+			if (!LH_NonMemory(MemAddress, Reg, false))
 			{
 				if (g_Settings->LoadDword(Debugger_ShowUnhandledMemory))
 				{
@@ -2150,7 +2176,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 				}
 			}
 			lpEP->ContextRecord->Eip = (DWORD)ReadPos;
-			return EXCEPTION_CONTINUE_EXECUTION;		
+			return EXCEPTION_CONTINUE_EXECUTION;
 		case 0x89:
 			if (!SH_NonMemory(MemAddress,*(WORD *)Reg))
 			{
@@ -2161,7 +2187,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 				}
 			}
 			lpEP->ContextRecord->Eip = (DWORD)ReadPos;
-			return EXCEPTION_CONTINUE_EXECUTION;		
+			return EXCEPTION_CONTINUE_EXECUTION;
 		case 0xC7:
 			if (Reg != &lpEP->ContextRecord->Eax)
 			{
@@ -2179,7 +2205,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 				}
 			}
 			lpEP->ContextRecord->Eip = (DWORD)(ReadPos + 2);
-			return EXCEPTION_CONTINUE_EXECUTION;		
+			return EXCEPTION_CONTINUE_EXECUTION;
 		default:
 			if (bHaveDebugger())
 			{
@@ -2199,9 +2225,9 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 			}
 		}
 		lpEP->ContextRecord->Eip = (DWORD)ReadPos;
-		return EXCEPTION_CONTINUE_EXECUTION;		
+		return EXCEPTION_CONTINUE_EXECUTION;
 	case 0x8A: 
-		if (!LB_NonMemory(MemAddress,Reg,FALSE))
+		if (!LB_NonMemory(MemAddress, Reg, false))
 		{
 			if (g_Settings->LoadDword(Debugger_ShowUnhandledMemory))
 			{
@@ -2211,7 +2237,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 			}
 		}
 		lpEP->ContextRecord->Eip = (DWORD)ReadPos;
-		return EXCEPTION_CONTINUE_EXECUTION;		
+		return EXCEPTION_CONTINUE_EXECUTION;
 	case 0x8B: 
 		if (!LW_NonMemory(MemAddress,Reg))
 		{
@@ -2223,7 +2249,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 			}
 		}
 		lpEP->ContextRecord->Eip = (DWORD)ReadPos;
-		return EXCEPTION_CONTINUE_EXECUTION;		
+		return EXCEPTION_CONTINUE_EXECUTION;
 	case 0x89:
 		if (!SW_NonMemory(MemAddress,*(DWORD *)Reg))
 		{
@@ -2234,7 +2260,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 			}
 		}
 		lpEP->ContextRecord->Eip = (DWORD)ReadPos;
-		return EXCEPTION_CONTINUE_EXECUTION;		
+		return EXCEPTION_CONTINUE_EXECUTION;
 	case 0xC6:
 		if (Reg != &lpEP->ContextRecord->Eax) 
 		{
@@ -2253,7 +2279,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 			}
 		}
 		lpEP->ContextRecord->Eip = (DWORD)(ReadPos + 1);
-		return EXCEPTION_CONTINUE_EXECUTION;		
+		return EXCEPTION_CONTINUE_EXECUTION;
 	case 0xC7:
 		if (Reg != &lpEP->ContextRecord->Eax) 
 		{
@@ -2272,7 +2298,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 			}
 		}
 		lpEP->ContextRecord->Eip = (DWORD)(ReadPos + 4);
-		return EXCEPTION_CONTINUE_EXECUTION;		
+		return EXCEPTION_CONTINUE_EXECUTION;
 	}
 	if (bHaveDebugger())
 	{
@@ -2281,25 +2307,28 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 
-int CMipsMemoryVM::LB_NonMemory ( DWORD PAddr, DWORD * Value, BOOL /*SignExtend*/ ) 
+bool CMipsMemoryVM::LB_NonMemory(DWORD PAddr, DWORD* Value, bool /*SignExtend*/)
 {
 	if (PAddr < 0x800000)
 	{
-		* Value = 0;
+		*Value = 0;
 		return true;
 	}
+
 	if (PAddr >= 0x10000000 && PAddr < 0x16000000) 
 	{
 		g_Notify->BreakPoint(__FILEW__,__LINE__);
 #ifdef tofix
 		if (WrittenToRom)
 		{
-			return FALSE;
+			return false;
 		}
+
 		if ((PAddr & 2) == 0)
 		{
 			PAddr = (PAddr + 4) ^ 2;
 		}
+
 		if ((PAddr - 0x10000000) < RomFileSize)
 		{
 			if (SignExtend)
@@ -2310,30 +2339,31 @@ int CMipsMemoryVM::LB_NonMemory ( DWORD PAddr, DWORD * Value, BOOL /*SignExtend*
 			{
 				*Value = ROM[PAddr - 0x10000000];
 			}
-			return TRUE;
+
+			return true;
 		}
 		else
 		{
 			*Value = 0;
-			return FALSE;
+			return false;
 		}
 #endif
 	}
 //	switch (PAddr & 0xFFF00000)
 //{
 //	default:
-		* Value = 0;
-//		return FALSE;
+		*Value = 0;
+//		return false;
 //		break;
 //	}
-	return TRUE;
+	return true;
 }
 
-int CMipsMemoryVM::LH_NonMemory ( DWORD PAddr, DWORD * Value, int/* SignExtend*/ ) 
+bool CMipsMemoryVM::LH_NonMemory(DWORD PAddr, DWORD* Value, bool/* SignExtend*/)
 {
 	if (PAddr < 0x800000)
 	{
-		* Value = 0;
+		*Value = 0;
 		return true;
 	}
 
@@ -2344,14 +2374,13 @@ int CMipsMemoryVM::LH_NonMemory ( DWORD PAddr, DWORD * Value, int/* SignExtend*/
 //	switch (PAddr & 0xFFF00000)
 //	{
 //	default:
-		* Value = 0;
-		return FALSE;
-//		break;
+		*Value = 0;
+		return false;
 //	}
-//	return TRUE;
+//	return true;
 }
 
-int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
+bool CMipsMemoryVM::LW_NonMemory(DWORD PAddr, DWORD* Value)
 {
 #ifdef CFB_READ
 	if (PAddr >= CFBStart && PAddr < CFBEnd)
@@ -2363,7 +2392,7 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 			FrameBufferRead(PAddr & ~0xFFF);
 		}
 		*Value = *(DWORD *)(m_RDRAM+PAddr);
-		return TRUE;
+		return true;
 	}	
 #endif
 	if (PAddr >= 0x10000000 && PAddr < 0x16000000) 
@@ -2372,25 +2401,25 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 		{ 
 			*Value = m_RomWroteValue;
 			//LogMessage("%X: Read crap from Rom %X from %X",PROGRAM_COUNTER,*Value,PAddr);
-			m_RomWrittenTo = FALSE;
+			m_RomWrittenTo = false;
 #ifdef ROM_IN_MAPSPACE
 			{
 				DWORD OldProtect;
 				VirtualProtect(ROM,RomFileSize,PAGE_READONLY, &OldProtect);
 			}
 #endif
-			return TRUE;
+			return true;
 		}
 		if ((PAddr - 0x10000000) < m_RomSize)
 		{
 			*Value = *(DWORD *)&m_Rom[PAddr - 0x10000000];
-			return TRUE;
+			return true;
 		}
 		else
 		{
 			*Value = PAddr & 0xFFFF;
 			*Value = (*Value << 16) | *Value;
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -2410,8 +2439,8 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 		case 0x03F00020: * Value = g_Reg->RDRAM_ADDR_SELECT_REG; break;
 		case 0x03F00024: * Value = g_Reg->RDRAM_DEVICE_MANUF_REG; break;	
 		default:
-			* Value = 0;
-			return FALSE;
+			*Value = 0;
+			return false;
 		}
 		break;
 	case 0x04000000:
@@ -2427,7 +2456,7 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 		case 0x04080000: *Value = g_Reg->SP_PC_REG; break;
 		default:
 			* Value = 0;
-			return FALSE;
+			return false;
 		}
 		break;
 	case 0x04100000:
@@ -2439,20 +2468,20 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 		case 0x04100018: *Value = g_Reg->DPC_PIPEBUSY_REG; break;
 		case 0x0410001C: *Value = g_Reg->DPC_TMEM_REG; break;
 		default:
-			* Value = 0;
-			return FALSE;
+			*Value = 0;
+			return false;
 		}
 		break;
 	case 0x04300000:
 		switch (PAddr)
 		{
-		case 0x04300000: * Value = g_Reg->MI_MODE_REG; break;
-		case 0x04300004: * Value = g_Reg->MI_VERSION_REG; break;
-		case 0x04300008: * Value = g_Reg->MI_INTR_REG; break;
-		case 0x0430000C: * Value = g_Reg->MI_INTR_MASK_REG; break;
+		case 0x04300000: *Value = g_Reg->MI_MODE_REG; break;
+		case 0x04300004: *Value = g_Reg->MI_VERSION_REG; break;
+		case 0x04300008: *Value = g_Reg->MI_INTR_REG; break;
+		case 0x0430000C: *Value = g_Reg->MI_INTR_MASK_REG; break;
 		default:
-			* Value = 0;
-			return FALSE;
+			*Value = 0;
+			return false;
 		}
 		break;
 	case 0x04400000:
@@ -2476,8 +2505,8 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 		case 0x04400030: *Value = g_Reg->VI_X_SCALE_REG; break;
 		case 0x04400034: *Value = g_Reg->VI_Y_SCALE_REG; break;
 		default:
-			* Value = 0;
-			return FALSE;
+			*Value = 0;
+			return false;
 		}
 		break;
 	case 0x04500000:
@@ -2511,8 +2540,8 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 			}
 			break;
 		default:
-			* Value = 0;
-			return FALSE;
+			*Value = 0;
+			return false;
 		}
 		break;
 	case 0x04600000:
@@ -2528,24 +2557,24 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 		case 0x0460002C: *Value = g_Reg->PI_BSD_DOM2_PGS_REG; break;
 		case 0x04600030: *Value = g_Reg->PI_BSD_DOM2_RLS_REG; break;
 		default:
-			* Value = 0;
-			return FALSE;
+			*Value = 0;
+			return false;
 		}
 		break;
 	case 0x04700000:
 		switch (PAddr)
 		{
-		case 0x04700000: * Value = g_Reg->RI_MODE_REG; break;
-		case 0x04700004: * Value = g_Reg->RI_CONFIG_REG; break;
-		case 0x04700008: * Value = g_Reg->RI_CURRENT_LOAD_REG; break;
-		case 0x0470000C: * Value = g_Reg->RI_SELECT_REG; break;
-		case 0x04700010: * Value = g_Reg->RI_REFRESH_REG; break;
-		case 0x04700014: * Value = g_Reg->RI_LATENCY_REG; break;
-		case 0x04700018: * Value = g_Reg->RI_RERROR_REG; break;
-		case 0x0470001C: * Value = g_Reg->RI_WERROR_REG; break;
+		case 0x04700000: *Value = g_Reg->RI_MODE_REG; break;
+		case 0x04700004: *Value = g_Reg->RI_CONFIG_REG; break;
+		case 0x04700008: *Value = g_Reg->RI_CURRENT_LOAD_REG; break;
+		case 0x0470000C: *Value = g_Reg->RI_SELECT_REG; break;
+		case 0x04700010: *Value = g_Reg->RI_REFRESH_REG; break;
+		case 0x04700014: *Value = g_Reg->RI_LATENCY_REG; break;
+		case 0x04700018: *Value = g_Reg->RI_RERROR_REG; break;
+		case 0x0470001C: *Value = g_Reg->RI_WERROR_REG; break;
 		default:
-			* Value = 0;
-			return FALSE;
+			*Value = 0;
+			return false;
 		}
 		break;
 	case 0x04800000:
@@ -2554,13 +2583,13 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 		case 0x04800018: *Value = g_Reg->SI_STATUS_REG; break;
 		default:
 			*Value = 0;
-			return FALSE;
+			return false;
 		}
 		break;
 	case 0x05000000:
 		*Value = PAddr & 0xFFFF;
 		*Value = (*Value << 16) | *Value;
-		return FALSE;
+		return false;
 	case 0x08000000:
 		if (g_System->m_SaveUsing == SaveChip_Auto)
 		{
@@ -2570,7 +2599,7 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 		{ 
 			*Value = PAddr & 0xFFFF;
 			*Value = (*Value << 16) | *Value;
-			return FALSE;
+			return false;
 		}
 		*Value = ReadFromFlashStatus(PAddr);
 		break;
@@ -2586,7 +2615,7 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 			}
 			* Value = ToSwap;*/
 			g_Notify->BreakPoint(__FILEW__,__LINE__);
-			return TRUE;
+			return true;
 		}
 		else if (PAddr < 0x1FC00800) 
 		{
@@ -2598,25 +2627,26 @@ int CMipsMemoryVM::LW_NonMemory ( DWORD PAddr, DWORD * Value )
 				bswap eax
 				mov ToSwap,eax
 			}
-			* Value = ToSwap;
-			return TRUE;
+			*Value = ToSwap;
+			return true;
 		}
 		else
 		{
-			* Value = 0;
-			return FALSE;
+			*Value = 0;
+			return false;
 		}
 		break;
 	default:
 		*Value = PAddr & 0xFFFF;
 		*Value = (*Value << 16) | *Value;
-		return FALSE;
+		return false;
 		break;
 	}
-	return TRUE;
+
+	return true;
 }
 
-int CMipsMemoryVM::SB_NonMemory ( DWORD PAddr, BYTE Value )
+bool CMipsMemoryVM::SB_NonMemory(DWORD PAddr, BYTE Value)
 {
 	switch (PAddr & 0xFFF00000)
 	{
@@ -2649,13 +2679,13 @@ int CMipsMemoryVM::SB_NonMemory ( DWORD PAddr, BYTE Value )
 		}
 		break;
 	default:
-		return FALSE;
-		break;
+		return false;
 	}
-	return TRUE;
+
+	return true;
 }
 
-int CMipsMemoryVM::SH_NonMemory ( DWORD PAddr, WORD Value )
+bool CMipsMemoryVM::SH_NonMemory(DWORD PAddr, WORD Value)
 {
 	switch (PAddr & 0xFFF00000)
 	{
@@ -2689,19 +2719,19 @@ int CMipsMemoryVM::SH_NonMemory ( DWORD PAddr, WORD Value )
 		}
 		break;
 	default:
-		return FALSE;
-		break;
+		return false;
 	}
-	return TRUE;
+
+	return true;
 }
 
-int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
+bool CMipsMemoryVM::SW_NonMemory(DWORD PAddr, DWORD Value)
 {
 	if (PAddr >= 0x10000000 && PAddr < 0x16000000) 
 	{
 		if ((PAddr - 0x10000000) < g_Rom->GetRomSize())
 		{
-			m_RomWrittenTo = TRUE;
+			m_RomWrittenTo = true;
 			m_RomWroteValue = Value;
 #ifdef ROM_IN_MAPSPACE
 			{
@@ -2713,7 +2743,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 		}
 		else
 		{
-			return FALSE;
+			return false;
 		}
 	}
 
@@ -2767,7 +2797,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 		case 0x03F8000C: break;
 		case 0x03F80014: break;
 		default:
-			return FALSE;
+			return false;
 		}
 		break;
 	case 0x04000000: 
@@ -2917,7 +2947,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 			case 0x0404001C: g_Reg->SP_SEMAPHORE_REG = 0; break;
 			case 0x04080000: g_Reg->SP_PC_REG = Value & 0xFFC; break;
 			default:
-				return FALSE;
+				return false;
 			}
 		}
 		break;
@@ -3001,7 +3031,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 #endif
 			break;
 		default:
-			return FALSE;
+			return false;
 		}
 		break;
 	case 0x04300000: 
@@ -3092,7 +3122,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 			}
 			break;
 		default:
-			return FALSE;
+			return false;
 		}
 		break;
 	case 0x04400000: 
@@ -3146,7 +3176,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 		case 0x04400030: g_Reg->VI_X_SCALE_REG = Value; break;
 		case 0x04400034: g_Reg->VI_Y_SCALE_REG = Value; break;
 		default:
-			return FALSE;
+			return false;
 		}
 		break;
 	case 0x04500000: 
@@ -3184,7 +3214,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 			break;
 		case 0x04500014:  g_Reg->AI_BITRATE_REG = Value; break;
 		default:
-			return FALSE;
+			return false;
 		}
 		break;
 	case 0x04600000: 
@@ -3220,7 +3250,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 		case 0x0460002C: g_Reg->PI_BSD_DOM2_PGS_REG = (Value & 0xFF); break;
 		case 0x04600030: g_Reg->PI_BSD_DOM2_RLS_REG = (Value & 0xFF); break;
 		default:
-			return FALSE;
+			return false;
 		}
 		break;
 	case 0x04700000:
@@ -3235,7 +3265,7 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 		case 0x04700018: g_Reg->RI_RERROR_REG = Value; break;
 		case 0x0470001C: g_Reg->RI_WERROR_REG = Value; break;
 		default:
-			return FALSE;
+			return false;
 		}
 		break;
 	case 0x04800000:
@@ -3256,13 +3286,13 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 			g_Reg->CheckInterrupts();
 			break;
 		default:
-			return FALSE;
+			return false;
 		}
 		break;
 	case 0x08000000:
 		if (PAddr != 0x08010000)
 		{
-			return FALSE;
+			return false;
 		}
 		if (g_System->m_SaveUsing == SaveChip_Auto)
 		{
@@ -3270,16 +3300,16 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 		}
 		if (g_System->m_SaveUsing != SaveChip_FlashRam)
 		{
-			return TRUE;
+			return true;
 		}
 		
 		WriteToFlashCommand(Value);
-		return TRUE;
+		return true;
 		break;
 	case 0x1FC00000:
 		if (PAddr < 0x1FC007C0)
 		{
-			return FALSE;
+			return false;
 		}
 		else if (PAddr < 0x1FC00800)
 		{
@@ -3294,15 +3324,16 @@ int CMipsMemoryVM::SW_NonMemory ( DWORD PAddr, DWORD Value )
 			{
 				PifRamWrite();
 			}
-			return TRUE;
+			return true;
 		}
-		return FALSE;
+		return false;
 		break;
 	default:
-		return FALSE;
+		return false;
 		break;
 	}
-	return TRUE;
+
+	return true;
 }
 
 void CMipsMemoryVM::UpdateHalfLine()
@@ -3417,8 +3448,8 @@ void CMipsMemoryVM::Compile_LB()
 	if (IsConst(Opcode.base))
 	{ 
 		DWORD Address = (GetMipsRegLo(Opcode.base) + (short)Opcode.offset) ^ 3;
-		Map_GPR_32bit(Opcode.rt,TRUE,-1);
-		Compile_LB(GetMipsRegMapLo(Opcode.rt),Address,TRUE);
+		Map_GPR_32bit(Opcode.rt, true, -1);
+		Compile_LB(GetMipsRegMapLo(Opcode.rt), Address, true);
 		return;
 	}
 	if (IsMapped(Opcode.rt))
@@ -3430,35 +3461,35 @@ void CMipsMemoryVM::Compile_LB()
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 	}
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
 		CompileReadTLBMiss(TempReg1,TempReg2);
-		XorConstToX86Reg(TempReg1,3);	
-		Map_GPR_32bit(Opcode.rt,TRUE,-1);
+		XorConstToX86Reg(TempReg1,3);
+		Map_GPR_32bit(Opcode.rt, true, -1);
 		MoveSxByteX86regPointerToX86reg(TempReg1, TempReg2,GetMipsRegMapLo(Opcode.rt));
 	}
 	else
 	{
 		AndConstToX86Reg(TempReg1,0x1FFFFFFF);
 		XorConstToX86Reg(TempReg1,3);
-		Map_GPR_32bit(Opcode.rt,TRUE,-1);
+		Map_GPR_32bit(Opcode.rt, true, -1);
 		MoveSxN64MemToX86regByte(GetMipsRegMapLo(Opcode.rt), TempReg1);
 	}
 }
@@ -3478,8 +3509,8 @@ void CMipsMemoryVM::Compile_LBU()
 	if (IsConst(Opcode.base))
 	{ 
 		DWORD Address = (GetMipsRegLo(Opcode.base) + (short)Opcode.offset) ^ 3;
-		Map_GPR_32bit(Opcode.rt,FALSE,-1);
-		Compile_LB(GetMipsRegMapLo(Opcode.rt),Address,FALSE);
+		Map_GPR_32bit(Opcode.rt, false, -1);
+		Compile_LB(GetMipsRegMapLo(Opcode.rt), Address, false);
 		return;
 	}
 	if (IsMapped(Opcode.rt))
@@ -3491,35 +3522,35 @@ void CMipsMemoryVM::Compile_LBU()
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 	}
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
 		CompileReadTLBMiss(TempReg1,TempReg2);
-		XorConstToX86Reg(TempReg1,3);	
-		Map_GPR_32bit(Opcode.rt,FALSE,-1);
+		XorConstToX86Reg(TempReg1,3);
+		Map_GPR_32bit(Opcode.rt, false, -1);
 		MoveZxByteX86regPointerToX86reg(TempReg1, TempReg2,GetMipsRegMapLo(Opcode.rt));
 	}
 	else
 	{
 		AndConstToX86Reg(TempReg1,0x1FFFFFFF);
 		XorConstToX86Reg(TempReg1,3);
-		Map_GPR_32bit(Opcode.rt,FALSE,-1);
+		Map_GPR_32bit(Opcode.rt, false, -1);
 		MoveZxN64MemToX86regByte(GetMipsRegMapLo(Opcode.rt), TempReg1);
 	}
 }
@@ -3536,8 +3567,8 @@ void CMipsMemoryVM::Compile_LH()
 	if (IsConst(Opcode.base))
 	{ 
 		DWORD Address = (GetMipsRegLo(Opcode.base) + (short)Opcode.offset) ^ 2;
-		Map_GPR_32bit(Opcode.rt,TRUE,-1);
-		Compile_LH(GetMipsRegMapLo(Opcode.rt),Address,TRUE);
+		Map_GPR_32bit(Opcode.rt, true, -1);
+		Compile_LH(GetMipsRegMapLo(Opcode.rt), Address, true);
 		return;
 	}
 	if (IsMapped(Opcode.rt))
@@ -3549,35 +3580,35 @@ void CMipsMemoryVM::Compile_LH()
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 	}
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
 		CompileReadTLBMiss(TempReg1,TempReg2);
-		XorConstToX86Reg(TempReg1,2);	
-		Map_GPR_32bit(Opcode.rt,TRUE,-1);
+		XorConstToX86Reg(TempReg1,2);
+		Map_GPR_32bit(Opcode.rt, true, -1);
 		MoveSxHalfX86regPointerToX86reg(TempReg1, TempReg2,GetMipsRegMapLo(Opcode.rt));
 	}
 	else
 	{
 		AndConstToX86Reg(TempReg1,0x1FFFFFFF);
 		XorConstToX86Reg(TempReg1,2);
-		Map_GPR_32bit(Opcode.rt,TRUE,-1);
+		Map_GPR_32bit(Opcode.rt, true, -1);
 		MoveSxN64MemToX86regHalf(GetMipsRegMapLo(Opcode.rt), TempReg1);
 	}
 }
@@ -3597,8 +3628,8 @@ void CMipsMemoryVM::Compile_LHU()
 	if (IsConst(Opcode.base))
 	{ 
 		DWORD Address = (GetMipsRegLo(Opcode.base) + (short)Opcode.offset) ^ 2;
-		Map_GPR_32bit(Opcode.rt,FALSE,-1);
-		Compile_LH(GetMipsRegMapLo(Opcode.rt),Address,FALSE);
+		Map_GPR_32bit(Opcode.rt, false, -1);
+		Compile_LH(GetMipsRegMapLo(Opcode.rt), Address, false);
 		return;
 	}
 	if (IsMapped(Opcode.rt))
@@ -3610,35 +3641,35 @@ void CMipsMemoryVM::Compile_LHU()
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 	}
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
 		CompileReadTLBMiss(TempReg1,TempReg2);
-		XorConstToX86Reg(TempReg1,2);	
-		Map_GPR_32bit(Opcode.rt,FALSE,-1);
+		XorConstToX86Reg(TempReg1,2);
+		Map_GPR_32bit(Opcode.rt, false, -1);
 		MoveZxHalfX86regPointerToX86reg(TempReg1, TempReg2,GetMipsRegMapLo(Opcode.rt));
 	}
 	else
 	{
 		AndConstToX86Reg(TempReg1,0x1FFFFFFF);
 		XorConstToX86Reg(TempReg1,2);
-		Map_GPR_32bit(Opcode.rt,TRUE,-1);
+		Map_GPR_32bit(Opcode.rt, true, -1);
 		MoveZxN64MemToX86regHalf(GetMipsRegMapLo(Opcode.rt), TempReg1);
 	}
 }
@@ -3705,21 +3736,21 @@ void CMipsMemoryVM::Compile_LW (bool ResultSigned, bool bRecordLLBit)
 					{ 
 						ProtectGPR(Opcode.base);
 						if (Opcode.offset != 0) {
-							TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+							TempReg1 = Map_TempReg(x86_Any, -1, false);
 							LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 						}
 						else
 						{
-							TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+							TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 						}
 					}
 					else
 					{
-						TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+						TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 						AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 					}
 				}
-				TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+				TempReg2 = Map_TempReg(x86_Any, -1, false);
 				MoveX86RegToX86Reg(TempReg1, TempReg2);
 				ShiftRightUnsignImmed(TempReg2,12);
 				MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
@@ -3780,25 +3811,25 @@ void CMipsMemoryVM::Compile_LWC1()
 	{
 		if (RegInStack(Opcode.ft-1,CRegInfo::FPU_Double) || RegInStack(Opcode.ft-1,CRegInfo::FPU_Qword))
 		{
-			UnMap_FPR(Opcode.ft-1,TRUE);
+			UnMap_FPR(Opcode.ft - 1, true);
 		}
 	}
 	if (RegInStack(Opcode.ft,CRegInfo::FPU_Double) || RegInStack(Opcode.ft,CRegInfo::FPU_Qword))
 	{
-		UnMap_FPR(Opcode.ft,TRUE);
+		UnMap_FPR(Opcode.ft, true);
 	}
 	else
 	{
-		UnMap_FPR(Opcode.ft,FALSE);
+		UnMap_FPR(Opcode.ft, false);
 	}
 	if (IsConst(Opcode.base))
 	{ 
 		DWORD Address = GetMipsRegLo(Opcode.base) + (short)Opcode.offset;
 
-		TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, -1, false);
 		Compile_LW(TempReg1,Address);
 
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_S[%d]",Opcode.ft);
 		MoveVariableToX86reg(&_FPR_S[Opcode.ft],Name,TempReg2);
 		MoveX86regToX86Pointer(TempReg1,TempReg2);
@@ -3813,7 +3844,7 @@ void CMipsMemoryVM::Compile_LWC1()
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 	}
 	else
@@ -3823,18 +3854,18 @@ void CMipsMemoryVM::Compile_LWC1()
 			ProtectGPR(Opcode.base);
 			if (Opcode.offset != 0)
 			{
-				TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+				TempReg1 = Map_TempReg(x86_Any, -1, false);
 				LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 			}
 			else
 			{
-				TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+				TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 			}
 			UnProtectGPR(Opcode.base);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 			if (Opcode.immediate == 0)
 			{
 				
@@ -3844,7 +3875,7 @@ void CMipsMemoryVM::Compile_LWC1()
 				IncX86reg(TempReg1);
 			}
 			else if (Opcode.immediate == 0xFFFF)
-			{			
+			{
 				DecX86reg(TempReg1);
 			}
 			else
@@ -3853,7 +3884,7 @@ void CMipsMemoryVM::Compile_LWC1()
 			}
 		}
 	}
-	TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+	TempReg2 = Map_TempReg(x86_Any, -1, false);
 	if (g_System->bUseTlb())
 	{
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
@@ -3861,13 +3892,13 @@ void CMipsMemoryVM::Compile_LWC1()
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
 		CompileReadTLBMiss(TempReg1,TempReg2);
 		
-		TempReg3 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg3 = Map_TempReg(x86_Any, -1, false);
 		MoveX86regPointerToX86reg(TempReg1, TempReg2,TempReg3);
 	}
 	else
 	{
 		AndConstToX86Reg(TempReg1,0x1FFFFFFF);
-		TempReg3 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg3 = Map_TempReg(x86_Any, -1, false);
 		MoveN64MemToX86reg(TempReg3,TempReg1);
 	}
 	sprintf(Name,"_FPR_S[%d]",Opcode.ft);
@@ -3892,8 +3923,8 @@ void CMipsMemoryVM::Compile_LWL()
 		DWORD Address = GetMipsRegLo(Opcode.base) + (short)Opcode.offset;
 		DWORD Offset  = Address & 3;
 
-		Map_GPR_32bit(Opcode.rt,TRUE,Opcode.rt);
-		x86Reg Value = Map_TempReg(x86_Any,-1,FALSE);
+		Map_GPR_32bit(Opcode.rt, true, Opcode.rt);
+		x86Reg Value = Map_TempReg(x86_Any, -1, false);
 		Compile_LW(Value,(Address & ~3));
 		AndConstToX86Reg(GetMipsRegMapLo(Opcode.rt),LWL_MASK[Offset]);
 		ShiftLeftSignImmed(Value,(BYTE)LWL_SHIFT[Offset]);
@@ -3901,7 +3932,7 @@ void CMipsMemoryVM::Compile_LWL()
 		return;
 	}
 
-	shift = Map_TempReg(x86_ECX,-1,FALSE);
+	shift = Map_TempReg(x86_ECX, -1, false);
 	if (IsMapped(Opcode.rt))
 	{
 		ProtectGPR(Opcode.rt);
@@ -3911,39 +3942,39 @@ void CMipsMemoryVM::Compile_LWL()
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 		UnProtectGPR(Opcode.base);
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 	}
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
 		
 		CompileReadTLBMiss(TempReg1,TempReg2);
 	}
-	OffsetReg = Map_TempReg(x86_Any,-1,FALSE);
+	OffsetReg = Map_TempReg(x86_Any, -1, false);
 	MoveX86RegToX86Reg(TempReg1, OffsetReg);
 	AndConstToX86Reg(OffsetReg,3);
 	AndConstToX86Reg(TempReg1,(DWORD)~3);
 
-	Map_GPR_32bit(Opcode.rt,TRUE,Opcode.rt);
+	Map_GPR_32bit(Opcode.rt, true, Opcode.rt);
 	AndVariableDispToX86Reg((void *)LWL_MASK,"LWL_MASK",GetMipsRegMapLo(Opcode.rt),OffsetReg,Multip_x4);
 	MoveVariableDispToX86Reg((void *)LWL_SHIFT,"LWL_SHIFT",shift,OffsetReg,4);
 	if (g_System->bUseTlb())
-	{			
+	{
 		MoveX86regPointerToX86reg(TempReg1, TempReg2,TempReg1);
 	}
 	else
@@ -3972,8 +4003,8 @@ void CMipsMemoryVM::Compile_LWR()
 		DWORD Address = GetMipsRegLo(Opcode.base) + (short)Opcode.offset;
 		DWORD Offset  = Address & 3;
 
-		Map_GPR_32bit(Opcode.rt,TRUE,Opcode.rt);
-		x86Reg Value = Map_TempReg(x86_Any,-1,FALSE);
+		Map_GPR_32bit(Opcode.rt, true, Opcode.rt);
+		x86Reg Value = Map_TempReg(x86_Any, -1, false);
 		Compile_LW(Value,(Address & ~3));
 		AndConstToX86Reg(GetMipsRegMapLo(Opcode.rt),LWR_MASK[Offset]);
 		ShiftRightUnsignImmed(Value,(BYTE)LWR_SHIFT[Offset]);
@@ -3981,7 +4012,7 @@ void CMipsMemoryVM::Compile_LWR()
 		return;
 	}
 
-	shift = Map_TempReg(x86_ECX,-1,FALSE);
+	shift = Map_TempReg(x86_ECX, -1, false);
 	if (IsMapped(Opcode.rt))
 	{
 		ProtectGPR(Opcode.rt);
@@ -3991,36 +4022,36 @@ void CMipsMemoryVM::Compile_LWR()
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 		UnProtectGPR(Opcode.base);
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 	}
 	
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
 		
 		CompileReadTLBMiss(TempReg1,TempReg2);
 	}
-	OffsetReg = Map_TempReg(x86_Any,-1,FALSE);
+	OffsetReg = Map_TempReg(x86_Any, -1, false);
 	MoveX86RegToX86Reg(TempReg1, OffsetReg);
 	AndConstToX86Reg(OffsetReg,3);
 	AndConstToX86Reg(TempReg1,(DWORD)~3);
 
-	Map_GPR_32bit(Opcode.rt,TRUE,Opcode.rt);
+	Map_GPR_32bit(Opcode.rt, true, Opcode.rt);
 	AndVariableDispToX86Reg((void *)LWR_MASK,"LWR_MASK",GetMipsRegMapLo(Opcode.rt),OffsetReg,Multip_x4);
 	MoveVariableDispToX86Reg((void *)LWR_SHIFT,"LWR_SHIFT",shift,OffsetReg,4);
 	if (g_System->bUseTlb())
@@ -4078,7 +4109,7 @@ void CMipsMemoryVM::Compile_LD()
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 	}
 	else
@@ -4088,23 +4119,23 @@ void CMipsMemoryVM::Compile_LD()
 			ProtectGPR(Opcode.base);
 			if (Opcode.offset != 0)
 			{
-				TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+				TempReg1 = Map_TempReg(x86_Any, -1, false);
 				LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 			}
 			else
 			{
-				TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+				TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 			}
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any,Opcode.base,false);
 			AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 		}
 	}
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
@@ -4137,14 +4168,14 @@ void CMipsMemoryVM::Compile_LDC1()
 
 	m_Section->CompileCop1Test();
 
-	UnMap_FPR(Opcode.ft,FALSE);
+	UnMap_FPR(Opcode.ft, false);
 	if (IsConst(Opcode.base))
 	{ 
 		DWORD Address = GetMipsRegLo(Opcode.base) + (short)Opcode.offset;
-		TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, -1, false);
 		Compile_LW(TempReg1,Address);
 
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_D[%d]",Opcode.ft);
 		MoveVariableToX86reg(&_FPR_D[Opcode.ft],Name,TempReg2);
 		AddConstToX86Reg(TempReg2,4);
@@ -4165,7 +4196,7 @@ void CMipsMemoryVM::Compile_LDC1()
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 	}
 	else
@@ -4175,17 +4206,17 @@ void CMipsMemoryVM::Compile_LDC1()
 			ProtectGPR(Opcode.base);
 			if (Opcode.offset != 0)
 			{
-				TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+				TempReg1 = Map_TempReg(x86_Any, -1, false);
 				LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 			}
 			else
 			{
-				TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+				TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 			}
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 			if (Opcode.immediate == 0)
 			{
 				
@@ -4205,14 +4236,14 @@ void CMipsMemoryVM::Compile_LDC1()
 		}
 	}
 
-	TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+	TempReg2 = Map_TempReg(x86_Any, -1, false);
 	if (g_System->bUseTlb())
 	{
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
 		CompileReadTLBMiss(TempReg1,TempReg2);
-		TempReg3 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg3 = Map_TempReg(x86_Any, -1, false);
 		MoveX86regPointerToX86reg(TempReg1, TempReg2,TempReg3);
 		Push(TempReg2);
 		sprintf(Name,"_FPR_S[%d]",Opcode.ft);
@@ -4228,7 +4259,7 @@ void CMipsMemoryVM::Compile_LDC1()
 	else
 	{
 		AndConstToX86Reg(TempReg1,0x1FFFFFFF);
-		TempReg3 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg3 = Map_TempReg(x86_Any, -1, false);
 		MoveN64MemToX86reg(TempReg3,TempReg1);
 
 		sprintf(Name,"_FPR_S[%d]",Opcode.ft);
@@ -4248,14 +4279,17 @@ void CMipsMemoryVM::Compile_LDL()
 	OPCODE & Opcode = CRecompilerOps::m_Opcode;
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(Opcode.Hex,m_CompilePC));
+
 	if (Opcode.base != 0)
 	{
-		UnMap_GPR(Opcode.base,TRUE);
+		UnMap_GPR(Opcode.base, true);
 	}
+
 	if (Opcode.rt != 0)
 	{
-		UnMap_GPR(Opcode.rt,TRUE);
+		UnMap_GPR(Opcode.rt, true);
 	}
+
 	BeforeCallDirect(m_RegWorkingSet);
 	MoveConstToVariable(Opcode.Hex, &R4300iOp::m_Opcode.Hex, "R4300iOp::m_Opcode.Hex");
 	Call_Direct(R4300iOp::LDL, "R4300iOp::LDL");
@@ -4267,14 +4301,17 @@ void CMipsMemoryVM::Compile_LDR()
 	OPCODE & Opcode = CRecompilerOps::m_Opcode;
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(Opcode.Hex,m_CompilePC));
+
 	if (Opcode.base != 0)
 	{
-		UnMap_GPR(Opcode.base,TRUE);
+		UnMap_GPR(Opcode.base, true);
 	}
+
 	if (Opcode.rt != 0)
 	{
-		UnMap_GPR(Opcode.rt,TRUE);
+		UnMap_GPR(Opcode.rt, true);
 	}
+
 	BeforeCallDirect(m_RegWorkingSet);
 	MoveConstToVariable(Opcode.Hex, &R4300iOp::m_Opcode.Hex, "R4300iOp::m_Opcode.Hex");
 	Call_Direct(R4300iOp::LDR, "R4300iOp::LDR");
@@ -4302,42 +4339,45 @@ void CMipsMemoryVM::Compile_SB()
 		}
 		else
 		{
-			Compile_SB_Register(Map_TempReg(x86_Any8Bit,Opcode.rt,FALSE), Address);
+			Compile_SB_Register(Map_TempReg(x86_Any8Bit, Opcode.rt, false), Address);
 		}
+
 		return;
 	}
+
 	if (IsMapped(Opcode.rt))
 	{
 		ProtectGPR(Opcode.rt);
 	}
+
 	if (IsMapped(Opcode.base))
-	{ 
+	{
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 		UnProtectGPR(Opcode.base);
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 	}
 	Compile_StoreInstructClean(TempReg1,4);
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_WriteMap,"m_TLB_WriteMap",TempReg2,TempReg2,4);
 		CompileWriteTLBMiss(TempReg1,TempReg2);
-		XorConstToX86Reg(TempReg1,3);	
+		XorConstToX86Reg(TempReg1,3);
 		if (IsConst(Opcode.rt))
 		{
 			MoveConstByteToX86regPointer((BYTE)(GetMipsRegLo(Opcode.rt) & 0xFF),TempReg1, TempReg2);
@@ -4347,9 +4387,9 @@ void CMipsMemoryVM::Compile_SB()
 			MoveX86regByteToX86regPointer(GetMipsRegMapLo(Opcode.rt),TempReg1, TempReg2);
 		}
 		else
-		{	
+		{
 			UnProtectGPR(Opcode.rt);
-			MoveX86regByteToX86regPointer(Map_TempReg(x86_Any8Bit,Opcode.rt,FALSE),TempReg1, TempReg2);
+			MoveX86regByteToX86regPointer(Map_TempReg(x86_Any8Bit, Opcode.rt, false), TempReg1, TempReg2);
 		}
 	}
 	else
@@ -4359,14 +4399,15 @@ void CMipsMemoryVM::Compile_SB()
 		if (IsConst(Opcode.rt))
 		{
 			MoveConstByteToN64Mem((BYTE)(GetMipsRegLo(Opcode.rt) & 0xFF),TempReg1);
-		} else if (IsMapped(Opcode.rt) && Is8BitReg(GetMipsRegMapLo(Opcode.rt)))
+		}
+		else if (IsMapped(Opcode.rt) && Is8BitReg(GetMipsRegMapLo(Opcode.rt)))
 		{
 			MoveX86regByteToN64Mem(GetMipsRegMapLo(Opcode.rt),TempReg1);
 		}
 		else
-		{	
+		{
 			UnProtectGPR(Opcode.rt);
-			MoveX86regByteToN64Mem(Map_TempReg(x86_Any8Bit,Opcode.rt,FALSE),TempReg1);
+			MoveX86regByteToN64Mem(Map_TempReg(x86_Any8Bit, Opcode.rt, false), TempReg1);
 		}
 	}
 }
@@ -4392,41 +4433,45 @@ void CMipsMemoryVM::Compile_SH()
 		}
 		else
 		{
-			Compile_SH_Register(Map_TempReg(x86_Any,Opcode.rt,FALSE), Address);
+			Compile_SH_Register(Map_TempReg(x86_Any, Opcode.rt, false), Address);
 		}
+
 		return;
 	}
+
 	if (IsMapped(Opcode.rt))
 	{
 		ProtectGPR(Opcode.rt);
 	}
+
 	if (IsMapped(Opcode.base))
-	{ 
+	{
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 		UnProtectGPR(Opcode.base);
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 	}
+
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_WriteMap,"m_TLB_WriteMap",TempReg2,TempReg2,4);
 		CompileWriteTLBMiss(TempReg1,TempReg2);
-		XorConstToX86Reg(TempReg1,2);	
+		XorConstToX86Reg(TempReg1,2);
 		if (IsConst(Opcode.rt))
 		{
 			MoveConstHalfToX86regPointer((WORD)(GetMipsRegLo(Opcode.rt) & 0xFFFF),TempReg1, TempReg2);
@@ -4437,12 +4482,12 @@ void CMipsMemoryVM::Compile_SH()
 		}
 		else
 		{	
-			MoveX86regHalfToX86regPointer(Map_TempReg(x86_Any,Opcode.rt,FALSE),TempReg1, TempReg2);
+			MoveX86regHalfToX86regPointer(Map_TempReg(x86_Any, Opcode.rt, false), TempReg1, TempReg2);
 		}
 	}
 	else
 	{
-		AndConstToX86Reg(TempReg1,0x1FFFFFFF);		
+		AndConstToX86Reg(TempReg1,0x1FFFFFFF);
 		XorConstToX86Reg(TempReg1,2);
 		if (IsConst(Opcode.rt))
 		{
@@ -4450,11 +4495,11 @@ void CMipsMemoryVM::Compile_SH()
 		}
 		else if (IsMapped(Opcode.rt))
 		{
-			MoveX86regHalfToN64Mem(GetMipsRegMapLo(Opcode.rt),TempReg1);		
+			MoveX86regHalfToN64Mem(GetMipsRegMapLo(Opcode.rt),TempReg1);
 		}
 		else
 		{	
-			MoveX86regHalfToN64Mem(Map_TempReg(x86_Any,Opcode.rt,FALSE),TempReg1);		
+			MoveX86regHalfToN64Mem(Map_TempReg(x86_Any, Opcode.rt, false), TempReg1);
 		}
 	}
 }
@@ -4485,7 +4530,7 @@ void CMipsMemoryVM::Compile_SW (bool bCheckLLbit)
 		{
 			ProtectGPR(Opcode.rt);
 		}
-		TempReg1 = Map_MemoryStack(x86_Any,true);
+		TempReg1 = Map_MemoryStack(x86_Any, true);
 
 		if (IsConst(Opcode.rt))
 		{
@@ -4496,10 +4541,10 @@ void CMipsMemoryVM::Compile_SW (bool bCheckLLbit)
 			MoveX86regToMemory(GetMipsRegMapLo(Opcode.rt),TempReg1,(DWORD)((short)Opcode.offset));
 		}
 		else
-		{	
-			TempReg2 = Map_TempReg(x86_Any,Opcode.rt,FALSE);
+		{
+			TempReg2 = Map_TempReg(x86_Any, Opcode.rt, false);
 			MoveX86regToMemory(TempReg2,TempReg1,(DWORD)((short)Opcode.offset));
-		}		
+		}
 	}
 	else
 	{
@@ -4521,14 +4566,15 @@ void CMipsMemoryVM::Compile_SW (bool bCheckLLbit)
 			}
 			else
 			{
-				Compile_SW_Register(Map_TempReg(x86_Any,Opcode.rt,FALSE), Address);
+				Compile_SW_Register(Map_TempReg(x86_Any, Opcode.rt, false), Address);
 			}
+
 			return;
 		}
+
 		if (IsMapped(Opcode.rt))
-		{
 			ProtectGPR(Opcode.rt);
-		}
+
 		if (IsMapped(Opcode.base))
 		{ 
 			ProtectGPR(Opcode.base);
@@ -4540,24 +4586,24 @@ void CMipsMemoryVM::Compile_SW (bool bCheckLLbit)
 			}
 			if (Opcode.offset != 0)
 			{
-				TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+				TempReg1 = Map_TempReg(x86_Any, -1, false);
 				LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 			}
 			else
 			{
-				TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+				TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 			}
 			UnProtectGPR(Opcode.base);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 			AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 		}
 		Compile_StoreInstructClean(TempReg1,4);
 		if (g_System->bUseTlb())
 		{
-			TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg2 = Map_TempReg(x86_Any, -1, false);
 			MoveX86RegToX86Reg(TempReg1, TempReg2);
 			ShiftRightUnsignImmed(TempReg2,12);
 			MoveVariableDispToX86Reg(m_TLB_WriteMap,"m_TLB_WriteMap",TempReg2,TempReg2,4);
@@ -4578,7 +4624,7 @@ void CMipsMemoryVM::Compile_SW (bool bCheckLLbit)
 			}
 			else
 			{	
-				MoveX86regToX86regPointer(Map_TempReg(x86_Any,Opcode.rt,FALSE),TempReg1, TempReg2);
+				MoveX86regToX86regPointer(Map_TempReg(x86_Any, Opcode.rt, false), TempReg1, TempReg2);
 			}
 			if (bCheckLLbit)
 			{
@@ -4606,7 +4652,7 @@ void CMipsMemoryVM::Compile_SW (bool bCheckLLbit)
 			}
 			else
 			{	
-				MoveX86regToN64Mem(Map_TempReg(x86_Any,Opcode.rt,FALSE),TempReg1);
+				MoveX86regToN64Mem(Map_TempReg(x86_Any, Opcode.rt, false), TempReg1);
 			}
 		}
 	}
@@ -4626,8 +4672,8 @@ void CMipsMemoryVM::Compile_SWC1()
 	{ 
 		DWORD Address = GetMipsRegLo(Opcode.base) + (short)Opcode.offset;
 		
-		UnMap_FPR(Opcode.ft,TRUE);
-		TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+		UnMap_FPR(Opcode.ft, true);
+		TempReg1 = Map_TempReg(x86_Any, -1, false);
 
 		sprintf(Name,"_FPR_S[%d]",Opcode.ft);
 		MoveVariableToX86reg(&_FPR_S[Opcode.ft],Name,TempReg1);
@@ -4640,17 +4686,17 @@ void CMipsMemoryVM::Compile_SWC1()
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		if (Opcode.immediate == 0)
 		{
 			
@@ -4658,8 +4704,9 @@ void CMipsMemoryVM::Compile_SWC1()
 		else if (Opcode.immediate == 1)
 		{
 			IncX86reg(TempReg1);
-		} else if (Opcode.immediate == 0xFFFF)
-		{			
+		}
+		else if (Opcode.immediate == 0xFFFF)
+		{
 			DecX86reg(TempReg1);
 		}
 		else
@@ -4669,14 +4716,14 @@ void CMipsMemoryVM::Compile_SWC1()
 	}
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_WriteMap,"m_TLB_WriteMap",TempReg2,TempReg2,4);
 		CompileWriteTLBMiss(TempReg1,TempReg2);
 
-		UnMap_FPR(Opcode.ft,TRUE);
-		TempReg3 = Map_TempReg(x86_Any,-1,FALSE);
+		UnMap_FPR(Opcode.ft, true);
+		TempReg3 = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_S[%d]",Opcode.ft);
 		MoveVariableToX86reg(&_FPR_S[Opcode.ft],Name,TempReg3);
 		MoveX86PointerToX86reg(TempReg3,TempReg3);
@@ -4684,8 +4731,8 @@ void CMipsMemoryVM::Compile_SWC1()
 	}
 	else
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
-		UnMap_FPR(Opcode.ft,TRUE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
+		UnMap_FPR(Opcode.ft, true);
 		sprintf(Name,"_FPR_S[%d]",Opcode.ft);
 		MoveVariableToX86reg(&_FPR_S[Opcode.ft],Name,TempReg2);
 		MoveX86PointerToX86reg(TempReg2,TempReg2);
@@ -4709,52 +4756,52 @@ void CMipsMemoryVM::Compile_SWL()
 		Address = GetMipsRegLo(Opcode.base) + (short)Opcode.offset;
 		DWORD Offset  = Address & 3;
 		
-		Value = Map_TempReg(x86_Any,-1,FALSE);
+		Value = Map_TempReg(x86_Any, -1, false);
 		Compile_LW(Value,(Address & ~3));
 		AndConstToX86Reg(Value,R4300iOp::SWL_MASK[Offset]);
-		TempReg1 = Map_TempReg(x86_Any,Opcode.rt,FALSE);
-		ShiftRightUnsignImmed(TempReg1,(BYTE)SWL_SHIFT[Offset]);		
-		AddX86RegToX86Reg(Value,TempReg1);		
+		TempReg1 = Map_TempReg(x86_Any, Opcode.rt, false);
+		ShiftRightUnsignImmed(TempReg1,(BYTE)SWL_SHIFT[Offset]);
+		AddX86RegToX86Reg(Value,TempReg1);
 		Compile_SW_Register(Value, (Address & ~3));
 		return;
 	}
-	shift = Map_TempReg(x86_ECX,-1,FALSE);
+	shift = Map_TempReg(x86_ECX, -1, false);
 	if (IsMapped(Opcode.base))
 	{ 
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 		UnProtectGPR(Opcode.base);
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
-	}		
+	}
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
 		CompileReadTLBMiss(TempReg1,TempReg2);
 	}
 	
-	OffsetReg = Map_TempReg(x86_Any,-1,FALSE);
+	OffsetReg = Map_TempReg(x86_Any, -1, false);
 	MoveX86RegToX86Reg(TempReg1, OffsetReg);
 	AndConstToX86Reg(OffsetReg,3);
 	AndConstToX86Reg(TempReg1,(DWORD)~3);
 
-	Value = Map_TempReg(x86_Any,-1,FALSE);
+	Value = Map_TempReg(x86_Any, -1, false);
 	if (g_System->bUseTlb())
-	{	
+	{
 		MoveX86regPointerToX86reg(TempReg1, TempReg2,Value);
 	}
 	else
@@ -4810,50 +4857,50 @@ void CMipsMemoryVM::Compile_SWR()
 		DWORD Address = GetMipsRegLo(Opcode.base) + (short)Opcode.offset;
 		DWORD Offset  = Address & 3;
 		
-		Value = Map_TempReg(x86_Any,-1,FALSE);
+		Value = Map_TempReg(x86_Any, -1, false);
 		Compile_LW(Value,(Address & ~3));
 		AndConstToX86Reg(Value,SWR_MASK[Offset]);
-		TempReg1 = Map_TempReg(x86_Any,Opcode.rt,FALSE);
-		ShiftLeftSignImmed(TempReg1,(BYTE)SWR_SHIFT[Offset]);		
-		AddX86RegToX86Reg(Value,TempReg1);		
+		TempReg1 = Map_TempReg(x86_Any, Opcode.rt, false);
+		ShiftLeftSignImmed(TempReg1,(BYTE)SWR_SHIFT[Offset]);
+		AddX86RegToX86Reg(Value,TempReg1);
 		Compile_SW_Register(Value, (Address & ~3));
 		return;
 	}
-	shift = Map_TempReg(x86_ECX,-1,FALSE);
+	shift = Map_TempReg(x86_ECX, -1, false);
 	if (IsMapped(Opcode.base))
 	{ 
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 		UnProtectGPR(Opcode.base);
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
-	}		
+	}
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_ReadMap,"m_TLB_ReadMap",TempReg2,TempReg2,4);
 		CompileReadTLBMiss(TempReg1,TempReg2);
 	}
 	
-	OffsetReg = Map_TempReg(x86_Any,-1,FALSE);
+	OffsetReg = Map_TempReg(x86_Any, -1, false);
 	MoveX86RegToX86Reg(TempReg1, OffsetReg);
 	AndConstToX86Reg(OffsetReg,3);
 	AndConstToX86Reg(TempReg1,(DWORD)~3);
 
-	Value = Map_TempReg(x86_Any,-1,FALSE);
+	Value = Map_TempReg(x86_Any, -1, false);
 	if (g_System->bUseTlb())
 	{
 		MoveX86regPointerToX86reg(TempReg1, TempReg2,Value);
@@ -4910,7 +4957,7 @@ void CMipsMemoryVM::Compile_StoreInstructClean (x86Reg AddressReg, int Length )
 	stdstr_f strLen("%d",Length);
 	UnMap_AllFPRs();
 	
-	/*x86Reg StoreTemp1 = Map_TempReg(x86_Any,-1,FALSE);
+	/*x86Reg StoreTemp1 = Map_TempReg(x86_Any,-1,false);
 	MoveX86RegToX86Reg(AddressReg, StoreTemp1);
  	AndConstToX86Reg(StoreTemp1,0xFFC);*/		
 	BeforeCallDirect(m_RegWorkingSet);
@@ -4968,14 +5015,14 @@ void CMipsMemoryVM::Compile_SD()
 		}
 		else if (IsMapped(Opcode.rt))
 		{
-			Compile_SW_Register(Is64Bit(Opcode.rt) ? GetMipsRegMapHi(Opcode.rt) : Map_TempReg(x86_Any,Opcode.rt,TRUE), Address);
-			Compile_SW_Register(GetMipsRegMapLo(Opcode.rt), Address + 4);		
+			Compile_SW_Register(Is64Bit(Opcode.rt) ? GetMipsRegMapHi(Opcode.rt) : Map_TempReg(x86_Any, Opcode.rt, true), Address);
+			Compile_SW_Register(GetMipsRegMapLo(Opcode.rt), Address + 4);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.rt,TRUE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.rt, true);
 			Compile_SW_Register(TempReg1, Address);
-			Compile_SW_Register(Map_TempReg(TempReg1,Opcode.rt,FALSE), Address + 4);		
+			Compile_SW_Register(Map_TempReg(TempReg1,Opcode.rt,false), Address + 4);
 		}
 	}
 	else
@@ -4989,18 +5036,18 @@ void CMipsMemoryVM::Compile_SD()
 			ProtectGPR(Opcode.base);
 			if (Opcode.offset != 0)
 			{
-				TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+				TempReg1 = Map_TempReg(x86_Any, -1, false);
 				LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 			}
 			else
 			{
-				TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+				TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 			}
 			UnProtectGPR(Opcode.base);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 			AddConstToX86Reg(TempReg1,(short)Opcode.immediate);
 		}
 		
@@ -5008,7 +5055,7 @@ void CMipsMemoryVM::Compile_SD()
 		
 		if (g_System->bUseTlb())
 		{
-			TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg2 = Map_TempReg(x86_Any, -1, false);
 			MoveX86RegToX86Reg(TempReg1, TempReg2);
 			ShiftRightUnsignImmed(TempReg2,12);
 			MoveVariableDispToX86Reg(m_TLB_WriteMap,"m_TLB_WriteMap",TempReg2,TempReg2,4);
@@ -5035,22 +5082,22 @@ void CMipsMemoryVM::Compile_SD()
 				}
 				else
 				{
-					MoveX86regToX86regPointer(Map_TempReg(x86_Any,Opcode.rt,TRUE),TempReg1, TempReg2);
+					MoveX86regToX86regPointer(Map_TempReg(x86_Any, Opcode.rt, true), TempReg1, TempReg2);
 				}
 				AddConstToX86Reg(TempReg1,4);
 				MoveX86regToX86regPointer(GetMipsRegMapLo(Opcode.rt),TempReg1, TempReg2);
 			}
 			else
 			{	
-				x86Reg Reg = Map_TempReg(x86_Any,Opcode.rt,TRUE);
+				x86Reg Reg = Map_TempReg(x86_Any, Opcode.rt, true);
 				MoveX86regToX86regPointer(Reg,TempReg1, TempReg2);
 				AddConstToX86Reg(TempReg1,4);
-				MoveX86regToX86regPointer(Map_TempReg(Reg,Opcode.rt,FALSE),TempReg1, TempReg2);
+				MoveX86regToX86regPointer(Map_TempReg(Reg, Opcode.rt, false), TempReg1, TempReg2);
 			}
 		}
 		else
 		{
-			AndConstToX86Reg(TempReg1,0x1FFFFFFF);		
+			AndConstToX86Reg(TempReg1,0x1FFFFFFF);
 			if (IsConst(Opcode.rt))
 			{
 				if (Is64Bit(Opcode.rt))
@@ -5075,19 +5122,19 @@ void CMipsMemoryVM::Compile_SD()
 				}
 				else if (IsSigned(Opcode.rt))
 				{
-					MoveX86regToN64Mem(Map_TempReg(x86_Any,Opcode.rt,TRUE), TempReg1);
+					MoveX86regToN64Mem(Map_TempReg(x86_Any, Opcode.rt, true), TempReg1);
 				}
 				else
 				{
 					MoveConstToN64Mem(0,TempReg1);
 				}
-				MoveX86regToN64MemDisp(GetMipsRegMapLo(Opcode.rt),TempReg1, 4);		
+				MoveX86regToN64MemDisp(GetMipsRegMapLo(Opcode.rt),TempReg1, 4);
 			}
 			else
 			{	
 				x86Reg Reg;
-				MoveX86regToN64Mem(Reg = Map_TempReg(x86_Any,Opcode.rt,TRUE), TempReg1);
-				MoveX86regToN64MemDisp(Map_TempReg(Reg,Opcode.rt,FALSE), TempReg1,4);
+				MoveX86regToN64Mem(Reg = Map_TempReg(x86_Any, Opcode.rt, true), TempReg1);
+				MoveX86regToN64MemDisp(Map_TempReg(Reg, Opcode.rt, false), TempReg1, 4);
 			}
 		}
 	}
@@ -5104,10 +5151,10 @@ void CMipsMemoryVM::Compile_SDC1()
 	m_Section->CompileCop1Test();
 	
 	if (IsConst(Opcode.base))
-	{ 
+	{
 		DWORD Address = GetMipsRegLo(Opcode.base) + (short)Opcode.offset;
-		
-		TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+
+		TempReg1 = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_D[%d]",Opcode.ft);
 		MoveVariableToX86reg((BYTE *)&_FPR_D[Opcode.ft],Name,TempReg1);
 		AddConstToX86Reg(TempReg1,4);
@@ -5117,7 +5164,7 @@ void CMipsMemoryVM::Compile_SDC1()
 		sprintf(Name,"_FPR_D[%d]",Opcode.ft);
 		MoveVariableToX86reg(&_FPR_D[Opcode.ft],Name,TempReg1);
 		MoveX86PointerToX86reg(TempReg1,TempReg1);
-		Compile_SW_Register(TempReg1, Address + 4);		
+		Compile_SW_Register(TempReg1, Address + 4);
 		return;
 	}
 	if (IsMapped(Opcode.base))
@@ -5125,17 +5172,17 @@ void CMipsMemoryVM::Compile_SDC1()
 		ProtectGPR(Opcode.base);
 		if (Opcode.offset != 0)
 		{
-			TempReg1 = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, -1, false);
 			LeaSourceAndOffset(TempReg1,GetMipsRegMapLo(Opcode.base),(short)Opcode.offset);
 		}
 		else
 		{
-			TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+			TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		}
 	}
 	else
 	{
-		TempReg1 = Map_TempReg(x86_Any,Opcode.base,FALSE);
+		TempReg1 = Map_TempReg(x86_Any, Opcode.base, false);
 		if (Opcode.immediate == 0)
 		{ 
 			
@@ -5155,37 +5202,37 @@ void CMipsMemoryVM::Compile_SDC1()
 	}
 	if (g_System->bUseTlb())
 	{
-		TempReg2 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg2 = Map_TempReg(x86_Any, -1, false);
 		MoveX86RegToX86Reg(TempReg1, TempReg2);
 		ShiftRightUnsignImmed(TempReg2,12);
 		MoveVariableDispToX86Reg(m_TLB_WriteMap,"m_TLB_WriteMap",TempReg2,TempReg2,4);
 		CompileWriteTLBMiss(TempReg1,TempReg2);
 
-		TempReg3 = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg3 = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_D[%d]",Opcode.ft);
 		MoveVariableToX86reg((BYTE *)&_FPR_D[Opcode.ft],Name,TempReg3);
 		AddConstToX86Reg(TempReg3,4);
-		MoveX86PointerToX86reg(TempReg3,TempReg3);		
+		MoveX86PointerToX86reg(TempReg3,TempReg3);
 		MoveX86regToX86regPointer(TempReg3,TempReg1, TempReg2);
 		AddConstToX86Reg(TempReg1,4);
 
 		sprintf(Name,"_FPR_D[%d]",Opcode.ft);
 		MoveVariableToX86reg((BYTE *)&_FPR_D[Opcode.ft],Name,TempReg3);
-		MoveX86PointerToX86reg(TempReg3,TempReg3);		
+		MoveX86PointerToX86reg(TempReg3,TempReg3);
 		MoveX86regToX86regPointer(TempReg3,TempReg1, TempReg2);
 	}
 	else
 	{
-		AndConstToX86Reg(TempReg1,0x1FFFFFFF);		
-		TempReg3 = Map_TempReg(x86_Any,-1,FALSE);
+		AndConstToX86Reg(TempReg1,0x1FFFFFFF);
+		TempReg3 = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_D[%d]",Opcode.ft);
 		MoveVariableToX86reg((BYTE *)&_FPR_D[Opcode.ft],Name,TempReg3);
 		AddConstToX86Reg(TempReg3,4);
-		MoveX86PointerToX86reg(TempReg3,TempReg3);		
+		MoveX86PointerToX86reg(TempReg3,TempReg3);
 		MoveX86regToN64Mem(TempReg3, TempReg1);
 		sprintf(Name,"_FPR_D[%d]",Opcode.ft);
 		MoveVariableToX86reg((BYTE *)&_FPR_D[Opcode.ft],Name,TempReg3);
-		MoveX86PointerToX86reg(TempReg3,TempReg3);		
+		MoveX86PointerToX86reg(TempReg3,TempReg3);
 		MoveX86regToN64MemDisp(TempReg3, TempReg1,4);
 	}
 }
@@ -5195,14 +5242,17 @@ void CMipsMemoryVM::Compile_SDL()
 	OPCODE & Opcode = CRecompilerOps::m_Opcode;
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(Opcode.Hex,m_CompilePC));
+
 	if (Opcode.base != 0)
 	{
-		UnMap_GPR(Opcode.base,TRUE);
+		UnMap_GPR(Opcode.base, true);
 	}
+
 	if (Opcode.rt != 0)
 	{
-		UnMap_GPR(Opcode.rt,TRUE);
+		UnMap_GPR(Opcode.rt, true);
 	}
+
 	BeforeCallDirect(m_RegWorkingSet);
 	MoveConstToVariable(Opcode.Hex, &R4300iOp::m_Opcode.Hex, "R4300iOp::m_Opcode.Hex");
 	Call_Direct(R4300iOp::SDL, "R4300iOp::SDL");
@@ -5214,14 +5264,17 @@ void CMipsMemoryVM::Compile_SDR()
 	OPCODE & Opcode = CRecompilerOps::m_Opcode;
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(Opcode.Hex,m_CompilePC));
+
 	if (Opcode.base != 0)
 	{
-		UnMap_GPR(Opcode.base,TRUE);
+		UnMap_GPR(Opcode.base, true);
 	}
+
 	if (Opcode.rt != 0)
 	{
-		UnMap_GPR(Opcode.rt,TRUE);
+		UnMap_GPR(Opcode.rt, true);
 	}
+
 	BeforeCallDirect(m_RegWorkingSet);
 	MoveConstToVariable(Opcode.Hex, &R4300iOp::m_Opcode.Hex, "R4300iOp::m_Opcode.Hex");
 	Call_Direct(R4300iOp::SDR, "R4300iOp::SDR");
@@ -5236,7 +5289,7 @@ LPCTSTR CMipsMemoryVM::LabelName ( DWORD Address ) const
 	//	return (*theIterator).second;
 	//}
 	
-	sprintf(m_strLabelName,"0x%08X",Address);		
+	sprintf(m_strLabelName,"0x%08X",Address);
 	return m_strLabelName;
 }
 

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
@@ -27,7 +27,7 @@ public:
 	static void ReserveMemory();
 	static void FreeReservedMemory();
 
-	BOOL   Initialize   ();
+	bool   Initialize   ();
 	void   Reset        ( bool EraseMemory );
 	
 	BYTE * Rdram        ();
@@ -36,25 +36,25 @@ public:
 	BYTE * Imem         ();
 	BYTE * PifRam       ();
 
-	BOOL  LB_VAddr     ( DWORD VAddr, BYTE & Value );
-	BOOL  LH_VAddr     ( DWORD VAddr, WORD & Value ); 
-	BOOL  LW_VAddr     ( DWORD VAddr, DWORD & Value );
-	BOOL  LD_VAddr     ( DWORD VAddr, QWORD & Value );
+	bool  LB_VAddr     ( DWORD VAddr, BYTE & Value );
+	bool  LH_VAddr     ( DWORD VAddr, WORD & Value ); 
+	bool  LW_VAddr     ( DWORD VAddr, DWORD & Value );
+	bool  LD_VAddr     ( DWORD VAddr, QWORD & Value );
 
-	BOOL  LB_PAddr     ( DWORD PAddr, BYTE & Value );
-	BOOL  LH_PAddr     ( DWORD PAddr, WORD & Value ); 
-	BOOL  LW_PAddr     ( DWORD PAddr, DWORD & Value );
-	BOOL  LD_PAddr     ( DWORD PAddr, QWORD & Value );
+	bool  LB_PAddr     ( DWORD PAddr, BYTE & Value );
+	bool  LH_PAddr     ( DWORD PAddr, WORD & Value ); 
+	bool  LW_PAddr     ( DWORD PAddr, DWORD & Value );
+	bool  LD_PAddr     ( DWORD PAddr, QWORD & Value );
 
-	BOOL  SB_VAddr     ( DWORD VAddr, BYTE Value );
-	BOOL  SH_VAddr     ( DWORD VAddr, WORD Value );
-	BOOL  SW_VAddr     ( DWORD VAddr, DWORD Value );
-	BOOL  SD_VAddr     ( DWORD VAddr, QWORD Value );
+	bool  SB_VAddr     ( DWORD VAddr, BYTE Value );
+	bool  SH_VAddr     ( DWORD VAddr, WORD Value );
+	bool  SW_VAddr     ( DWORD VAddr, DWORD Value );
+	bool  SD_VAddr     ( DWORD VAddr, QWORD Value );
 
-	BOOL  SB_PAddr     ( DWORD PAddr, BYTE Value );
-	BOOL  SH_PAddr     ( DWORD PAddr, WORD Value );
-	BOOL  SW_PAddr     ( DWORD PAddr, DWORD Value );
-	BOOL  SD_PAddr     ( DWORD PAddr, QWORD Value );
+	bool  SB_PAddr     ( DWORD PAddr, BYTE Value );
+	bool  SH_PAddr     ( DWORD PAddr, WORD Value );
+	bool  SW_PAddr     ( DWORD PAddr, DWORD Value );
+	bool  SD_PAddr     ( DWORD PAddr, QWORD Value );
 
 	int   MemoryFilter(DWORD dwExptCode, void * lpExceptionPointer);
 	void  UpdateFieldSerration(unsigned int interlaced);
@@ -94,8 +94,8 @@ public:
 	void Compile_SDC1();
 
 	void ResetMemoryStack    ( CRegInfo& RegInfo );
-	void Compile_LB          ( CX86Ops::x86Reg Reg, DWORD Addr, BOOL SignExtend );
-	void Compile_LH          ( CX86Ops::x86Reg Reg, DWORD Addr, BOOL SignExtend );
+	void Compile_LB          ( CX86Ops::x86Reg Reg, DWORD Addr, bool SignExtend );
+	void Compile_LH          ( CX86Ops::x86Reg Reg, DWORD Addr, bool SignExtend );
 	void Compile_LW          ( CX86Ops::x86Reg Reg, DWORD Addr );
 	void Compile_SB_Const    ( BYTE Value, DWORD Addr );
 	void Compile_SB_Register ( CX86Ops::x86Reg Reg, DWORD Addr );
@@ -129,13 +129,13 @@ private:
 	static void ChangeSpStatus  ();
 	static void ChangeMiIntrMask();
 
-	int  LB_NonMemory         ( DWORD PAddr, DWORD * Value, BOOL SignExtend );
-	int  LH_NonMemory         ( DWORD PAddr, DWORD * Value, int SignExtend );
-	int  LW_NonMemory         ( DWORD PAddr, DWORD * Value );
+	bool LB_NonMemory         ( DWORD PAddr, DWORD * Value, bool SignExtend );
+	bool LH_NonMemory         ( DWORD PAddr, DWORD * Value, bool SignExtend );
+	bool LW_NonMemory         ( DWORD PAddr, DWORD * Value );
 
-	int  SB_NonMemory         ( DWORD PAddr, BYTE Value );
-	int  SH_NonMemory         ( DWORD PAddr, WORD Value );
-	int  SW_NonMemory         ( DWORD PAddr, DWORD Value );
+	bool SB_NonMemory         ( DWORD PAddr, BYTE Value );
+	bool SH_NonMemory         ( DWORD PAddr, WORD Value );
+	bool SW_NonMemory         ( DWORD PAddr, DWORD Value );
 
 	void Compile_StoreInstructClean (x86Reg AddressReg, int Length );
 

--- a/Source/Project64/N64 System/Mips/Register Class.cpp
+++ b/Source/Project64/N64 System/Mips/Register Class.cpp
@@ -329,7 +329,7 @@ void CRegisters::CheckInterrupts()
 	}
 }
 
-void CRegisters::DoAddressError ( BOOL DelaySlot, DWORD BadVaddr, BOOL FromRead) 
+void CRegisters::DoAddressError(bool DelaySlot, DWORD BadVaddr, bool FromRead)
 {
 	if (bHaveDebugger())
 	{
@@ -385,7 +385,7 @@ void CRegisters::FixFpuLocations()
 	}
 }
 
-void CRegisters::DoBreakException ( BOOL DelaySlot) 
+void CRegisters::DoBreakException(bool DelaySlot)
 {
 	if (bHaveDebugger())
 	{
@@ -413,7 +413,7 @@ void CRegisters::DoBreakException ( BOOL DelaySlot)
 	m_PROGRAM_COUNTER = 0x80000180;
 }
 
-void CRegisters::DoCopUnusableException ( BOOL DelaySlot, int Coprocessor )
+void CRegisters::DoCopUnusableException(bool DelaySlot, int Coprocessor)
 {
 	if (bHaveDebugger())
 	{
@@ -446,26 +446,31 @@ void CRegisters::DoCopUnusableException ( BOOL DelaySlot, int Coprocessor )
 }
 
 
-BOOL CRegisters::DoIntrException ( BOOL DelaySlot ) 
+bool CRegisters::DoIntrException(bool DelaySlot)
 {
-	if (( STATUS_REGISTER & STATUS_IE   ) == 0 )
+	if ((STATUS_REGISTER & STATUS_IE) == 0)
 	{
-		return FALSE;
+		return false;
 	}
-	if (( STATUS_REGISTER & STATUS_EXL  ) != 0 )
+
+	if ((STATUS_REGISTER & STATUS_EXL) != 0)
 	{
-		return FALSE;
+		return false;
 	}
-	if (( STATUS_REGISTER & STATUS_ERL  ) != 0 )
+
+	if ((STATUS_REGISTER & STATUS_ERL) != 0)
 	{
-		return FALSE;
+		return false;
 	}
+
 	if (LogOptions.GenerateLog && LogOptions.LogExceptions && !LogOptions.NoInterrupts)
 	{
-		LogMessage("%08X: Interrupt Generated", m_PROGRAM_COUNTER );
+		LogMessage("%08X: Interrupt Generated", m_PROGRAM_COUNTER);
 	}
+
 	CAUSE_REGISTER = FAKE_CAUSE_REGISTER;
 	CAUSE_REGISTER |= EXC_INT;
+
 	if (DelaySlot)
 	{
 		CAUSE_REGISTER |= CAUSE_BD;
@@ -475,12 +480,13 @@ BOOL CRegisters::DoIntrException ( BOOL DelaySlot )
 	{
 		EPC_REGISTER = m_PROGRAM_COUNTER;
 	}
+
 	STATUS_REGISTER |= STATUS_EXL;
 	m_PROGRAM_COUNTER = 0x80000180;
-	return TRUE;
+	return true;
 }
 
-void CRegisters::DoTLBReadMiss ( BOOL DelaySlot, DWORD BadVaddr ) 
+void CRegisters::DoTLBReadMiss(bool DelaySlot, DWORD BadVaddr)
 {
 	CAUSE_REGISTER = EXC_RMISS;
 	BAD_VADDR_REGISTER = BadVaddr;
@@ -518,7 +524,7 @@ void CRegisters::DoTLBReadMiss ( BOOL DelaySlot, DWORD BadVaddr )
 	}
 }
 
-void CRegisters::DoSysCallException ( BOOL DelaySlot) 
+void CRegisters::DoSysCallException(bool DelaySlot)
 {
 	if (bHaveDebugger())
 	{

--- a/Source/Project64/N64 System/Mips/Register Class.h
+++ b/Source/Project64/N64 System/Mips/Register Class.h
@@ -532,12 +532,12 @@ public:
 
 
 	void CheckInterrupts        ();
-	void DoAddressError         ( BOOL DelaySlot, DWORD BadVaddr, BOOL FromRead ); 
-	void DoBreakException       ( BOOL DelaySlot ); 
-	void DoCopUnusableException ( BOOL DelaySlot, int Coprocessor );
-	BOOL DoIntrException        ( BOOL DelaySlot );
-	void DoTLBReadMiss          ( BOOL DelaySlot, DWORD BadVaddr );
-	void DoSysCallException     ( BOOL DelaySlot);
+	void DoAddressError         ( bool DelaySlot, DWORD BadVaddr, bool FromRead );
+	void DoBreakException       ( bool DelaySlot );
+	void DoCopUnusableException ( bool DelaySlot, int Coprocessor );
+	bool DoIntrException        ( bool DelaySlot );
+	void DoTLBReadMiss          ( bool DelaySlot, DWORD BadVaddr );
+	void DoSysCallException     ( bool DelaySlot);
 	void FixFpuLocations        ();
 	void Reset                  ();
 	void SetAsCurrentSystem     ();

--- a/Source/Project64/N64 System/Mips/Sram.cpp
+++ b/Source/Project64/N64 System/Mips/Sram.cpp
@@ -26,7 +26,7 @@ CSram::~CSram()
 	}
 }
 
-BOOL CSram::LoadSram()
+bool CSram::LoadSram()
 {
 	CPath FileName;
 

--- a/Source/Project64/N64 System/Mips/Sram.h
+++ b/Source/Project64/N64 System/Mips/Sram.h
@@ -20,7 +20,7 @@ public:
 	void DmaToSram(BYTE * Source, int StartOffset, int len);
 
 private:
-	BOOL LoadSram();
+	bool LoadSram();
 
 	bool   m_ReadOnly;
 	HANDLE m_hFile;

--- a/Source/Project64/N64 System/Mips/System Events.h
+++ b/Source/Project64/N64 System/Mips/System Events.h
@@ -62,7 +62,7 @@ public:
 	void ExecuteEvents();
 	void QueueEvent(SystemEvent action);
 
-	const BOOL& DoSomething() const
+	const bool& DoSomething() const
 	{
 		return m_bDoSomething;
 	}
@@ -77,6 +77,6 @@ private:
 	CN64System    * m_System;
 	CPlugins      * m_Plugins;
 	EventList       m_Events;
-	BOOL            m_bDoSomething;
+	bool            m_bDoSomething;
 	CriticalSection m_CS;
 };

--- a/Source/Project64/N64 System/Mips/TLB class.cpp
+++ b/Source/Project64/N64 System/Mips/TLB class.cpp
@@ -202,7 +202,7 @@ void CTLB::SetupTLB_Entry (int index, bool Random)
 	m_FastTlb[FastIndx].VALID = m_tlb[index].EntryLo0.V;
 	m_FastTlb[FastIndx].DIRTY = m_tlb[index].EntryLo0.D; 
 	m_FastTlb[FastIndx].GLOBAL = m_tlb[index].EntryLo0.GLOBAL & m_tlb[index].EntryLo1.GLOBAL;
-	m_FastTlb[FastIndx].ValidEntry = FALSE;
+	m_FastTlb[FastIndx].ValidEntry = false;
 	m_FastTlb[FastIndx].Random = Random;
 	m_FastTlb[FastIndx].Probed = false;
 
@@ -220,7 +220,7 @@ void CTLB::SetupTLB_Entry (int index, bool Random)
 	m_FastTlb[FastIndx].VALID = m_tlb[index].EntryLo1.V;
 	m_FastTlb[FastIndx].DIRTY = m_tlb[index].EntryLo1.D; 
 	m_FastTlb[FastIndx].GLOBAL = m_tlb[index].EntryLo0.GLOBAL & m_tlb[index].EntryLo1.GLOBAL;
-	m_FastTlb[FastIndx].ValidEntry = FALSE;
+	m_FastTlb[FastIndx].ValidEntry = false;
 	m_FastTlb[FastIndx].Random = Random;
 	m_FastTlb[FastIndx].Probed = false;
 

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -1595,43 +1595,45 @@ bool CN64System::LoadState(LPCSTR FileName)
 		}
 		DWORD Value;
 		while (port == UNZ_OK) 
-        {
+		{
 			unz_file_info info;
 			char zname[132];
 
 			unzGetCurrentFileInfo(file, &info, zname, 128, NULL,0, NULL,0);
-		    if (unzLocateFile(file, zname, 1) != UNZ_OK ) 
-            {
+			if (unzLocateFile(file, zname, 1) != UNZ_OK ) 
+			{
 				unzClose(file);
 				port = -1;
 				continue;
 			}
 			if( unzOpenCurrentFile(file) != UNZ_OK ) 
-            {
+			{
 				unzClose(file);
 				port = -1;
 				continue;
 			}
 			unzReadCurrentFile(file,&Value,4);
 			if (Value != 0x23D8A6C8 && Value != 0x56D2CD23) 
-            { 
+			{
 				unzCloseCurrentFile(file);
 				port = unzGoToNextFile(file);
 				continue;
 			}
 			if (!LoadedZipFile && Value == 0x23D8A6C8 && port == UNZ_OK) 
-            {
+			{
 				unzReadCurrentFile(file,&SaveRDRAMSize,sizeof(SaveRDRAMSize));
 				//Check header
 
 				BYTE LoadHeader[64];
-				unzReadCurrentFile(file,LoadHeader,0x40);	
+				unzReadCurrentFile(file,LoadHeader,0x40);
 				if (memcmp(LoadHeader,g_Rom->GetRomAddress(),0x40) != 0)
-                {
-					//if (inFullScreen) { return FALSE; }
+				{
+					//if (inFullScreen) { return false; }
 					int result = MessageBoxW(NULL,GS(MSG_SAVE_STATE_HEADER),GS(MSG_MSGBOX_TITLE),
 						MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON2);
-					if (result == IDNO) { return FALSE; }
+
+					if (result == IDNO)
+						return false;
 				}
 				Reset(false,true);
 
@@ -1666,8 +1668,8 @@ bool CN64System::LoadState(LPCSTR FileName)
 				continue;
 			}
 			if (LoadedZipFile && Value == 0x56D2CD23 && port == UNZ_OK) 
-            {
-				m_SystemTimer.LoadData(file);			
+			{
+				m_SystemTimer.LoadData(file);
 			}
 			unzCloseCurrentFile(file);
 			port = unzGoToNextFile(file);
@@ -1675,27 +1677,32 @@ bool CN64System::LoadState(LPCSTR FileName)
 		unzClose(file);
 	}
 	if (!LoadedZipFile) 
-    {
+	{
 		HANDLE hSaveFile = CreateFile(FileNameStr.c_str(),GENERIC_WRITE | GENERIC_READ, FILE_SHARE_READ,NULL,
 			OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL | FILE_FLAG_RANDOM_ACCESS, NULL);
 		if (hSaveFile == INVALID_HANDLE_VALUE) 
-        {
-            g_Notify->DisplayMessage(5,L"%s %s",GS(MSG_UNABLED_LOAD_STATE),FileNameStr.ToUTF16().c_str());
+		{
+			g_Notify->DisplayMessage(5,L"%s %s",GS(MSG_UNABLED_LOAD_STATE),FileNameStr.ToUTF16().c_str());
 			return false;
 		}
-		SetFilePointer(hSaveFile,0,NULL,FILE_BEGIN);	
+
+		SetFilePointer(hSaveFile,0,NULL,FILE_BEGIN);
 		ReadFile( hSaveFile,&Value,sizeof(Value),&dwRead,NULL);
-		if (Value != 0x23D8A6C8) { return FALSE; }
-		ReadFile( hSaveFile,&SaveRDRAMSize,sizeof(SaveRDRAMSize),&dwRead,NULL);		
+		if (Value != 0x23D8A6C8)
+			return false;
+
+		ReadFile( hSaveFile,&SaveRDRAMSize,sizeof(SaveRDRAMSize),&dwRead,NULL);
 		//Check header
 		BYTE LoadHeader[64];
-		ReadFile( hSaveFile,LoadHeader,0x40,&dwRead,NULL);	
+		ReadFile( hSaveFile,LoadHeader,0x40,&dwRead,NULL);
 		if (memcmp(LoadHeader,g_Rom->GetRomAddress(),0x40) != 0)
-        {
-			//if (inFullScreen) { return FALSE; }
+		{
+			//if (inFullScreen) { return false; }
 			int result = MessageBoxW(NULL,GS(MSG_SAVE_STATE_HEADER),GS(MSG_MSGBOX_TITLE),
 				MB_YESNO|MB_ICONQUESTION|MB_DEFBUTTON2);
-			if (result == IDNO) { return FALSE; }
+
+			if (result == IDNO)
+				return false;
 		}
 		Reset(false,true);
 		m_MMU_VM.UnProtectMemory(0x80000000,0x80000000 + g_Settings->LoadDword(Game_RDRamSize) - 4);
@@ -1737,7 +1744,7 @@ bool CN64System::LoadState(LPCSTR FileName)
 	
 	//Fix Random Register
 	while ((int)m_Reg.RANDOM_REGISTER < (int)m_Reg.WIRED_REGISTER)
-    {
+	{
 		m_Reg.RANDOM_REGISTER += 32 - m_Reg.WIRED_REGISTER;
 	}
 	//Fix up timer
@@ -1767,7 +1774,7 @@ bool CN64System::LoadState(LPCSTR FileName)
 	if (bFastSP() && m_Recomp) { m_Recomp->ResetMemoryStackPos(); }
 
 	if (g_Settings->LoadDword(Game_CpuType) == CPU_SyncCores) 
-    {
+	{
 		if (m_SyncCPU)
 		{
 			for (int i = 0; i < (sizeof(m_LastSuccessSyncPC)/sizeof(m_LastSuccessSyncPC[0])); i++) 
@@ -1782,7 +1789,7 @@ bool CN64System::LoadState(LPCSTR FileName)
 	}
 	WriteTrace(TraceDebug,__FUNCTION__ ": 13");
 	std::wstring LoadMsg = g_Lang->GetString(MSG_LOADED_STATE);
-    g_Notify->DisplayMessage(5,L"%s %s",LoadMsg.c_str(),CPath(FileNameStr).GetNameExtension().ToUTF16().c_str());
+	g_Notify->DisplayMessage(5,L"%s %s",LoadMsg.c_str(),CPath(FileNameStr).GetNameExtension().ToUTF16().c_str());
 	WriteTrace(TraceDebug,__FUNCTION__ ": Done");
 	return true;
 }

--- a/Source/Project64/N64 System/N64 Class.h
+++ b/Source/Project64/N64 System/N64 Class.h
@@ -144,7 +144,7 @@ private:
 	bool            m_RspBroke;
 	bool            m_DMAUsed;
 	DWORD           m_Buttons[4];
-	BOOL            m_TestTimer;
+	bool            m_TestTimer;
 	DWORD           m_NextInstruction;
 	DWORD           m_JumpToLocation;
 	DWORD           m_TLBLoadAddress;

--- a/Source/Project64/N64 System/N64 Rom Class.cpp
+++ b/Source/Project64/N64 System/N64 Rom Class.cpp
@@ -101,16 +101,17 @@ bool CN64Rom::AllocateAndLoadN64Image ( const char * FileLoc, bool LoadBootCodeO
 	return true;
 }
 
-bool CN64Rom::AllocateAndLoadZipImage ( const char * FileLoc, bool LoadBootCodeOnly ) {
+bool CN64Rom::AllocateAndLoadZipImage(const char * FileLoc, bool LoadBootCodeOnly) {
 	unzFile file = unzOpen(FileLoc);
-	if (file == NULL) { return false; }
+	if (file == NULL)
+		return false;
 
 	int port = unzGoToFirstFile(file);
-	bool FoundRom = FALSE; 
+	bool FoundRom = false; 
 	
 	//scan through all files in zip to a suitable file is found
-	while(port == UNZ_OK && FoundRom == FALSE) {
-	    unz_file_info info;
+	while(port == UNZ_OK && !FoundRom) {
+		unz_file_info info;
 		char zname[_MAX_PATH];
 
 		unzGetCurrentFileInfo(file, &info, zname, sizeof(zname), NULL,0, NULL,0);
@@ -185,9 +186,9 @@ bool CN64Rom::AllocateAndLoadZipImage ( const char * FileLoc, bool LoadBootCodeO
 			g_Notify->DisplayMessage(1,L"");
 		}
 		unzCloseCurrentFile(file);
-		if (FoundRom == FALSE) {
+
+		if (!FoundRom)
 			port = unzGoToNextFile(file);
-		}
 	}
 	unzClose(file);
 	

--- a/Source/Project64/N64 System/Recompiler/Code Section.cpp
+++ b/Source/Project64/N64 System/Recompiler/Code Section.cpp
@@ -12,17 +12,18 @@
 
 void InPermLoop();
 
-bool DelaySlotEffectsCompare ( DWORD PC, DWORD Reg1, DWORD Reg2 );
+bool DelaySlotEffectsCompare(DWORD PC, DWORD Reg1, DWORD Reg2);
 
-int DelaySlotEffectsJump (DWORD JumpPC) {
+static bool DelaySlotEffectsJump(DWORD JumpPC) {
 	OPCODE Command;
 
-	if (!g_MMU->LW_VAddr(JumpPC, Command.Hex)) { return TRUE; }
+	if (!g_MMU->LW_VAddr(JumpPC, Command.Hex))
+		return true;
 
 	switch (Command.op) {
 	case R4300i_SPECIAL:
 		switch (Command.funct) {
-		case R4300i_SPECIAL_JR:	return DelaySlotEffectsCompare(JumpPC,Command.rs,0);
+		case R4300i_SPECIAL_JR: return DelaySlotEffectsCompare(JumpPC,Command.rs,0);
 		case R4300i_SPECIAL_JALR: return DelaySlotEffectsCompare(JumpPC,Command.rs,31);
 		}
 		break;
@@ -39,7 +40,7 @@ int DelaySlotEffectsJump (DWORD JumpPC) {
 		break;
 	case R4300i_JAL: 
 	case R4300i_SPECIAL_JALR: return DelaySlotEffectsCompare(JumpPC,31,0); break;
-	case R4300i_J: return FALSE;
+	case R4300i_J: return false;
 	case R4300i_BEQ: 
 	case R4300i_BNE: 
 	case R4300i_BLEZ: 
@@ -54,19 +55,20 @@ int DelaySlotEffectsJump (DWORD JumpPC) {
 			case R4300i_COP1_BC_BCFL:
 			case R4300i_COP1_BC_BCTL:
 				{
-					int EffectDelaySlot;
+					bool EffectDelaySlot = false;
 					OPCODE NewCommand;
 
-					if (!g_MMU->LW_VAddr(JumpPC + 4, NewCommand.Hex)) { return TRUE; }
-					
-					EffectDelaySlot = FALSE;
+					if (!g_MMU->LW_VAddr(JumpPC + 4, NewCommand.Hex)) {
+						return true;
+					}
+
 					if (NewCommand.op == R4300i_CP1) {
-						if (NewCommand.fmt == R4300i_COP1_S && (NewCommand.funct & 0x30) == 0x30 ) {
-							EffectDelaySlot = TRUE;
-						} 
-						if (NewCommand.fmt == R4300i_COP1_D && (NewCommand.funct & 0x30) == 0x30 ) {
-							EffectDelaySlot = TRUE;
-						} 
+						if (NewCommand.fmt == R4300i_COP1_S && (NewCommand.funct & 0x30) == 0x30) {
+							EffectDelaySlot = true;
+						}
+						if (NewCommand.fmt == R4300i_COP1_D && (NewCommand.funct & 0x30) == 0x30) {
+							EffectDelaySlot = true;
+						}
 					}
 					return EffectDelaySlot;
 				} 
@@ -81,7 +83,7 @@ int DelaySlotEffectsJump (DWORD JumpPC) {
 	case R4300i_BGTZL: 
 		return DelaySlotEffectsCompare(JumpPC,Command.rs,Command.rt);
 	}
-	return TRUE;
+	return true;
 }
 
 CCodeSection::CCodeSection( CCodeBlock * CodeBlock, DWORD EnterPC, DWORD ID, bool LinkAllowed) :
@@ -106,7 +108,7 @@ CCodeSection::~CCodeSection()
 {
 }
 
-void CCodeSection::CompileExit ( DWORD JumpPC, DWORD TargetPC, CRegInfo &ExitRegSet, CExitInfo::EXIT_REASON reason, int CompileNow, void (*x86Jmp)(const char * Label, DWORD Value))
+void CCodeSection::CompileExit(DWORD JumpPC, DWORD TargetPC, CRegInfo &ExitRegSet, CExitInfo::EXIT_REASON reason, bool CompileNow, void(*x86Jmp)(const char * Label, DWORD Value))
 {
 	if (!CompileNow) 
 	{
@@ -569,7 +571,7 @@ void CCodeSection::GenerateSectionLinkage()
 	{
 		if (JumpInfo[i]->FallThrough && !TargetSection[i]->GenerateX86Code(m_BlockInfo->NextTest())) 
 		{ 
-			JumpInfo[i]->FallThrough = FALSE;				
+			JumpInfo[i]->FallThrough = false;
 			JmpLabel32(JumpInfo[i]->BranchLabel.c_str(),0);
 			JumpInfo[i]->LinkLocation = (DWORD *)(m_RecompPos - 4);
 		}
@@ -859,10 +861,12 @@ void CCodeSection::SetContinueAddress (DWORD JumpPC, DWORD TargetPC)
 
 void CCodeSection::CompileCop1Test()
 {
-	if (m_RegWorkingSet.FpuBeenUsed()) { return; }
+	if (m_RegWorkingSet.FpuBeenUsed())
+		return;
+
 	TestVariable(STATUS_CU1,&g_Reg->STATUS_REGISTER,"STATUS_REGISTER");
-	CompileExit(m_CompilePC,m_CompilePC,m_RegWorkingSet,CExitInfo::COP1_Unuseable,FALSE,JeLabel32);
-	m_RegWorkingSet.FpuBeenUsed() = TRUE;
+	CompileExit(m_CompilePC,m_CompilePC,m_RegWorkingSet,CExitInfo::COP1_Unuseable,false,JeLabel32);
+	m_RegWorkingSet.FpuBeenUsed() = true;
 }
 
 bool CCodeSection::ParentContinue()

--- a/Source/Project64/N64 System/Recompiler/Code Section.h
+++ b/Source/Project64/N64 System/Recompiler/Code Section.h
@@ -28,7 +28,7 @@ public:
 	bool CreateSectionLinkage      ();
 	bool GenerateX86Code           ( DWORD Test );
 	void GenerateSectionLinkage    ();
-	void CompileExit               ( DWORD JumpPC, DWORD TargetPC, CRegInfo &ExitRegSet, CExitInfo::EXIT_REASON reason, int CompileNow, void (*x86Jmp)(const char * Label, DWORD Value));
+	void CompileExit               ( DWORD JumpPC, DWORD TargetPC, CRegInfo &ExitRegSet, CExitInfo::EXIT_REASON reason, bool CompileNow, void (*x86Jmp)(const char * Label, DWORD Value));
 	void DetermineLoop             ( DWORD Test, DWORD Test2, DWORD TestID );
 	bool FixConstants              ( DWORD Test );
 	CCodeSection * ExistingSection ( DWORD Addr, DWORD Test );

--- a/Source/Project64/N64 System/Recompiler/Recompiler Memory.cpp
+++ b/Source/Project64/N64 System/Recompiler/Recompiler Memory.cpp
@@ -30,20 +30,20 @@ CRecompMemory::~CRecompMemory()
 bool CRecompMemory::AllocateMemory()
 {
 	BYTE * RecompCodeBase = (BYTE *)VirtualAlloc( NULL, MaxCompileBufferSize + 4, MEM_RESERVE|MEM_TOP_DOWN, PAGE_EXECUTE_READWRITE);
-	if (RecompCodeBase==NULL) 
-	{  
+	if (RecompCodeBase == NULL)
+	{
 		WriteTrace(TraceError,__FUNCTION__ ": failed to allocate RecompCodeBase");
 		g_Notify->DisplayError(MSG_MEM_ALLOC_ERROR);
-		return FALSE;
+		return false;
 	}
 
 	m_RecompCode = (BYTE *)VirtualAlloc( RecompCodeBase, InitialCompileBufferSize, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
-	if (m_RecompCode==NULL) 
-	{  
+	if (m_RecompCode == NULL)
+	{
 		WriteTrace(TraceError,__FUNCTION__ ": failed to commit initial buffer");
 		VirtualFree( RecompCodeBase, 0 , MEM_RELEASE);
 		g_Notify->DisplayError(MSG_MEM_ALLOC_ERROR);
-		return FALSE;
+		return false;
 	}
 	m_RecompSize = InitialCompileBufferSize;
 	m_RecompPos = m_RecompCode;

--- a/Source/Project64/N64 System/Recompiler/Recompiler Ops.cpp
+++ b/Source/Project64/N64 System/Recompiler/Recompiler Ops.cpp
@@ -21,38 +21,36 @@ void CRecompilerOps::CompileReadTLBMiss (DWORD VirtualAddress, x86Reg LookUpReg 
 {
 	MoveConstToVariable(VirtualAddress,g_TLBLoadAddress,"TLBLoadAddress");
 	TestX86RegToX86Reg(LookUpReg,LookUpReg);
-	m_Section->CompileExit(m_CompilePC, m_CompilePC,m_RegWorkingSet,CExitInfo::TLBReadMiss,FALSE,JeLabel32);
+	m_Section->CompileExit(m_CompilePC, m_CompilePC, m_RegWorkingSet, CExitInfo::TLBReadMiss, false, JeLabel32);
 }
 
 void CRecompilerOps::CompileReadTLBMiss (x86Reg AddressReg, x86Reg LookUpReg ) 
 {
 	MoveX86regToVariable(AddressReg,g_TLBLoadAddress,"TLBLoadAddress");
 	TestX86RegToX86Reg(LookUpReg,LookUpReg);
-	m_Section->CompileExit(m_CompilePC, m_CompilePC,m_RegWorkingSet,CExitInfo::TLBReadMiss,FALSE,JeLabel32);
+	m_Section->CompileExit(m_CompilePC, m_CompilePC, m_RegWorkingSet, CExitInfo::TLBReadMiss, false, JeLabel32);
 }
 
 void CRecompilerOps::CompileWriteTLBMiss (x86Reg AddressReg, x86Reg LookUpReg ) 
 {
 	MoveX86regToVariable(AddressReg,&g_TLBStoreAddress,"g_TLBStoreAddress");
 	TestX86RegToX86Reg(LookUpReg,LookUpReg);
-	m_Section->CompileExit(m_CompilePC, m_CompilePC,m_RegWorkingSet,CExitInfo::TLBWriteMiss,FALSE,JeLabel32);
+	m_Section->CompileExit(m_CompilePC, m_CompilePC, m_RegWorkingSet, CExitInfo::TLBWriteMiss, false, JeLabel32);
 }
 
 bool DelaySlotEffectsCompare ( DWORD PC, DWORD Reg1, DWORD Reg2 );
 
 /************************** Branch functions  ************************/
-void CRecompilerOps::Compile_Branch (CRecompilerOps::BranchFunction CompareFunc, BRANCH_TYPE BranchType, BOOL Link)
+void CRecompilerOps::Compile_Branch (CRecompilerOps::BranchFunction CompareFunc, BRANCH_TYPE BranchType, bool Link)
 {
 	static CRegInfo RegBeforeDelay;
 	static bool EffectDelaySlot;
 
-	if ( m_NextInstruction == NORMAL ) {
+	if (m_NextInstruction == NORMAL) {
 		CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 		
 		if (m_CompilePC + ((short)m_Opcode.offset << 2) + 4 == m_CompilePC + 8)
-		{
-			return; 
-		}
+			return;
 
 		if ((m_CompilePC & 0xFFC) != 0xFFC) 
 		{
@@ -68,14 +66,13 @@ void CRecompilerOps::Compile_Branch (CRecompilerOps::BranchFunction CompareFunc,
 						ExitThread(0);
 					}
 					
-					EffectDelaySlot = FALSE;
+					EffectDelaySlot = false;
 					if (Command.op == R4300i_CP1) {
-						if (Command.fmt == R4300i_COP1_S && (Command.funct & 0x30) == 0x30 ) {
-							EffectDelaySlot = TRUE;
-						} 
-						if (Command.fmt == R4300i_COP1_D && (Command.funct & 0x30) == 0x30 ) {
-							EffectDelaySlot = TRUE;
-						} 
+						if (Command.fmt == R4300i_COP1_S && (Command.funct & 0x30) == 0x30)
+							EffectDelaySlot = true;
+
+						if (Command.fmt == R4300i_COP1_D && (Command.funct & 0x30) == 0x30)
+							EffectDelaySlot = true;
 					}
 				}
 				break;
@@ -94,7 +91,7 @@ void CRecompilerOps::Compile_Branch (CRecompilerOps::BranchFunction CompareFunc,
 		}
 		m_Section->m_Jump.LinkLocation    = NULL;
 		m_Section->m_Jump.LinkLocation2   = NULL;
-		m_Section->m_Jump.DoneDelaySlot   = FALSE;
+		m_Section->m_Jump.DoneDelaySlot   = false;
 		m_Section->m_Cont.JumpPC          = m_CompilePC;
 		m_Section->m_Cont.TargetPC        = m_CompilePC + 8;
 		if (m_Section->m_ContinueSection != NULL) {
@@ -104,17 +101,17 @@ void CRecompilerOps::Compile_Branch (CRecompilerOps::BranchFunction CompareFunc,
 		}
 		m_Section->m_Cont.LinkLocation    = NULL;
 		m_Section->m_Cont.LinkLocation2   = NULL;
-		m_Section->m_Cont.DoneDelaySlot   = FALSE;
+		m_Section->m_Cont.DoneDelaySlot   = false;
 		if (m_Section->m_Jump.TargetPC < m_Section->m_Cont.TargetPC) {
-			m_Section->m_Cont.FallThrough = FALSE;
-			m_Section->m_Jump.FallThrough = TRUE;
+			m_Section->m_Cont.FallThrough = false;
+			m_Section->m_Jump.FallThrough = true;
 		} else {
-			m_Section->m_Cont.FallThrough = TRUE;
-			m_Section->m_Jump.FallThrough = FALSE;
+			m_Section->m_Cont.FallThrough = true;
+			m_Section->m_Jump.FallThrough = false;
 		}
 
 		if (Link) {
-			UnMap_GPR( 31, FALSE);
+			UnMap_GPR(31, false);
 			m_RegWorkingSet.SetMipsRegLo(31,m_CompilePC + 8);
 			m_RegWorkingSet.SetMipsRegState(31,CRegInfo::STATE_CONST_32_SIGN);
 		}
@@ -141,7 +138,7 @@ void CRecompilerOps::Compile_Branch (CRecompilerOps::BranchFunction CompareFunc,
 						SetJump32((DWORD *)m_Section->m_Jump.LinkLocation2,(DWORD *)m_RecompPos);
 						m_Section->m_Jump.LinkLocation2 = NULL;
 					}
-					m_Section->m_Jump.FallThrough = TRUE;
+					m_Section->m_Jump.FallThrough = true;
 				} else if (m_Section->m_Cont.LinkLocation != NULL){
 					CPU_Message("");
 					CPU_Message("      %s:",m_Section->m_Cont.BranchLabel.c_str());
@@ -151,7 +148,7 @@ void CRecompilerOps::Compile_Branch (CRecompilerOps::BranchFunction CompareFunc,
 						SetJump32((DWORD *)m_Section->m_Cont.LinkLocation2,(DWORD *)m_RecompPos);
 						m_Section->m_Cont.LinkLocation2 = NULL;
 					}
-					m_Section->m_Cont.FallThrough = TRUE;
+					m_Section->m_Cont.FallThrough = true;
 				}
 			}
 			if ((m_CompilePC & 0xFFC) == 0xFFC) 
@@ -249,9 +246,9 @@ void CRecompilerOps::Compile_Branch (CRecompilerOps::BranchFunction CompareFunc,
 						m_Section->m_Cont.BranchLabel = "ExitBlock";
 					}
 				}		
-				FallInfo->DoneDelaySlot = TRUE;
+				FallInfo->DoneDelaySlot = true;
 				if (!JumpInfo->DoneDelaySlot) {
-					FallInfo->FallThrough = FALSE;				
+					FallInfo->FallThrough = false;
 					JmpLabel32(FallInfo->BranchLabel.c_str(),0);
 					FallInfo->LinkLocation = (DWORD *)(m_RecompPos - 4);
 					
@@ -263,7 +260,7 @@ void CRecompilerOps::Compile_Branch (CRecompilerOps::BranchFunction CompareFunc,
 							SetJump32((DWORD *)JumpInfo->LinkLocation2,(DWORD *)m_RecompPos);
 							JumpInfo->LinkLocation2 = NULL;
 						}
-						JumpInfo->FallThrough = TRUE;
+						JumpInfo->FallThrough = true;
 						m_NextInstruction = DO_DELAY_SLOT;
 						m_RegWorkingSet = RegBeforeDelay;
 						return; 
@@ -303,9 +300,9 @@ void CRecompilerOps::Compile_Branch (CRecompilerOps::BranchFunction CompareFunc,
 	}
 }
 
-void CRecompilerOps::Compile_BranchLikely (BranchFunction CompareFunc, BOOL Link)
+void CRecompilerOps::Compile_BranchLikely (BranchFunction CompareFunc, bool Link)
 {
-	if ( m_NextInstruction == NORMAL ) {		
+	if (m_NextInstruction == NORMAL) {
 		CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 		
 		if (!g_System->bLinkBlocks() || (m_CompilePC & 0xFFC) == 0xFFC)
@@ -314,42 +311,43 @@ void CRecompilerOps::Compile_BranchLikely (BranchFunction CompareFunc, BOOL Link
 			m_Section->m_Jump.TargetPC = m_CompilePC + ((short)m_Opcode.offset << 2) + 4;
 			m_Section->m_Cont.JumpPC   = m_CompilePC;
 			m_Section->m_Cont.TargetPC = m_CompilePC + 8;
-		} else {
+		}
+		else
+		{
 			if (m_Section->m_Jump.JumpPC != m_CompilePC)
-			{
 				g_Notify->BreakPoint(__FILEW__,__LINE__);
-			}
+
 			if (m_Section->m_Cont.JumpPC != m_CompilePC)
-			{
 				g_Notify->BreakPoint(__FILEW__,__LINE__);
-			}
+
 			if (m_Section->m_Cont.TargetPC != m_CompilePC + 8)
-			{
 				g_Notify->BreakPoint(__FILEW__,__LINE__);
-			}
 		}
-		if (m_Section->m_JumpSection != NULL) {
+
+		if (m_Section->m_JumpSection != NULL)
 			m_Section->m_Jump.BranchLabel.Format("Section_%d",((CCodeSection *)m_Section->m_JumpSection)->m_SectionID);
-		} else {
+		else
 			m_Section->m_Jump.BranchLabel = "ExitBlock";
-		}
-		if (m_Section->m_ContinueSection != NULL) {
+
+		if (m_Section->m_ContinueSection != NULL)
 			m_Section->m_Cont.BranchLabel.Format("Section_%d",((CCodeSection *)m_Section->m_ContinueSection)->m_SectionID);
-		} else {
+		else
 			m_Section->m_Cont.BranchLabel = "ExitBlock";
-		}
-		m_Section->m_Jump.FallThrough   = TRUE;
+
+		m_Section->m_Jump.FallThrough   = true;
 		m_Section->m_Jump.LinkLocation  = NULL;
 		m_Section->m_Jump.LinkLocation2 = NULL;
-		m_Section->m_Cont.FallThrough   = FALSE;
+		m_Section->m_Cont.FallThrough   = false;
 		m_Section->m_Cont.LinkLocation  = NULL;
 		m_Section->m_Cont.LinkLocation2 = NULL;
+
 		if (Link)
 		{
-			UnMap_GPR( 31, FALSE);
+			UnMap_GPR(31, false);
 			m_RegWorkingSet.SetMipsRegLo(31, m_CompilePC + 8);
 			m_RegWorkingSet.SetMipsRegState(31,CRegInfo::STATE_CONST_32_SIGN);
 		}
+
 		CompareFunc(); 
 		ResetX86Protection();
 
@@ -359,9 +357,7 @@ void CRecompilerOps::Compile_BranchLikely (BranchFunction CompareFunc, BOOL Link
 			if (m_Section->m_Cont.FallThrough) 
 			{
 				if (m_Section->m_Jump.LinkLocation != NULL)
-				{
-					g_Notify->BreakPoint(__FILEW__,__LINE__); 
-				}
+					g_Notify->BreakPoint(__FILEW__,__LINE__);
 			}
 
 			if (m_Section->m_Jump.LinkLocation != NULL || m_Section->m_Jump.FallThrough) 
@@ -391,7 +387,7 @@ void CRecompilerOps::Compile_BranchLikely (BranchFunction CompareFunc, BOOL Link
 					m_Section->m_Cont.LinkLocation2 = NULL;
 				}
 			}
-			m_Section->CompileExit(m_CompilePC, m_CompilePC + 8,m_Section->m_Cont.RegSet,CExitInfo::Normal,TRUE,NULL);
+			m_Section->CompileExit(m_CompilePC, m_CompilePC + 8, m_Section->m_Cont.RegSet, CExitInfo::Normal, true, NULL);
 			return;
 		} else {
 			m_NextInstruction = DO_DELAY_SLOT;
@@ -432,11 +428,11 @@ void CRecompilerOps::BNE_Compare()
 			if (Is64Bit(m_Opcode.rs) || Is64Bit(m_Opcode.rt)) {
 				CRecompilerOps::UnknownOpcode();
 			} else if (GetMipsRegLo(m_Opcode.rs) != GetMipsRegLo(m_Opcode.rt)) {
-				m_Section->m_Jump.FallThrough = TRUE;
-				m_Section->m_Cont.FallThrough = FALSE;
+				m_Section->m_Jump.FallThrough = true;
+				m_Section->m_Cont.FallThrough = false;
 			} else {
-				m_Section->m_Jump.FallThrough = FALSE;
-				m_Section->m_Cont.FallThrough = TRUE;
+				m_Section->m_Jump.FallThrough = false;
+				m_Section->m_Cont.FallThrough = true;
 			}
 		} else if (IsMapped(m_Opcode.rs) && IsMapped(m_Opcode.rt)) {
 			ProtectGPR(m_Opcode.rs);
@@ -444,8 +440,8 @@ void CRecompilerOps::BNE_Compare()
 			if (Is64Bit(m_Opcode.rs) || Is64Bit(m_Opcode.rt)) 
 			{
 				CompX86RegToX86Reg(
-					Is32Bit(m_Opcode.rs)?Map_TempReg(x86_Any,m_Opcode.rs,TRUE):GetMipsRegMapHi(m_Opcode.rs),
-					Is32Bit(m_Opcode.rt)?Map_TempReg(x86_Any,m_Opcode.rt,TRUE):GetMipsRegMapHi(m_Opcode.rt)
+					Is32Bit(m_Opcode.rs) ? Map_TempReg(x86_Any, m_Opcode.rs, true) : GetMipsRegMapHi(m_Opcode.rs),
+					Is32Bit(m_Opcode.rt) ? Map_TempReg(x86_Any, m_Opcode.rt, true) : GetMipsRegMapHi(m_Opcode.rt)
 				);
 					
 				if (m_Section->m_Jump.FallThrough) {
@@ -494,7 +490,7 @@ void CRecompilerOps::BNE_Compare()
 				if (Is32Bit(ConstReg) || Is32Bit(MappedReg)) {
 					ProtectGPR(MappedReg);
 					if (Is32Bit(MappedReg)) {
-						CompConstToX86reg(Map_TempReg(x86_Any,MappedReg,TRUE),GetMipsRegHi(ConstReg));
+						CompConstToX86reg(Map_TempReg(x86_Any, MappedReg, true), GetMipsRegHi(ConstReg));
 					} else {
 						CompConstToX86reg(GetMipsRegMapHi(MappedReg),GetMipsRegLo_S(ConstReg) >> 31);
 					}
@@ -559,7 +555,7 @@ void CRecompilerOps::BNE_Compare()
 					CompX86regToVariable(GetMipsRegMapHi(KnownReg),&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
 				} else if (IsSigned(KnownReg)) {
 					ProtectGPR(KnownReg);
-					CompX86regToVariable(Map_TempReg(x86_Any,KnownReg,TRUE),&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
+					CompX86regToVariable(Map_TempReg(x86_Any,KnownReg,true),&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
 				} else {
 					CompConstToVariable(0,&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
 				}
@@ -612,7 +608,7 @@ void CRecompilerOps::BNE_Compare()
 
 		if (!g_System->b32BitCore())
 		{
-			Reg = Map_TempReg(x86_Any,m_Opcode.rt,TRUE);		
+			Reg = Map_TempReg(x86_Any, m_Opcode.rt, true);
 			CompX86regToVariable(Reg,&_GPR[m_Opcode.rs].W[1],CRegName::GPR_Hi[m_Opcode.rs]);
 			if (m_Section->m_Jump.FallThrough) {
 				JneLabel8("continue",0);
@@ -623,7 +619,7 @@ void CRecompilerOps::BNE_Compare()
 			}
 		}
 
-		Reg = Map_TempReg(Reg,m_Opcode.rt,FALSE);
+		Reg = Map_TempReg(Reg, m_Opcode.rt, false);
 		CompX86regToVariable(Reg,&_GPR[m_Opcode.rs].W[0],CRegName::GPR_Lo[m_Opcode.rs]);
 		if (m_Section->m_Cont.FallThrough) {
 			JneLabel32 ( m_Section->m_Jump.BranchLabel.c_str(), 0 );
@@ -664,11 +660,11 @@ void CRecompilerOps::BEQ_Compare() {
 			if (Is64Bit(m_Opcode.rs) || Is64Bit(m_Opcode.rt)) {
 				CRecompilerOps::UnknownOpcode();
 			} else if (GetMipsRegLo(m_Opcode.rs) == GetMipsRegLo(m_Opcode.rt)) {
-				m_Section->m_Jump.FallThrough = TRUE;
-				m_Section->m_Cont.FallThrough = FALSE;
+				m_Section->m_Jump.FallThrough = true;
+				m_Section->m_Cont.FallThrough = false;
 			} else {
-				m_Section->m_Jump.FallThrough = FALSE;
-				m_Section->m_Cont.FallThrough = TRUE;
+				m_Section->m_Jump.FallThrough = false;
+				m_Section->m_Cont.FallThrough = true;
 			}
 		}
 		else if (IsMapped(m_Opcode.rs) && IsMapped(m_Opcode.rt)) 
@@ -679,8 +675,8 @@ void CRecompilerOps::BEQ_Compare() {
 				ProtectGPR(m_Opcode.rt);
 
 				CompX86RegToX86Reg(
-					Is32Bit(m_Opcode.rs)?Map_TempReg(x86_Any,m_Opcode.rs,TRUE):GetMipsRegMapHi(m_Opcode.rs),
-					Is32Bit(m_Opcode.rt)?Map_TempReg(x86_Any,m_Opcode.rt,TRUE):GetMipsRegMapHi(m_Opcode.rt)
+					Is32Bit(m_Opcode.rs) ? Map_TempReg(x86_Any, m_Opcode.rs, true) : GetMipsRegMapHi(m_Opcode.rs),
+					Is32Bit(m_Opcode.rt) ? Map_TempReg(x86_Any, m_Opcode.rt, true) : GetMipsRegMapHi(m_Opcode.rt)
 				);
 				if (m_Section->m_Cont.FallThrough) {
 					JneLabel8("continue",0);
@@ -728,7 +724,7 @@ void CRecompilerOps::BEQ_Compare() {
 				if (Is32Bit(ConstReg) || Is32Bit(MappedReg)) {
 					if (Is32Bit(MappedReg)) {
 						ProtectGPR(MappedReg);
-						CompConstToX86reg(Map_TempReg(x86_Any,MappedReg,TRUE),GetMipsRegHi(ConstReg));
+						CompConstToX86reg(Map_TempReg(x86_Any, MappedReg, true), GetMipsRegHi(ConstReg));
 					} else {
 						CompConstToX86reg(GetMipsRegMapHi(MappedReg),GetMipsRegLo_S(ConstReg) >> 31);
 					}
@@ -793,7 +789,7 @@ void CRecompilerOps::BEQ_Compare() {
 				if (Is64Bit(KnownReg)) {
 					CompX86regToVariable(GetMipsRegMapHi(KnownReg),&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
 				} else if (IsSigned(KnownReg)) {
-					CompX86regToVariable(Map_TempReg(x86_Any,KnownReg,TRUE),&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
+					CompX86regToVariable(Map_TempReg(x86_Any,KnownReg,true),&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
 				} else {
 					CompConstToVariable(0,&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
 				}
@@ -838,7 +834,7 @@ void CRecompilerOps::BEQ_Compare() {
 		x86Reg Reg = x86_Any;
 		if (!g_System->b32BitCore())
 		{
-			Reg = Map_TempReg(x86_Any,m_Opcode.rs,TRUE);
+			Reg = Map_TempReg(x86_Any, m_Opcode.rs, true);
 			CompX86regToVariable(Reg,&_GPR[m_Opcode.rt].W[1],CRegName::GPR_Hi[m_Opcode.rt]);
 			if (m_Section->m_Cont.FallThrough) {
 				JneLabel8("continue",0);
@@ -848,7 +844,7 @@ void CRecompilerOps::BEQ_Compare() {
 				m_Section->m_Cont.LinkLocation = (DWORD *)(m_RecompPos - 4);
 			}
 		}
-		CompX86regToVariable(Map_TempReg(Reg,m_Opcode.rs,FALSE),&_GPR[m_Opcode.rt].W[0],CRegName::GPR_Lo[m_Opcode.rt]);
+		CompX86regToVariable(Map_TempReg(Reg, m_Opcode.rs, false), &_GPR[m_Opcode.rt].W[0], CRegName::GPR_Lo[m_Opcode.rt]);
 		if (m_Section->m_Cont.FallThrough) {
 			JeLabel32 ( m_Section->m_Jump.BranchLabel.c_str(), 0 );
 			m_Section->m_Jump.LinkLocation = (DWORD *)(m_RecompPos - 4);
@@ -884,19 +880,19 @@ void CRecompilerOps::BGTZ_Compare() {
 	if (IsConst(m_Opcode.rs)) {
 		if (Is64Bit(m_Opcode.rs)) {
 			if (GetMipsReg_S(m_Opcode.rs) > 0) {
-				m_Section->m_Jump.FallThrough = TRUE;
-				m_Section->m_Cont.FallThrough = FALSE;
+				m_Section->m_Jump.FallThrough = true;
+				m_Section->m_Cont.FallThrough = false;
 			} else {
-				m_Section->m_Jump.FallThrough = FALSE;
-				m_Section->m_Cont.FallThrough = TRUE;
+				m_Section->m_Jump.FallThrough = false;
+				m_Section->m_Cont.FallThrough = true;
 			}
 		} else {
 			if (GetMipsRegLo_S(m_Opcode.rs) > 0) {
-				m_Section->m_Jump.FallThrough = TRUE;
-				m_Section->m_Cont.FallThrough = FALSE;
+				m_Section->m_Jump.FallThrough = true;
+				m_Section->m_Cont.FallThrough = false;
 			} else {
-				m_Section->m_Jump.FallThrough = FALSE;
-				m_Section->m_Cont.FallThrough = TRUE;
+				m_Section->m_Jump.FallThrough = false;
+				m_Section->m_Cont.FallThrough = true;
 			}
 		}
 	} else if (IsMapped(m_Opcode.rs) && Is32Bit(m_Opcode.rs)) {
@@ -980,27 +976,27 @@ void CRecompilerOps::BLEZ_Compare() {
 	if (IsConst(m_Opcode.rs)) {
 		if (Is64Bit(m_Opcode.rs)) {
 			if (GetMipsReg_S(m_Opcode.rs) <= 0) {
-				m_Section->m_Jump.FallThrough = TRUE;
-				m_Section->m_Cont.FallThrough = FALSE;
+				m_Section->m_Jump.FallThrough = true;
+				m_Section->m_Cont.FallThrough = false;
 			} else {
-				m_Section->m_Jump.FallThrough = FALSE;
-				m_Section->m_Cont.FallThrough = TRUE;
+				m_Section->m_Jump.FallThrough = false;
+				m_Section->m_Cont.FallThrough = true;
 			}
 		} else if (IsSigned(m_Opcode.rs)) {
 			if (GetMipsRegLo_S(m_Opcode.rs) <= 0) {
-				m_Section->m_Jump.FallThrough = TRUE;
-				m_Section->m_Cont.FallThrough = FALSE;
+				m_Section->m_Jump.FallThrough = true;
+				m_Section->m_Cont.FallThrough = false;
 			} else {
-				m_Section->m_Jump.FallThrough = FALSE;
-				m_Section->m_Cont.FallThrough = TRUE;
+				m_Section->m_Jump.FallThrough = false;
+				m_Section->m_Cont.FallThrough = true;
 			}
 		} else {
 			if (GetMipsRegLo(m_Opcode.rs) == 0) {
-				m_Section->m_Jump.FallThrough = TRUE;
-				m_Section->m_Cont.FallThrough = FALSE;
+				m_Section->m_Jump.FallThrough = true;
+				m_Section->m_Cont.FallThrough = false;
 			} else {
-				m_Section->m_Jump.FallThrough = FALSE;
-				m_Section->m_Cont.FallThrough = TRUE;
+				m_Section->m_Jump.FallThrough = false;
+				m_Section->m_Cont.FallThrough = true;
 			}
 		}
 	} else if (IsMapped(m_Opcode.rs)) {
@@ -1138,23 +1134,23 @@ void CRecompilerOps::BLTZ_Compare() {
 	if (IsConst(m_Opcode.rs)) {
 		if (Is64Bit(m_Opcode.rs)) {
 			if (GetMipsReg_S(m_Opcode.rs) < 0) {
-				m_Section->m_Jump.FallThrough = TRUE;
-				m_Section->m_Cont.FallThrough = FALSE;
+				m_Section->m_Jump.FallThrough = true;
+				m_Section->m_Cont.FallThrough = false;
 			} else {
-				m_Section->m_Jump.FallThrough = FALSE;
-				m_Section->m_Cont.FallThrough = TRUE;
+				m_Section->m_Jump.FallThrough = false;
+				m_Section->m_Cont.FallThrough = true;
 			}
 		} else if (IsSigned(m_Opcode.rs)) {
 			if (GetMipsRegLo_S(m_Opcode.rs) < 0) {
-				m_Section->m_Jump.FallThrough = TRUE;
-				m_Section->m_Cont.FallThrough = FALSE;
+				m_Section->m_Jump.FallThrough = true;
+				m_Section->m_Cont.FallThrough = false;
 			} else {
-				m_Section->m_Jump.FallThrough = FALSE;
-				m_Section->m_Cont.FallThrough = TRUE;
+				m_Section->m_Jump.FallThrough = false;
+				m_Section->m_Cont.FallThrough = true;
 			}
 		} else {
-			m_Section->m_Jump.FallThrough = FALSE;
-			m_Section->m_Cont.FallThrough = TRUE;
+			m_Section->m_Jump.FallThrough = false;
+			m_Section->m_Cont.FallThrough = true;
 		}
 	} else if (IsMapped(m_Opcode.rs)) {
 		if (Is64Bit(m_Opcode.rs)) {
@@ -1186,8 +1182,8 @@ void CRecompilerOps::BLTZ_Compare() {
 				m_Section->m_Jump.LinkLocation = (DWORD *)(m_RecompPos - 4);
 			}
 		} else {
-			m_Section->m_Jump.FallThrough = FALSE;
-			m_Section->m_Cont.FallThrough = TRUE;
+			m_Section->m_Jump.FallThrough = false;
+			m_Section->m_Cont.FallThrough = true;
 		}
 	} else if (IsUnknown(m_Opcode.rs)) {
 		if (g_System->b32BitCore())
@@ -1218,15 +1214,15 @@ void CRecompilerOps::BGEZ_Compare() {
 			CRecompilerOps::UnknownOpcode();
 		} else if (IsSigned(m_Opcode.rs)) {
 			if (GetMipsRegLo_S(m_Opcode.rs) >= 0) {
-				m_Section->m_Jump.FallThrough = TRUE;
-				m_Section->m_Cont.FallThrough = FALSE;
+				m_Section->m_Jump.FallThrough = true;
+				m_Section->m_Cont.FallThrough = false;
 			} else {
-				m_Section->m_Jump.FallThrough = FALSE;
-				m_Section->m_Cont.FallThrough = TRUE;
+				m_Section->m_Jump.FallThrough = false;
+				m_Section->m_Cont.FallThrough = true;
 			}
 		} else {
-			m_Section->m_Jump.FallThrough = TRUE;
-			m_Section->m_Cont.FallThrough = FALSE;
+			m_Section->m_Jump.FallThrough = true;
+			m_Section->m_Cont.FallThrough = false;
 		}
 	} else if (IsMapped(m_Opcode.rs)) {
 		if (Is64Bit(m_Opcode.rs)) { 
@@ -1258,8 +1254,8 @@ void CRecompilerOps::BGEZ_Compare() {
 				m_Section->m_Jump.LinkLocation = (DWORD *)(m_RecompPos - 4);
 			}
 		} else { 
-			m_Section->m_Jump.FallThrough = TRUE;
-			m_Section->m_Cont.FallThrough = FALSE;
+			m_Section->m_Jump.FallThrough = true;
+			m_Section->m_Cont.FallThrough = false;
 		}
 	} else {
 		if (g_System->b32BitCore())
@@ -1333,11 +1329,11 @@ void CRecompilerOps::J() {
 		} else {
 			m_Section->m_Jump.BranchLabel = "ExitBlock";
 		}
-		m_Section->m_Jump.FallThrough   = TRUE;
+		m_Section->m_Jump.FallThrough   = true;
 		m_Section->m_Jump.LinkLocation  = NULL;
 		m_Section->m_Jump.LinkLocation2 = NULL;
 		m_NextInstruction = DO_DELAY_SLOT;
-	} else if (m_NextInstruction == DELAY_SLOT_DONE ) {		
+	} else if (m_NextInstruction == DELAY_SLOT_DONE ) {
 		m_Section->m_Jump.RegSet = m_RegWorkingSet;
 		m_Section->GenerateSectionLinkage();
 		m_NextInstruction = END_BLOCK;
@@ -1367,11 +1363,11 @@ void CRecompilerOps::JAL() {
 		} else {
 			m_Section->m_Jump.BranchLabel = "ExitBlock";
 		}
-		m_Section->m_Jump.FallThrough   = TRUE;
+		m_Section->m_Jump.FallThrough   = true;
 		m_Section->m_Jump.LinkLocation  = NULL;
 		m_Section->m_Jump.LinkLocation2 = NULL;
 		m_NextInstruction = DO_DELAY_SLOT;
-	} else if (m_NextInstruction == DELAY_SLOT_DONE ) {		
+	} else if (m_NextInstruction == DELAY_SLOT_DONE ) {
 		if (m_Section->m_JumpSection)
 		{
 			m_Section->m_Jump.RegSet = m_RegWorkingSet;
@@ -1389,7 +1385,7 @@ void CRecompilerOps::JAL() {
 			bool bCheck = TargetPC <= m_CompilePC;
 			UpdateCounters(m_RegWorkingSet,bCheck, true);
 
-			m_Section->CompileExit((DWORD)-1, (DWORD)-1,m_RegWorkingSet,bCheck ? CExitInfo::Normal : CExitInfo::Normal_NoSysCheck,TRUE,NULL);
+			m_Section->CompileExit((DWORD)-1, (DWORD)-1, m_RegWorkingSet, bCheck ? CExitInfo::Normal : CExitInfo::Normal_NoSysCheck, true, NULL);
 		}
 		m_NextInstruction = END_BLOCK;
 	} else {
@@ -1408,11 +1404,13 @@ void CRecompilerOps::ADDI() {
 	}
 
 	if (IsConst(m_Opcode.rs)) { 
-		if (IsMapped(m_Opcode.rt)) { UnMap_GPR(m_Opcode.rt, FALSE); }
+		if (IsMapped(m_Opcode.rt))
+			UnMap_GPR(m_Opcode.rt, false);
+
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rt, GetMipsRegLo(m_Opcode.rs) + (short)m_Opcode.immediate);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rt,CRegInfo::STATE_CONST_32_SIGN);
 	} else {
-		Map_GPR_32bit(m_Opcode.rt,TRUE,m_Opcode.rs);
+		Map_GPR_32bit(m_Opcode.rt, true, m_Opcode.rs);
 		AddConstToX86Reg(GetMipsRegMapLo(m_Opcode.rt),(short)m_Opcode.immediate);
 	}
 	if (g_System->bFastSP() && m_Opcode.rt == 29 && m_Opcode.rs != 29) { 
@@ -1424,22 +1422,25 @@ void CRecompilerOps::ADDI() {
 void CRecompilerOps::ADDIU() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	if (m_Opcode.rt == 0 || (m_Opcode.immediate == 0 && m_Opcode.rs == m_Opcode.rt)) { return; }
+	if (m_Opcode.rt == 0 || (m_Opcode.immediate == 0 && m_Opcode.rs == m_Opcode.rt))
+		return;
 
 	if (g_System->bFastSP())
 	{
 		if (m_Opcode.rs == 29 && m_Opcode.rt == 29) 
 		{
-			AddConstToX86Reg(Map_MemoryStack(x86_Any, TRUE),(short)m_Opcode.immediate);
+			AddConstToX86Reg(Map_MemoryStack(x86_Any, true),(short)m_Opcode.immediate);
 		}
 	}
 
 	if (IsConst(m_Opcode.rs)) { 
-		if (IsMapped(m_Opcode.rt)) { UnMap_GPR(m_Opcode.rt, FALSE); }
+		if (IsMapped(m_Opcode.rt))
+			UnMap_GPR(m_Opcode.rt, false);
+
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rt, GetMipsRegLo(m_Opcode.rs) + (short)m_Opcode.immediate);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rt,CRegInfo::STATE_CONST_32_SIGN);
 	} else {
-		Map_GPR_32bit(m_Opcode.rt,TRUE,m_Opcode.rs);
+		Map_GPR_32bit(m_Opcode.rt, true, m_Opcode.rs);
 		AddConstToX86Reg(GetMipsRegMapLo(m_Opcode.rt),(short)m_Opcode.immediate);
 	}
 
@@ -1451,13 +1452,14 @@ void CRecompilerOps::ADDIU() {
 
 void CRecompilerOps::SLTIU() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rt == 0) { return; }
+	if (m_Opcode.rt == 0)
+		return;
 
 	if (IsConst(m_Opcode.rs)) 
 	{ 
 		DWORD Result = Is64Bit(m_Opcode.rs) ? GetMipsReg(m_Opcode.rs) < ((unsigned)((__int64)((short)m_Opcode.immediate)))?1:0 : 
 						GetMipsRegLo(m_Opcode.rs) < ((unsigned)((short)m_Opcode.immediate))?1:0;
-		UnMap_GPR(m_Opcode.rt, FALSE);
+		UnMap_GPR(m_Opcode.rt, false);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rt,CRegInfo::STATE_CONST_32_SIGN);
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rt,Result);
 	} else if (IsMapped(m_Opcode.rs)) { 
@@ -1478,18 +1480,18 @@ void CRecompilerOps::SLTIU() {
 			CPU_Message("");
 			CPU_Message("      Continue:");
 			SetJump8(Jump[1],m_RecompPos);
-			Map_GPR_32bit(m_Opcode.rt,FALSE, -1);
+			Map_GPR_32bit(m_Opcode.rt, false, -1);
 			MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rt));
 		} else {
 			CompConstToX86reg(GetMipsRegMapLo(m_Opcode.rs),(short)m_Opcode.immediate);
 			SetbVariable(&m_BranchCompare,"m_BranchCompare");
-			Map_GPR_32bit(m_Opcode.rt,FALSE, -1);
+			Map_GPR_32bit(m_Opcode.rt, false, -1);
 			MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rt));
 		}
 	} else if (g_System->b32BitCore()) {
 		CompConstToVariable((short)m_Opcode.immediate,&_GPR[m_Opcode.rs].W[0],CRegName::GPR_Lo[m_Opcode.rs]);
 		SetbVariable(&m_BranchCompare,"m_BranchCompare");
-		Map_GPR_32bit(m_Opcode.rt,FALSE, -1);
+		Map_GPR_32bit(m_Opcode.rt, false, -1);
 		MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rt));
 	} else {
 		BYTE * Jump = NULL;
@@ -1502,22 +1504,23 @@ void CRecompilerOps::SLTIU() {
 		CPU_Message("      CompareSet:");
 		SetJump8(Jump,m_RecompPos);
 		SetbVariable(&m_BranchCompare,"m_BranchCompare");
-		Map_GPR_32bit(m_Opcode.rt,FALSE, -1);
-		MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rt));	
+		Map_GPR_32bit(m_Opcode.rt, false, -1);
+		MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rt));
 	}
 }
 
 void CRecompilerOps::SLTI()
 {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rt == 0) { return; }
+	if (m_Opcode.rt == 0)
+		return;
 
 	if (IsConst(m_Opcode.rs)) { 
 		DWORD Result = Is64Bit(m_Opcode.rs) ? 
 			((__int64)GetMipsReg(m_Opcode.rs) < (__int64)((short)m_Opcode.immediate) ? 1:0) :
 			( GetMipsRegLo_S(m_Opcode.rs) < (short)m_Opcode.immediate?1:0);
 
-		UnMap_GPR(m_Opcode.rt, FALSE);
+		UnMap_GPR(m_Opcode.rt, false);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rt,CRegInfo::STATE_CONST_32_SIGN);
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rt,Result);
 	} else if (IsMapped(m_Opcode.rs)) { 
@@ -1538,16 +1541,16 @@ void CRecompilerOps::SLTI()
 			CPU_Message("");
 			CPU_Message("      Continue:");
 			SetJump8(Jump[1],m_RecompPos);
-			Map_GPR_32bit(m_Opcode.rt,FALSE, -1);
+			Map_GPR_32bit(m_Opcode.rt, false, -1);
 			MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rt));
 		} else {
 		/*	CompConstToX86reg(GetMipsRegMapLo(m_Opcode.rs),(short)m_Opcode.immediate);
 			SetlVariable(&m_BranchCompare,"m_BranchCompare");
-			Map_GPR_32bit(m_Opcode.rt,FALSE, -1);
+			Map_GPR_32bit(m_Opcode.rt, false, -1);
 			MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rt));
 			*/
 			ProtectGPR( m_Opcode.rs);
-			Map_GPR_32bit(m_Opcode.rt,FALSE, -1);
+			Map_GPR_32bit(m_Opcode.rt, false, -1);
 			CompConstToX86reg(GetMipsRegMapLo(m_Opcode.rs),(short)m_Opcode.immediate);
 			
 			if (GetMipsRegMapLo(m_Opcode.rt) > x86_EBX) {
@@ -1559,7 +1562,7 @@ void CRecompilerOps::SLTI()
 			}
 		}
 	} else if (g_System->b32BitCore()) {
-		Map_GPR_32bit(m_Opcode.rt,FALSE, -1);
+		Map_GPR_32bit(m_Opcode.rt, false, -1);
 		CompConstToVariable((short)m_Opcode.immediate,&_GPR[m_Opcode.rs].W[0],CRegName::GPR_Lo[m_Opcode.rs]);
 
 		if (GetMipsRegMapLo(m_Opcode.rt) > x86_EBX) {
@@ -1588,7 +1591,7 @@ void CRecompilerOps::SLTI()
 			CPU_Message("      Continue:");
 			SetJump8(Jump[1],m_RecompPos);
 		}
-		Map_GPR_32bit(m_Opcode.rt,FALSE, -1);
+		Map_GPR_32bit(m_Opcode.rt, false, -1);
 		MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rt));
 	}
 }
@@ -1596,30 +1599,36 @@ void CRecompilerOps::SLTI()
 void CRecompilerOps::ANDI() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	if (m_Opcode.rt == 0) { return;}
+	if (m_Opcode.rt == 0)
+		return;
 
 	if (IsConst(m_Opcode.rs)) {
-		if (IsMapped(m_Opcode.rt)) { UnMap_GPR(m_Opcode.rt, FALSE); }
+		if (IsMapped(m_Opcode.rt))
+			UnMap_GPR(m_Opcode.rt, false);
+
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rt,CRegInfo::STATE_CONST_32_SIGN);
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rt, GetMipsRegLo(m_Opcode.rs) & m_Opcode.immediate);
 	} else if (m_Opcode.immediate != 0) { 
-		Map_GPR_32bit(m_Opcode.rt,FALSE,m_Opcode.rs);
+		Map_GPR_32bit(m_Opcode.rt, false, m_Opcode.rs);
 		AndConstToX86Reg(GetMipsRegMapLo(m_Opcode.rt),m_Opcode.immediate);
 	} else {
-		Map_GPR_32bit(m_Opcode.rt,FALSE,0);
+		Map_GPR_32bit(m_Opcode.rt, false, 0);
 	}
 }
 
 void CRecompilerOps::ORI() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rt == 0) { return;}
+	if (m_Opcode.rt == 0)
+		return;
 
 	if (g_System->bFastSP() && m_Opcode.rs == 29 && m_Opcode.rt == 29) {
 		OrConstToX86Reg(m_Opcode.immediate,Map_MemoryStack(x86_Any, true));
 	}
 
 	if (IsConst(m_Opcode.rs)) {
-		if (IsMapped(m_Opcode.rt)) { UnMap_GPR(m_Opcode.rt, FALSE); }
+		if (IsMapped(m_Opcode.rt))
+			UnMap_GPR(m_Opcode.rt, false);
+
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rt,GetMipsRegState(m_Opcode.rs));
 		m_RegWorkingSet.SetMipsRegHi(m_Opcode.rt,GetMipsRegHi(m_Opcode.rs));
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rt,GetMipsRegLo(m_Opcode.rs) | m_Opcode.immediate);
@@ -1653,10 +1662,13 @@ void CRecompilerOps::ORI() {
 
 void CRecompilerOps::XORI() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rt == 0) { return;}
+	if (m_Opcode.rt == 0)
+		return;
 
 	if (IsConst(m_Opcode.rs)) {
-		if (m_Opcode.rs != m_Opcode.rt) { UnMap_GPR(m_Opcode.rt, FALSE); }
+		if (m_Opcode.rs != m_Opcode.rt)
+			UnMap_GPR(m_Opcode.rt, false);
+
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rt,GetMipsRegState(m_Opcode.rs));
 		m_RegWorkingSet.SetMipsRegHi(m_Opcode.rt,GetMipsRegHi(m_Opcode.rs));
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rt,GetMipsRegLo(m_Opcode.rs) ^ m_Opcode.immediate);
@@ -1674,7 +1686,8 @@ void CRecompilerOps::XORI() {
 
 void CRecompilerOps::LUI() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rt == 0) { return;}
+	if (m_Opcode.rt == 0)
+		return;
 
 	if (g_System->bFastSP() && m_Opcode.rt == 29) {
 		x86Reg Reg = Map_MemoryStack(x86_Any, true, false);
@@ -1688,7 +1701,7 @@ void CRecompilerOps::LUI() {
 		}
 	}
 
-	UnMap_GPR(m_Opcode.rt, FALSE);
+	UnMap_GPR(m_Opcode.rt, false);
 	m_RegWorkingSet.SetMipsRegLo(m_Opcode.rt, ((short)m_Opcode.offset << 16));
 	m_RegWorkingSet.SetMipsRegState(m_Opcode.rt,CRegInfo::STATE_CONST_32_SIGN);
 }
@@ -1696,8 +1709,12 @@ void CRecompilerOps::LUI() {
 void CRecompilerOps::DADDIU() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	if (m_Opcode.rs != 0) { UnMap_GPR(m_Opcode.rs,TRUE); }
-	if (m_Opcode.rs != 0) { UnMap_GPR(m_Opcode.rt,TRUE); }
+	if (m_Opcode.rs != 0)
+		UnMap_GPR(m_Opcode.rs, true);
+
+	if (m_Opcode.rs != 0)
+		UnMap_GPR(m_Opcode.rt, true);
+
 	BeforeCallDirect(m_RegWorkingSet);
 	MoveConstToVariable(m_Opcode.Hex, &R4300iOp::m_Opcode.Hex, "R4300iOp::m_Opcode.Hex");
 	Call_Direct(R4300iOp::DADDIU, "R4300iOp::DADDIU");
@@ -1755,10 +1772,13 @@ void CRecompilerOps::CACHE(){
 void CRecompilerOps::SPECIAL_SLL() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(m_Opcode.rt)) {
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd, GetMipsRegLo(m_Opcode.rt) << m_Opcode.sa);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 		return;
@@ -1766,139 +1786,155 @@ void CRecompilerOps::SPECIAL_SLL() {
 	if (m_Opcode.rd != m_Opcode.rt && IsMapped(m_Opcode.rt)) {
 		switch (m_Opcode.sa) {
 		case 0: 
-			Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+			Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 			break;
 		case 1:
 			ProtectGPR(m_Opcode.rt);
-			Map_GPR_32bit(m_Opcode.rd,TRUE,-1);
+			Map_GPR_32bit(m_Opcode.rd, true, -1);
 			LeaRegReg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(m_Opcode.rt), 0, Multip_x2);
-			break;			
+			break;
 		case 2:
 			ProtectGPR(m_Opcode.rt);
-			Map_GPR_32bit(m_Opcode.rd,TRUE,-1);
+			Map_GPR_32bit(m_Opcode.rd, true, -1);
 			LeaRegReg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(m_Opcode.rt), 0, Multip_x4);
-			break;			
+			break;
 		case 3:
 			ProtectGPR(m_Opcode.rt);
-			Map_GPR_32bit(m_Opcode.rd,TRUE,-1);
+			Map_GPR_32bit(m_Opcode.rd, true, -1);
 			LeaRegReg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(m_Opcode.rt), 0, Multip_x8);
 			break;
 		default:
-			Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+			Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 			ShiftLeftSignImmed(GetMipsRegMapLo(m_Opcode.rd),(BYTE)m_Opcode.sa);
 		}
 	} else {
-		Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+		Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 		ShiftLeftSignImmed(GetMipsRegMapLo(m_Opcode.rd),(BYTE)m_Opcode.sa);
 	}
 }
 
 void CRecompilerOps::SPECIAL_SRL() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
-	
+	if (m_Opcode.rd == 0)
+		return;
+
 	if (IsConst(m_Opcode.rt)) {
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd, GetMipsRegLo(m_Opcode.rt) >> m_Opcode.sa);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 		return;
 	}
-	Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+	Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 	ShiftRightUnsignImmed(GetMipsRegMapLo(m_Opcode.rd),(BYTE)m_Opcode.sa);
 }
 
 void CRecompilerOps::SPECIAL_SRA() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 	
 	if (IsConst(m_Opcode.rt)) {
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd, GetMipsRegLo_S(m_Opcode.rt) >> m_Opcode.sa);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 		return;
 	}
-	Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+	Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 	ShiftRightSignImmed(GetMipsRegMapLo(m_Opcode.rd),(BYTE)m_Opcode.sa);
 }
 
 void CRecompilerOps::SPECIAL_SLLV() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 	
 	if (IsConst(m_Opcode.rs)) {
 		DWORD Shift = (GetMipsRegLo(m_Opcode.rs) & 0x1F);
 		if (IsConst(m_Opcode.rt)) {
-			if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+			if (IsMapped(m_Opcode.rd))
+				UnMap_GPR(m_Opcode.rd, false);
+
 			m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd, GetMipsRegLo(m_Opcode.rt) << Shift);
 			m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 		} else {
-			Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+			Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 			ShiftLeftSignImmed(GetMipsRegMapLo(m_Opcode.rd),(BYTE)Shift);
 		}
 		return;
 	}
-	Map_TempReg(x86_ECX,m_Opcode.rs,FALSE);
-	AndConstToX86Reg(x86_ECX,0x1F);
-	Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+	Map_TempReg(x86_ECX, m_Opcode.rs, false);
+	AndConstToX86Reg(x86_ECX, 0x1F);
+	Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 	ShiftLeftSign(GetMipsRegMapLo(m_Opcode.rd));
 }
 
 void CRecompilerOps::SPECIAL_SRLV() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
-	
+	if (m_Opcode.rd == 0)
+		return;
+
 	if (IsKnown(m_Opcode.rs) && IsConst(m_Opcode.rs)) {
 		DWORD Shift = (GetMipsRegLo(m_Opcode.rs) & 0x1F);
 		if (IsConst(m_Opcode.rt)) {
-			if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+			if (IsMapped(m_Opcode.rd))
+				UnMap_GPR(m_Opcode.rd, false);
+
 			m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd, GetMipsRegLo(m_Opcode.rt) >> Shift);
 			m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 			return;
 		}
-		Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+		Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 		ShiftRightUnsignImmed(GetMipsRegMapLo(m_Opcode.rd),(BYTE)Shift);
 		return;
 	}
-	Map_TempReg(x86_ECX,m_Opcode.rs,FALSE);
-	AndConstToX86Reg(x86_ECX,0x1F);
-	Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+
+	Map_TempReg(x86_ECX, m_Opcode.rs, false);
+	AndConstToX86Reg(x86_ECX, 0x1F);
+	Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 	ShiftRightUnsign(GetMipsRegMapLo(m_Opcode.rd));
 }
 
 void CRecompilerOps::SPECIAL_SRAV() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 	
 	if (IsKnown(m_Opcode.rs) && IsConst(m_Opcode.rs)) {
 		DWORD Shift = (GetMipsRegLo(m_Opcode.rs) & 0x1F);
 		if (IsConst(m_Opcode.rt)) {
-			if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+			if (IsMapped(m_Opcode.rd))
+				UnMap_GPR(m_Opcode.rd, false);
+
 			m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd, GetMipsRegLo_S(m_Opcode.rt) >> Shift);
 			m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 			return;
 		}
-		Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+		Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 		ShiftRightSignImmed(GetMipsRegMapLo(m_Opcode.rd),(BYTE)Shift);
 		return;
 	}
-	Map_TempReg(x86_ECX,m_Opcode.rs,FALSE);
+	Map_TempReg(x86_ECX, m_Opcode.rs, false);
 	AndConstToX86Reg(x86_ECX,0x1F);
-	Map_GPR_32bit(m_Opcode.rd,TRUE,m_Opcode.rt);
+	Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rt);
 	ShiftRightSign(GetMipsRegMapLo(m_Opcode.rd));
 }
 
 void CRecompilerOps::SPECIAL_JR() {
-	if ( m_NextInstruction == NORMAL ) 
+	if (m_NextInstruction == NORMAL)
 	{
 		CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-		if ((m_CompilePC & 0xFFC) == 0xFFC) 
+		if ((m_CompilePC & 0xFFC) == 0xFFC)
 		{
 			if (IsMapped(m_Opcode.rs)) {
-				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs),&R4300iOp::m_JumpToLocation,"R4300iOp::m_JumpToLocation");
+				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs), &R4300iOp::m_JumpToLocation, "R4300iOp::m_JumpToLocation");
 				m_RegWorkingSet.WriteBackRegisters();
 			} else {
 				m_RegWorkingSet.WriteBackRegisters();
-				MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rs,FALSE),&R4300iOp::m_JumpToLocation,"R4300iOp::m_JumpToLocation");
+				MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rs, false), &R4300iOp::m_JumpToLocation, "R4300iOp::m_JumpToLocation");
 			}
 			OverflowDelaySlot(true);
 			return;
@@ -1907,33 +1943,33 @@ void CRecompilerOps::SPECIAL_JR() {
 		m_Section->m_Jump.FallThrough   = false;
 		m_Section->m_Jump.LinkLocation  = NULL;
 		m_Section->m_Jump.LinkLocation2 = NULL;
-		m_Section->m_Cont.FallThrough   = FALSE;
+		m_Section->m_Cont.FallThrough   = false;
 		m_Section->m_Cont.LinkLocation  = NULL;
 		m_Section->m_Cont.LinkLocation2 = NULL;
 
 		if (DelaySlotEffectsCompare(m_CompilePC,m_Opcode.rs,0)) {
-			if (IsConst(m_Opcode.rs)) { 
-				MoveConstToVariable(GetMipsRegLo(m_Opcode.rs),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
-			} else 	if (IsMapped(m_Opcode.rs)) { 
-				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
+			if (IsConst(m_Opcode.rs)) {
+				MoveConstToVariable(GetMipsRegLo(m_Opcode.rs), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
+			} else if (IsMapped(m_Opcode.rs)) {
+				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
 			} else {
-				MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rs,FALSE),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
+				MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rs, false), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
 			}
 		}
 		m_NextInstruction = DO_DELAY_SLOT;
-	} else if (m_NextInstruction == DELAY_SLOT_DONE ) {		
+	} else if (m_NextInstruction == DELAY_SLOT_DONE) {
 		if (DelaySlotEffectsCompare(m_CompilePC,m_Opcode.rs,0)) {
-			m_Section->CompileExit(m_CompilePC,(DWORD)-1,m_RegWorkingSet,CExitInfo::Normal,TRUE,NULL);
+			m_Section->CompileExit(m_CompilePC, (DWORD)-1, m_RegWorkingSet, CExitInfo::Normal, true, NULL);
 		} else {
 			UpdateCounters(m_RegWorkingSet,true,true);
 			if (IsConst(m_Opcode.rs)) { 
-				MoveConstToVariable(GetMipsRegLo(m_Opcode.rs),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
+				MoveConstToVariable(GetMipsRegLo(m_Opcode.rs), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
 			} else if (IsMapped(m_Opcode.rs)) { 
-				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
+				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
 			} else {
-				MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rs,FALSE),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
+				MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rs, false), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
 			}
-			m_Section->CompileExit((DWORD)-1, (DWORD)-1,m_RegWorkingSet,CExitInfo::Normal,TRUE,NULL);
+			m_Section->CompileExit((DWORD)-1, (DWORD)-1, m_RegWorkingSet, CExitInfo::Normal, true, NULL);
 			if (m_Section->m_JumpSection)
 			{
 				m_Section->GenerateSectionLinkage();
@@ -1947,30 +1983,30 @@ void CRecompilerOps::SPECIAL_JR() {
 
 void CRecompilerOps::SPECIAL_JALR()
 {
-	if ( m_NextInstruction == NORMAL ) 
+	if (m_NextInstruction == NORMAL)
 	{
 		CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 		if (DelaySlotEffectsCompare(m_CompilePC,m_Opcode.rs,0) && (m_CompilePC & 0xFFC) != 0xFFC)
 		{
-			if (IsConst(m_Opcode.rs)) { 
-				MoveConstToVariable(GetMipsRegLo(m_Opcode.rs),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
-			} else 	if (IsMapped(m_Opcode.rs)) { 
-				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
+			if (IsConst(m_Opcode.rs)) {
+				MoveConstToVariable(GetMipsRegLo(m_Opcode.rs), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
+			} else if (IsMapped(m_Opcode.rs)) {
+				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
 			} else {
-				MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rs,FALSE),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
+				MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rs, false), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
 			}
 		}
-		UnMap_GPR( m_Opcode.rd, FALSE);
+		UnMap_GPR(m_Opcode.rd, false);
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd,m_CompilePC + 8);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 		if ((m_CompilePC & 0xFFC) == 0xFFC) 
 		{
 			if (IsMapped(m_Opcode.rs)) {
-				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs),&R4300iOp::m_JumpToLocation,"R4300iOp::m_JumpToLocation");
+				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs), &R4300iOp::m_JumpToLocation, "R4300iOp::m_JumpToLocation");
 				m_RegWorkingSet.WriteBackRegisters();
 			} else {
 				m_RegWorkingSet.WriteBackRegisters();
-				MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rs,FALSE),&R4300iOp::m_JumpToLocation,"R4300iOp::m_JumpToLocation");
+				MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rs, false), &R4300iOp::m_JumpToLocation, "R4300iOp::m_JumpToLocation");
 			}
 			OverflowDelaySlot(true);
 			return;
@@ -1979,24 +2015,24 @@ void CRecompilerOps::SPECIAL_JALR()
 		m_Section->m_Jump.FallThrough   = false;
 		m_Section->m_Jump.LinkLocation  = NULL;
 		m_Section->m_Jump.LinkLocation2 = NULL;
-		m_Section->m_Cont.FallThrough   = FALSE;
+		m_Section->m_Cont.FallThrough   = false;
 		m_Section->m_Cont.LinkLocation  = NULL;
 		m_Section->m_Cont.LinkLocation2 = NULL;
 
 		m_NextInstruction = DO_DELAY_SLOT;
 	} else if (m_NextInstruction == DELAY_SLOT_DONE ) {		
 		if (DelaySlotEffectsCompare(m_CompilePC,m_Opcode.rs,0)) {
-			m_Section->CompileExit(m_CompilePC,(DWORD)-1,m_RegWorkingSet,CExitInfo::Normal,TRUE,NULL);
+			m_Section->CompileExit(m_CompilePC, (DWORD)-1, m_RegWorkingSet, CExitInfo::Normal, true, NULL);
 		} else {
 			UpdateCounters(m_RegWorkingSet,true,true);
 			if (IsConst(m_Opcode.rs)) { 
-				MoveConstToVariable(GetMipsRegLo(m_Opcode.rs),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
+				MoveConstToVariable(GetMipsRegLo(m_Opcode.rs), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
 			} else if (IsMapped(m_Opcode.rs)) { 
-				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
+				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
 			} else {
-				MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rs,FALSE),_PROGRAM_COUNTER, "PROGRAM_COUNTER");
+				MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rs, false), _PROGRAM_COUNTER, "PROGRAM_COUNTER");
 			}
-			m_Section->CompileExit((DWORD)-1, (DWORD)-1,m_RegWorkingSet,CExitInfo::Normal,TRUE,NULL);
+			m_Section->CompileExit((DWORD)-1, (DWORD)-1, m_RegWorkingSet, CExitInfo::Normal, true, NULL);
 			if (m_Section->m_JumpSection)
 			{
 				m_Section->GenerateSectionLinkage();
@@ -2010,7 +2046,7 @@ void CRecompilerOps::SPECIAL_JALR()
 
 void CRecompilerOps::SPECIAL_SYSCALL() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	m_Section->CompileExit(m_CompilePC,(DWORD)-1,m_RegWorkingSet,CExitInfo::DoSysCall,TRUE,NULL);
+	m_Section->CompileExit(m_CompilePC, (DWORD)-1, m_RegWorkingSet, CExitInfo::DoSysCall, true, NULL);
 	m_NextInstruction = END_BLOCK;
 }
 
@@ -2039,15 +2075,15 @@ void CRecompilerOps::SPECIAL_MTLO() {
 		if (Is64Bit(m_Opcode.rs)) {
 			MoveX86regToVariable(GetMipsRegMapHi(m_Opcode.rs),&_RegLO->UW[1],"_RegLO->UW[1]");
 		} else if (IsSigned(m_Opcode.rs)) {
-			MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rs,TRUE),&_RegLO->UW[1],"_RegLO->UW[1]");
+			MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rs, true), &_RegLO->UW[1], "_RegLO->UW[1]");
 		} else {
 			MoveConstToVariable(0,&_RegLO->UW[1],"_RegLO->UW[1]");
 		}
 		MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs), &_RegLO->UW[0],"_RegLO->UW[0]");
 	} else {
-		x86Reg reg = Map_TempReg(x86_Any,m_Opcode.rs,TRUE);
+		x86Reg reg = Map_TempReg(x86_Any, m_Opcode.rs, true);
 		MoveX86regToVariable(reg,&_RegLO->UW[1],"_RegLO->UW[1]");
-		MoveX86regToVariable(Map_TempReg(reg,m_Opcode.rs,FALSE), &_RegLO->UW[0],"_RegLO->UW[0]");
+		MoveX86regToVariable(Map_TempReg(reg, m_Opcode.rs, false), &_RegLO->UW[0], "_RegLO->UW[0]");
 	}
 }
 
@@ -2076,15 +2112,15 @@ void CRecompilerOps::SPECIAL_MTHI() {
 		if (Is64Bit(m_Opcode.rs)) {
 			MoveX86regToVariable(GetMipsRegMapHi(m_Opcode.rs),&_RegHI->UW[1],"_RegHI->UW[1]");
 		} else if (IsSigned(m_Opcode.rs)) {
-			MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rs,TRUE),&_RegHI->UW[1],"_RegHI->UW[1]");
+			MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rs, true), &_RegHI->UW[1], "_RegHI->UW[1]");
 		} else {
 			MoveConstToVariable(0,&_RegHI->UW[1],"_RegHI->UW[1]");
 		}
 		MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rs), &_RegHI->UW[0],"_RegHI->UW[0]");
 	} else {
-		x86Reg reg = Map_TempReg(x86_Any,m_Opcode.rs,TRUE);
-		MoveX86regToVariable(reg,&_RegHI->UW[1],"_RegHI->UW[1]");
-		MoveX86regToVariable(Map_TempReg(reg,m_Opcode.rs,FALSE), &_RegHI->UW[0],"_RegHI->UW[0]");
+		x86Reg reg = Map_TempReg(x86_Any, m_Opcode.rs, true);
+		MoveX86regToVariable(reg, &_RegHI->UW[1], "_RegHI->UW[1]");
+		MoveX86regToVariable(Map_TempReg(reg, m_Opcode.rs, false), &_RegHI->UW[0], "_RegHI->UW[0]");
 	}
 }
 
@@ -2092,7 +2128,8 @@ void CRecompilerOps::SPECIAL_DSLLV() {
 	BYTE * Jump[2];
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 	
 	if (IsConst(m_Opcode.rs)) 
 	{
@@ -2100,7 +2137,7 @@ void CRecompilerOps::SPECIAL_DSLLV() {
 		CRecompilerOps::UnknownOpcode();
 		return;
 	}
-	Map_TempReg(x86_ECX,m_Opcode.rs,FALSE);
+	Map_TempReg(x86_ECX, m_Opcode.rs, false);
 	AndConstToX86Reg(x86_ECX,0x3F);
 	Map_GPR_64bit(m_Opcode.rd,m_Opcode.rt);
 	CompConstToX86reg(x86_ECX,0x20);
@@ -2130,12 +2167,15 @@ void CRecompilerOps::SPECIAL_DSRLV() {
 	BYTE * Jump[2];
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 	
 	if (IsConst(m_Opcode.rs)) {
 		DWORD Shift = (GetMipsRegLo(m_Opcode.rs) & 0x3F);
 		if (IsConst(m_Opcode.rt)) {
-			if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+			if (IsMapped(m_Opcode.rd))
+				UnMap_GPR(m_Opcode.rd, false);
+
 			m_RegWorkingSet.SetMipsReg(m_Opcode.rd, Is64Bit(m_Opcode.rt)?GetMipsReg(m_Opcode.rt):(__int64)GetMipsRegLo_S(m_Opcode.rt));
 			m_RegWorkingSet.SetMipsReg(m_Opcode.rd, GetMipsReg(m_Opcode.rd) >> Shift);
 			if ((GetMipsRegHi(m_Opcode.rd) == 0) && (GetMipsRegLo(m_Opcode.rd) & 0x80000000) == 0) {
@@ -2153,7 +2193,7 @@ void CRecompilerOps::SPECIAL_DSRLV() {
 			return;
 		}
 
-		Map_TempReg(x86_ECX,-1,FALSE);
+		Map_TempReg(x86_ECX, -1, false);
 		MoveConstToX86reg(Shift, x86_ECX);
 		Map_GPR_64bit(m_Opcode.rd,m_Opcode.rt);
 		if ((Shift & 0x20) == 0x20)
@@ -2167,7 +2207,7 @@ void CRecompilerOps::SPECIAL_DSRLV() {
 			ShiftRightUnsign(GetMipsRegMapHi(m_Opcode.rd));
 		}
 	} else {
-		Map_TempReg(x86_ECX,m_Opcode.rs,FALSE);
+		Map_TempReg(x86_ECX, m_Opcode.rs, false);
 		AndConstToX86Reg(x86_ECX,0x3F);
 		Map_GPR_64bit(m_Opcode.rd,m_Opcode.rt);
 		CompConstToX86reg(x86_ECX,0x20);
@@ -2199,7 +2239,8 @@ void CRecompilerOps::SPECIAL_DSRAV()
 	BYTE * Jump[2];
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 	
 	if (IsConst(m_Opcode.rs)) 
 	{
@@ -2207,7 +2248,7 @@ void CRecompilerOps::SPECIAL_DSRAV()
 		CRecompilerOps::UnknownOpcode();
 		return;
 	}
-	Map_TempReg(x86_ECX,m_Opcode.rs,FALSE);
+	Map_TempReg(x86_ECX, m_Opcode.rs, false);
 	AndConstToX86Reg(x86_ECX,0x3F);
 	Map_GPR_64bit(m_Opcode.rd,m_Opcode.rt);
 	CompConstToX86reg(x86_ECX,0x20);
@@ -2236,10 +2277,10 @@ void CRecompilerOps::SPECIAL_DSRAV()
 void CRecompilerOps::SPECIAL_MULT() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	m_RegWorkingSet.SetX86Protected(x86_EDX,TRUE);
-	Map_TempReg(x86_EAX,m_Opcode.rs,FALSE);
-	m_RegWorkingSet.SetX86Protected(x86_EDX,FALSE);
-	Map_TempReg(x86_EDX,m_Opcode.rt,FALSE);
+	m_RegWorkingSet.SetX86Protected(x86_EDX, true);
+	Map_TempReg(x86_EAX, m_Opcode.rs, false);
+	m_RegWorkingSet.SetX86Protected(x86_EDX, false);
+	Map_TempReg(x86_EDX, m_Opcode.rt, false);
 
 	imulX86reg(x86_EDX);
 
@@ -2254,10 +2295,10 @@ void CRecompilerOps::SPECIAL_MULT() {
 void CRecompilerOps::SPECIAL_MULTU() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	m_RegWorkingSet.SetX86Protected(x86_EDX, TRUE);
-	Map_TempReg(x86_EAX,m_Opcode.rs,FALSE);
-	m_RegWorkingSet.SetX86Protected(x86_EDX,FALSE);
-	Map_TempReg(x86_EDX,m_Opcode.rt,FALSE);
+	m_RegWorkingSet.SetX86Protected(x86_EDX, true);
+	Map_TempReg(x86_EAX, m_Opcode.rs, false);
+	m_RegWorkingSet.SetX86Protected(x86_EDX, false);
+	Map_TempReg(x86_EDX, m_Opcode.rt, false);
 
 	MulX86reg(x86_EDX);
 
@@ -2287,17 +2328,17 @@ void CRecompilerOps::SPECIAL_DIV()
 		} else {
 			CompConstToVariable(0, &_GPR[m_Opcode.rt].W[0], CRegName::GPR_Lo[m_Opcode.rt]);
 		}
-		m_Section->CompileExit(m_CompilePC, m_CompilePC,m_RegWorkingSet,CExitInfo::DivByZero,FALSE,JeLabel32);
+		m_Section->CompileExit(m_CompilePC, m_CompilePC, m_RegWorkingSet, CExitInfo::DivByZero, false, JeLabel32);
 	}
 	/*	lo = (SD)rs / (SD)rt;
 		hi = (SD)rs % (SD)rt; */
 
-	m_RegWorkingSet.SetX86Protected(x86_EDX,TRUE);
-	Map_TempReg(x86_EAX,m_Opcode.rs,FALSE);
+	m_RegWorkingSet.SetX86Protected(x86_EDX, true);
+	Map_TempReg(x86_EAX, m_Opcode.rs, false);
 
 	/* edx is the signed portion to eax */
-	m_RegWorkingSet.SetX86Protected(x86_EDX, FALSE);
-	Map_TempReg(x86_EDX, -1, FALSE);
+	m_RegWorkingSet.SetX86Protected(x86_EDX, false);
+	Map_TempReg(x86_EDX, -1, false);
 
 	MoveX86RegToX86Reg(x86_EAX, x86_EDX);
 	ShiftRightSignImmed(x86_EDX,31);
@@ -2305,7 +2346,7 @@ void CRecompilerOps::SPECIAL_DIV()
 	if (IsMapped(m_Opcode.rt)) {
 		idivX86reg(GetMipsRegMapLo(m_Opcode.rt));
 	} else {
-		idivX86reg(Map_TempReg(x86_Any,m_Opcode.rt,FALSE));
+		idivX86reg(Map_TempReg(x86_Any, m_Opcode.rt, false));
 	}
 		
 
@@ -2358,12 +2399,12 @@ void CRecompilerOps::SPECIAL_DIVU() {
 	/*	lo = (UD)rs / (UD)rt;
 		hi = (UD)rs % (UD)rt; */
 
-	m_RegWorkingSet.SetX86Protected(x86_EAX,TRUE);
-	Map_TempReg(x86_EDX, 0, FALSE);
-	m_RegWorkingSet.SetX86Protected(x86_EAX,FALSE);
+	m_RegWorkingSet.SetX86Protected(x86_EAX, true);
+	Map_TempReg(x86_EDX, 0, false);
+	m_RegWorkingSet.SetX86Protected(x86_EAX, false);
 
-	Map_TempReg(x86_EAX,m_Opcode.rs,FALSE);
-	Reg = Map_TempReg(x86_Any,m_Opcode.rt,FALSE);
+	Map_TempReg(x86_EAX, m_Opcode.rs, false);
+	Reg = Map_TempReg(x86_Any, m_Opcode.rt, false);
 
 	DivX86reg(Reg);
 
@@ -2388,8 +2429,12 @@ void CRecompilerOps::SPECIAL_DMULT()
 {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	if (m_Opcode.rs != 0) { UnMap_GPR(m_Opcode.rs,TRUE); }
-	if (m_Opcode.rs != 0) { UnMap_GPR(m_Opcode.rt,TRUE); }
+	if (m_Opcode.rs != 0)
+		UnMap_GPR(m_Opcode.rs, true);
+
+	if (m_Opcode.rs != 0)
+		UnMap_GPR(m_Opcode.rt, true);
+
 	BeforeCallDirect(m_RegWorkingSet);
 	MoveConstToVariable(m_Opcode.Hex, &R4300iOp::m_Opcode.Hex, "R4300iOp::m_Opcode.Hex");
 	Call_Direct(R4300iOp::SPECIAL_DMULT, "R4300iOp::SPECIAL_DMULT");
@@ -2399,8 +2444,8 @@ void CRecompilerOps::SPECIAL_DMULT()
 void CRecompilerOps::SPECIAL_DMULTU() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	UnMap_GPR(m_Opcode.rs,TRUE);
-	UnMap_GPR(m_Opcode.rt,TRUE);
+	UnMap_GPR(m_Opcode.rs, true);
+	UnMap_GPR(m_Opcode.rt, true);
 	BeforeCallDirect(m_RegWorkingSet);
 	MoveConstToVariable(m_Opcode.Hex, &R4300iOp::m_Opcode.Hex, "R4300iOp::m_Opcode.Hex");
 	Call_Direct(R4300iOp::SPECIAL_DMULTU, "R4300iOp::SPECIAL_DMULTU");
@@ -2408,41 +2453,41 @@ void CRecompilerOps::SPECIAL_DMULTU() {
 
 #ifdef toremove
 	/* _RegLO->UDW = (uint64)_GPR[m_Opcode.rs].UW[0] * (uint64)_GPR[m_Opcode.rt].UW[0]; */
-	X86Protected(x86_EDX) = TRUE;
-	Map_TempReg(x86_EAX,m_Opcode.rs,FALSE);
-	X86Protected(x86_EDX) = FALSE;
-	Map_TempReg(x86_EDX,m_Opcode.rt,FALSE);
+	X86Protected(x86_EDX) = true;
+	Map_TempReg(x86_EAX,m_Opcode.rs,false);
+	X86Protected(x86_EDX) = false;
+	Map_TempReg(x86_EDX,m_Opcode.rt,false);
 
 	MulX86reg(x86_EDX);
 	MoveX86regToVariable(x86_EAX, &_RegLO->UW[0], "_RegLO->UW[0]");
 	MoveX86regToVariable(x86_EDX, &_RegLO->UW[1], "_RegLO->UW[1]");
 
 	/* _RegHI->UDW = (uint64)_GPR[m_Opcode.rs].UW[1] * (uint64)_GPR[m_Opcode.rt].UW[1]; */
-	Map_TempReg(x86_EAX,m_Opcode.rs,TRUE);
-	Map_TempReg(x86_EDX,m_Opcode.rt,TRUE);
+	Map_TempReg(x86_EAX,m_Opcode.rs,true);
+	Map_TempReg(x86_EDX,m_Opcode.rt,true);
 
 	MulX86reg(x86_EDX);
 	MoveX86regToVariable(x86_EAX, &_RegHI->UW[0], "_RegHI->UW[0]");
 	MoveX86regToVariable(x86_EDX, &_RegHI->UW[1], "_RegHI->UW[1]");
 
 	/* Tmp[0].UDW = (uint64)_GPR[m_Opcode.rs].UW[1] * (uint64)_GPR[m_Opcode.rt].UW[0]; */
-	Map_TempReg(x86_EAX,m_Opcode.rs,TRUE);
-	Map_TempReg(x86_EDX,m_Opcode.rt,FALSE);
+	Map_TempReg(x86_EAX,m_Opcode.rs,true);
+	Map_TempReg(x86_EDX,m_Opcode.rt,false);
 
-	Map_TempReg(x86_EBX,-1,FALSE);
-	Map_TempReg(x86_ECX,-1,FALSE);
+	Map_TempReg(x86_EBX,-1,false);
+	Map_TempReg(x86_ECX,-1,false);
 
 	MulX86reg(x86_EDX);
 	MoveX86RegToX86Reg(x86_EAX, x86_EBX); /* EDX:EAX -> ECX:EBX */
 	MoveX86RegToX86Reg(x86_EDX, x86_ECX);
 
 	/* Tmp[1].UDW = (uint64)_GPR[m_Opcode.rs].UW[0] * (uint64)_GPR[m_Opcode.rt].UW[1]; */
-	Map_TempReg(x86_EAX,m_Opcode.rs,FALSE);
-	Map_TempReg(x86_EDX,m_Opcode.rt,TRUE);
+	Map_TempReg(x86_EAX,m_Opcode.rs,false);
+	Map_TempReg(x86_EDX,m_Opcode.rt,true);
 
 	MulX86reg(x86_EDX);
-	Map_TempReg(x86_ESI,-1,FALSE);
-	Map_TempReg(x86_EDI,-1,FALSE);
+	Map_TempReg(x86_ESI,-1,false);
+	Map_TempReg(x86_EDI,-1,false);
 	MoveX86RegToX86Reg(x86_EAX, x86_ESI); /* EDX:EAX -> EDI:ESI */
 	MoveX86RegToX86Reg(x86_EDX, x86_EDI);
 
@@ -2477,8 +2522,8 @@ void CRecompilerOps::SPECIAL_DMULTU() {
 void CRecompilerOps::SPECIAL_DDIV() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	UnMap_GPR(m_Opcode.rs,TRUE);
-	UnMap_GPR(m_Opcode.rt,TRUE);
+	UnMap_GPR(m_Opcode.rs, true);
+	UnMap_GPR(m_Opcode.rt, true);
 	BeforeCallDirect(m_RegWorkingSet);
 	MoveConstToVariable(m_Opcode.Hex, &R4300iOp::m_Opcode.Hex, "R4300iOp::m_Opcode.Hex");
 	Call_Direct(R4300iOp::SPECIAL_DDIV, "R4300iOp::SPECIAL_DDIV");
@@ -2489,8 +2534,8 @@ void CRecompilerOps::SPECIAL_DDIVU()
 {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	UnMap_GPR(m_Opcode.rs,TRUE);
-	UnMap_GPR(m_Opcode.rt,TRUE);
+	UnMap_GPR(m_Opcode.rs, true);
+	UnMap_GPR(m_Opcode.rt, true);
 	BeforeCallDirect(m_RegWorkingSet);
 	MoveConstToVariable(m_Opcode.Hex, &R4300iOp::m_Opcode.Hex, "R4300iOp::m_Opcode.Hex");
 	Call_Direct(R4300iOp::SPECIAL_DDIVU, "R4300iOp::SPECIAL_DDIVU");
@@ -2502,17 +2547,20 @@ void CRecompilerOps::SPECIAL_ADD() {
 	int source2 = m_Opcode.rd == m_Opcode.rt?m_Opcode.rs:m_Opcode.rt;
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(source1) && IsConst(source2)) {
 		DWORD temp = GetMipsRegLo(source1) + GetMipsRegLo(source2);
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd,temp);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 		return;
 	}
 
-	Map_GPR_32bit(m_Opcode.rd,TRUE, source1);
+	Map_GPR_32bit(m_Opcode.rd, true, source1);
 	if (IsConst(source2)) {
 		AddConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegLo(source2));
 	} else if (IsKnown(source2) && IsMapped(source2)) {
@@ -2531,17 +2579,20 @@ void CRecompilerOps::SPECIAL_ADDU() {
 	int source2 = m_Opcode.rd == m_Opcode.rt?m_Opcode.rs:m_Opcode.rt;
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(source1) && IsConst(source2)) {
 		DWORD temp = GetMipsRegLo(source1) + GetMipsRegLo(source2);
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd,temp);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 		return;
 	}
 
-	Map_GPR_32bit(m_Opcode.rd,TRUE, source1);
+	Map_GPR_32bit(m_Opcode.rd, true, source1);
 	if (IsConst(source2)) {
 		AddConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegLo(source2));
 	} else if (IsKnown(source2) && IsMapped(source2)) {
@@ -2557,21 +2608,25 @@ void CRecompilerOps::SPECIAL_ADDU() {
 
 void CRecompilerOps::SPECIAL_SUB() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(m_Opcode.rt)  && IsConst(m_Opcode.rs)) {
 		DWORD temp = GetMipsRegLo(m_Opcode.rs) - GetMipsRegLo(m_Opcode.rt);
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd,temp);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 	} else {
 		if (m_Opcode.rd == m_Opcode.rt) {
-			x86Reg Reg = Map_TempReg(x86_Any,m_Opcode.rt,FALSE);
-			Map_GPR_32bit(m_Opcode.rd,TRUE, m_Opcode.rs);
+			x86Reg Reg = Map_TempReg(x86_Any, m_Opcode.rt, false);
+			Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rs);
 			SubX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),Reg);
 			return;
 		}
-		Map_GPR_32bit(m_Opcode.rd,TRUE, m_Opcode.rs);
+		Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rs);
 		if (IsConst(m_Opcode.rt)) {
 			SubConstFromX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegLo(m_Opcode.rt));
 		} else if (IsMapped(m_Opcode.rt)) {
@@ -2588,21 +2643,25 @@ void CRecompilerOps::SPECIAL_SUB() {
 
 void CRecompilerOps::SPECIAL_SUBU() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(m_Opcode.rt)  && IsConst(m_Opcode.rs)) {
 		DWORD temp = GetMipsRegLo(m_Opcode.rs) - GetMipsRegLo(m_Opcode.rt);
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd,temp);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 	} else {
 		if (m_Opcode.rd == m_Opcode.rt) {
-			x86Reg Reg = Map_TempReg(x86_Any,m_Opcode.rt,FALSE);
-			Map_GPR_32bit(m_Opcode.rd,TRUE, m_Opcode.rs);
+			x86Reg Reg = Map_TempReg(x86_Any, m_Opcode.rt, false);
+			Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rs);
 			SubX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),Reg);
 			return;
 		}
-		Map_GPR_32bit(m_Opcode.rd,TRUE, m_Opcode.rs);
+		Map_GPR_32bit(m_Opcode.rd, true, m_Opcode.rs);
 		if (IsConst(m_Opcode.rt)) {
 			SubConstFromX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegLo(m_Opcode.rt));
 		} else if (IsMapped(m_Opcode.rt)) {
@@ -2648,17 +2707,17 @@ void CRecompilerOps::SPECIAL_AND()
 			ProtectGPR(source1);
 			ProtectGPR(source2);
 			if (Is32Bit(source1) && Is32Bit(source2)) {
-				bool Sign = (IsSigned(m_Opcode.rt) && IsSigned(m_Opcode.rs))?true:false;
-				Map_GPR_32bit(m_Opcode.rd,Sign,source1);				
+				bool Sign = (IsSigned(m_Opcode.rt) && IsSigned(m_Opcode.rs));
+				Map_GPR_32bit(m_Opcode.rd, Sign, source1);
 				AndX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(source2));
 			} else if (Is32Bit(source1) || Is32Bit(source2)) {
 				if (IsUnsigned(Is32Bit(source1)?source1:source2)) {
-					Map_GPR_32bit(m_Opcode.rd,FALSE,source1);
+					Map_GPR_32bit(m_Opcode.rd, false, source1);
 					AndX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(source2));
 				} else {
 					Map_GPR_64bit(m_Opcode.rd,source1);
 					if (Is32Bit(source2)) {
-						AndX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),Map_TempReg(x86_Any,source2,TRUE));
+						AndX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),Map_TempReg(x86_Any,source2,true));
 					} else {
 						AndX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),GetMipsRegMapHi(source2));
 					}
@@ -2676,10 +2735,10 @@ void CRecompilerOps::SPECIAL_AND()
 			if (Is64Bit(ConstReg)) {
 				if (Is32Bit(MappedReg) && IsUnsigned(MappedReg)) {
 					if (GetMipsRegLo(ConstReg) == 0) {
-						Map_GPR_32bit(m_Opcode.rd,FALSE, 0);
+						Map_GPR_32bit(m_Opcode.rd, false, 0);
 					} else {
 						DWORD Value = GetMipsRegLo(ConstReg);
-						Map_GPR_32bit(m_Opcode.rd,FALSE, MappedReg);
+						Map_GPR_32bit(m_Opcode.rd, false, MappedReg);
 						AndConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd),Value);
 					}
 				} else {
@@ -2691,20 +2750,23 @@ void CRecompilerOps::SPECIAL_AND()
 			} else if (Is64Bit(MappedReg)) {
 				DWORD Value = GetMipsRegLo(ConstReg); 
 				if (Value != 0) {
-					Map_GPR_32bit(m_Opcode.rd,IsSigned(ConstReg)?TRUE:FALSE,MappedReg);					
+					Map_GPR_32bit(m_Opcode.rd, IsSigned(ConstReg), MappedReg);
 					AndConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd),Value);
 				} else {
-					Map_GPR_32bit(m_Opcode.rd,IsSigned(ConstReg)?TRUE:FALSE, 0);
+					Map_GPR_32bit(m_Opcode.rd, IsSigned(ConstReg), 0);
 				}
 			} else {
 				DWORD Value = GetMipsRegLo(ConstReg); 
 				bool Sign = false;
-				if (IsSigned(ConstReg) && IsSigned(MappedReg)) { Sign = true; }				
+
+				if (IsSigned(ConstReg) && IsSigned(MappedReg))
+					Sign = true;
+
 				if (Value != 0) {
 					Map_GPR_32bit(m_Opcode.rd,Sign,MappedReg);
 					AndConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd),Value);
 				} else {
-					Map_GPR_32bit(m_Opcode.rd,false, 0);
+					Map_GPR_32bit(m_Opcode.rd, false, 0);
 				}
 			}
 		}
@@ -2762,8 +2824,11 @@ void CRecompilerOps::SPECIAL_OR() {
 
 	if (IsKnown(m_Opcode.rt) && IsKnown(m_Opcode.rs)) {
 		if (IsConst(m_Opcode.rt) && IsConst(m_Opcode.rs)) {
-			if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
-			if (Is64Bit(m_Opcode.rt) || Is64Bit(m_Opcode.rs)) {				
+
+			if (IsMapped(m_Opcode.rd))
+				UnMap_GPR(m_Opcode.rd, false);
+
+			if (Is64Bit(m_Opcode.rt) || Is64Bit(m_Opcode.rs)) {
 				m_RegWorkingSet.SetMipsReg(m_Opcode.rd,
 					(Is64Bit(m_Opcode.rt)?GetMipsReg(m_Opcode.rt):(__int64)GetMipsRegLo_S(m_Opcode.rt)) |
 					(Is64Bit(m_Opcode.rs)?GetMipsReg(m_Opcode.rs):(__int64)GetMipsRegLo_S(m_Opcode.rs))
@@ -2790,11 +2855,11 @@ void CRecompilerOps::SPECIAL_OR() {
 				if (Is64Bit(source2)) {
 					OrX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),GetMipsRegMapHi(source2));
 				} else {
-					OrX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),Map_TempReg(x86_Any,source2,TRUE));
+					OrX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd), Map_TempReg(x86_Any, source2, true));
 				}
 			} else {
 				ProtectGPR(source2);
-				Map_GPR_32bit(m_Opcode.rd,TRUE,source1);
+				Map_GPR_32bit(m_Opcode.rd, true, source1);
 			}
 			OrX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(source2));
 		} else {
@@ -2819,7 +2884,7 @@ void CRecompilerOps::SPECIAL_OR() {
 				}
 			} else {
 				int Value = GetMipsRegLo(ConstReg);
-				Map_GPR_32bit(m_Opcode.rd,TRUE, MappedReg);
+				Map_GPR_32bit(m_Opcode.rd, true, MappedReg);
 				if (Value != 0) { OrConstToX86Reg(Value,GetMipsRegMapLo(m_Opcode.rd)); }
 			}
 		}
@@ -2877,17 +2942,20 @@ void CRecompilerOps::SPECIAL_OR() {
 
 void CRecompilerOps::SPECIAL_XOR() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (m_Opcode.rt == m_Opcode.rs) {
-		UnMap_GPR( m_Opcode.rd, FALSE);
+		UnMap_GPR(m_Opcode.rd, false);
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd, 0);
 		return;
 	}
 	if (IsKnown(m_Opcode.rt) && IsKnown(m_Opcode.rs)) {
 		if (IsConst(m_Opcode.rt) && IsConst(m_Opcode.rs)) {
-			if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+			if (IsMapped(m_Opcode.rd))
+				UnMap_GPR(m_Opcode.rd, false);
+
 			if (Is64Bit(m_Opcode.rt) || Is64Bit(m_Opcode.rs)) {
 				if (bHaveDebugger()) { g_Notify->DisplayError(L"XOR 1"); }
 				CRecompilerOps::UnknownOpcode();
@@ -2906,12 +2974,12 @@ void CRecompilerOps::SPECIAL_XOR() {
 				if (Is64Bit(source2)) {
 					XorX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),GetMipsRegMapHi(source2));
 				} else if (IsSigned(source2)) {
-					XorX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),Map_TempReg(x86_Any,source2,TRUE));
+					XorX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd), Map_TempReg(x86_Any, source2, true));
 				}
 				XorX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(source2));
 			} else {
 				if (IsSigned(m_Opcode.rt) != IsSigned(m_Opcode.rs)) {
-					Map_GPR_32bit(m_Opcode.rd,TRUE,source1);
+					Map_GPR_32bit(m_Opcode.rd, true, source1);
 				} else {
 					Map_GPR_32bit(m_Opcode.rd,IsSigned(m_Opcode.rt),source1);
 				}
@@ -2932,9 +3000,9 @@ void CRecompilerOps::SPECIAL_XOR() {
 			} else {
 				int Value = GetMipsRegLo(ConstReg);
 				if (IsSigned(m_Opcode.rt) != IsSigned(m_Opcode.rs)) {
-					Map_GPR_32bit(m_Opcode.rd,TRUE, MappedReg);
+					Map_GPR_32bit(m_Opcode.rd, true, MappedReg);
 				} else {
-					Map_GPR_32bit(m_Opcode.rd,IsSigned(MappedReg)?TRUE:FALSE, MappedReg);
+					Map_GPR_32bit(m_Opcode.rd, IsSigned(MappedReg), MappedReg);
 				}
 				if (Value != 0) { XorConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd),Value); }
 			}
@@ -2990,8 +3058,10 @@ void CRecompilerOps::SPECIAL_NOR() {
 
 	if (IsKnown(m_Opcode.rt) && IsKnown(m_Opcode.rs)) {
 		if (IsConst(m_Opcode.rt) && IsConst(m_Opcode.rs)) {
-			if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
-			if (Is64Bit(m_Opcode.rt) || Is64Bit(m_Opcode.rs)) {				
+			if (IsMapped(m_Opcode.rd))
+				UnMap_GPR(m_Opcode.rd, false);
+
+			if (Is64Bit(m_Opcode.rt) || Is64Bit(m_Opcode.rs)) {
 				m_RegWorkingSet.SetMipsReg(m_Opcode.rd,
 					~((Is64Bit(m_Opcode.rt)?GetMipsReg(m_Opcode.rt):(__int64)GetMipsRegLo_S(m_Opcode.rt)) |
 					(Is64Bit(m_Opcode.rs)?GetMipsReg(m_Opcode.rs):(__int64)GetMipsRegLo_S(m_Opcode.rs)))
@@ -3018,11 +3088,11 @@ void CRecompilerOps::SPECIAL_NOR() {
 				if (Is64Bit(source2)) {
 					OrX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),GetMipsRegMapHi(source2));
 				} else {
-					OrX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),Map_TempReg(x86_Any,source2,TRUE));
+					OrX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd), Map_TempReg(x86_Any, source2, true));
 				}
 			} else {
 				ProtectGPR(source2);
-				Map_GPR_32bit(m_Opcode.rd,TRUE,source1);
+				Map_GPR_32bit(m_Opcode.rd, true, source1);
 			}
 			OrX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(source2));
 		} else {
@@ -3047,7 +3117,7 @@ void CRecompilerOps::SPECIAL_NOR() {
 				}
 			} else {
 				int Value = GetMipsRegLo(ConstReg);
-				Map_GPR_32bit(m_Opcode.rd,TRUE, MappedReg);
+				Map_GPR_32bit(m_Opcode.rd, true, MappedReg);
 				if (Value != 0) { OrConstToX86Reg(Value,GetMipsRegMapLo(m_Opcode.rd)); }
 			}
 		}
@@ -3103,13 +3173,14 @@ void CRecompilerOps::SPECIAL_NOR() {
 		{
 			NotX86Reg(GetMipsRegMapHi(m_Opcode.rd));
 		} 
-		NotX86Reg(GetMipsRegMapLo(m_Opcode.rd));		
+		NotX86Reg(GetMipsRegMapLo(m_Opcode.rd));
 	}
 }
 
 void CRecompilerOps::SPECIAL_SLT() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsKnown(m_Opcode.rt) && IsKnown(m_Opcode.rs)) {
 		if (IsConst(m_Opcode.rt) && IsConst(m_Opcode.rs)) {
@@ -3117,8 +3188,10 @@ void CRecompilerOps::SPECIAL_SLT() {
 				g_Notify->DisplayError(L"1");
 				CRecompilerOps::UnknownOpcode();
 			} else {
-				if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
-				m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);	
+				if (IsMapped(m_Opcode.rd))
+					UnMap_GPR(m_Opcode.rd, false);
+
+				m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 				if (GetMipsRegLo_S(m_Opcode.rs) < GetMipsRegLo_S(m_Opcode.rt)) {
 					m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd,1);
 				} else {
@@ -3134,8 +3207,8 @@ void CRecompilerOps::SPECIAL_SLT() {
 				BYTE *Jump[2];
 
 				CompX86RegToX86Reg(
-					Is64Bit(m_Opcode.rs)?GetMipsRegMapHi(m_Opcode.rs):Map_TempReg(x86_Any,m_Opcode.rs,TRUE), 
-					Is64Bit(m_Opcode.rt)?GetMipsRegMapHi(m_Opcode.rt):Map_TempReg(x86_Any,m_Opcode.rt,TRUE)
+					Is64Bit(m_Opcode.rs) ? GetMipsRegMapHi(m_Opcode.rs) : Map_TempReg(x86_Any, m_Opcode.rs, true),
+					Is64Bit(m_Opcode.rt) ? GetMipsRegMapHi(m_Opcode.rt) : Map_TempReg(x86_Any, m_Opcode.rt, true)
 					);
 				JeLabel8("Low Compare",0);
 				Jump[0] = m_RecompPos - 1;
@@ -3151,16 +3224,16 @@ void CRecompilerOps::SPECIAL_SLT() {
 				CPU_Message("");
 				CPU_Message("      Continue:");
 				SetJump8(Jump[1],m_RecompPos);
-				Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
 			} else {
-				Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				CompX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rs), GetMipsRegMapLo(m_Opcode.rt));
 
 				if (GetMipsRegMapLo(m_Opcode.rd) > x86_EBX) {
 					SetlVariable(&m_BranchCompare,"m_BranchCompare");
 					MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
-				} else {					
+				} else {
 					Setl(GetMipsRegMapLo(m_Opcode.rd));
 					AndConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd), 1);
 				}
@@ -3174,8 +3247,8 @@ void CRecompilerOps::SPECIAL_SLT() {
 				BYTE *Jump[2];
 
 				CompConstToX86reg(
-					Is64Bit(MappedReg)?GetMipsRegMapHi(MappedReg):Map_TempReg(x86_Any,MappedReg,TRUE), 
-					Is64Bit(ConstReg)?GetMipsRegHi(ConstReg):(GetMipsRegLo_S(ConstReg) >> 31)
+					Is64Bit(MappedReg) ? GetMipsRegMapHi(MappedReg) : Map_TempReg(x86_Any, MappedReg, true),
+					Is64Bit(ConstReg)  ? GetMipsRegHi(ConstReg) : (GetMipsRegLo_S(ConstReg) >> 31)
 					);
 				JeLabel8("Low Compare",0);
 				Jump[0] = m_RecompPos - 1;
@@ -3199,11 +3272,11 @@ void CRecompilerOps::SPECIAL_SLT() {
 				CPU_Message("");
 				CPU_Message("      Continue:");
 				SetJump8(Jump[1],m_RecompPos);
-				Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
 			} else {
 				DWORD Constant = GetMipsRegLo(ConstReg);
-				Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				CompConstToX86reg(GetMipsRegMapLo(MappedReg), Constant);
 
 				if (GetMipsRegMapLo(m_Opcode.rd) > x86_EBX) {
@@ -3213,7 +3286,7 @@ void CRecompilerOps::SPECIAL_SLT() {
 						SetgVariable(&m_BranchCompare,"m_BranchCompare");
 					}
 					MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
-				} else {					
+				} else {
 					if (MappedReg == m_Opcode.rs) {
 						Setl(GetMipsRegMapLo(m_Opcode.rd));
 					} else {
@@ -3241,7 +3314,7 @@ void CRecompilerOps::SPECIAL_SLT() {
 					CompConstToVariable((GetMipsRegLo_S(KnownReg) >> 31),&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
 				} else {
 					ProtectGPR(KnownReg);
-					CompX86regToVariable(Map_TempReg(x86_Any,KnownReg,TRUE),&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
+					CompX86regToVariable(Map_TempReg(x86_Any, KnownReg, true), &_GPR[UnknownReg].W[1], CRegName::GPR_Hi[UnknownReg]);
 				}
 			}
 			JeLabel8("Low Compare",0);
@@ -3270,7 +3343,7 @@ void CRecompilerOps::SPECIAL_SLT() {
 			CPU_Message("");
 			CPU_Message("      Continue:");
 			SetJump8(Jump[1],m_RecompPos);
-			Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+			Map_GPR_32bit(m_Opcode.rd, true, -1);
 			MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
 		} else {
 			if (IsMapped(KnownReg))
@@ -3280,7 +3353,7 @@ void CRecompilerOps::SPECIAL_SLT() {
 			bool bConstant = IsConst(KnownReg);
 			DWORD Value = IsConst(KnownReg) ? GetMipsRegLo(KnownReg) : 0;
 
-			Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+			Map_GPR_32bit(m_Opcode.rd, true, -1);
 			if (bConstant) {
 				CompConstToVariable(Value,&_GPR[UnknownReg].W[0],CRegName::GPR_Lo[UnknownReg]);
 			} else {
@@ -3293,7 +3366,7 @@ void CRecompilerOps::SPECIAL_SLT() {
 					SetlVariable(&m_BranchCompare,"m_BranchCompare");
 				}
 				MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
-			} else {					
+			} else {
 				if (KnownReg == (bConstant?m_Opcode.rs:m_Opcode.rt)) {
 					Setg(GetMipsRegMapLo(m_Opcode.rd));
 				} else {
@@ -3309,14 +3382,14 @@ void CRecompilerOps::SPECIAL_SLT() {
 		if (GetMipsRegMapLo(m_Opcode.rd) > x86_EBX) {
 			SetlVariable(&m_BranchCompare,"m_BranchCompare");
 			MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
-		} else {					
+		} else {
 			Setl(GetMipsRegMapLo(m_Opcode.rd));
 			AndConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd), 1);
 		}
 	} else {
 		BYTE *Jump[2] = { NULL, NULL };
 
-		x86Reg Reg = Map_TempReg(x86_Any,m_Opcode.rs,TRUE);
+		x86Reg Reg = Map_TempReg(x86_Any, m_Opcode.rs, true);
 		CompX86regToVariable(Reg,&_GPR[m_Opcode.rt].W[1],CRegName::GPR_Hi[m_Opcode.rt]);
 		JeLabel8("Low Compare",0);
 		Jump[0] = m_RecompPos - 1;
@@ -3327,7 +3400,7 @@ void CRecompilerOps::SPECIAL_SLT() {
 		CPU_Message("");
 		CPU_Message("      Low Compare:");
 		SetJump8(Jump[0],m_RecompPos);
-		CompX86regToVariable(Map_TempReg(Reg,m_Opcode.rs,FALSE),&_GPR[m_Opcode.rt].W[0],CRegName::GPR_Lo[m_Opcode.rt]);
+		CompX86regToVariable(Map_TempReg(Reg, m_Opcode.rs, false), &_GPR[m_Opcode.rt].W[0], CRegName::GPR_Lo[m_Opcode.rt]);
 		SetbVariable(&m_BranchCompare,"m_BranchCompare");
 		if (Jump[1])
 		{
@@ -3335,14 +3408,15 @@ void CRecompilerOps::SPECIAL_SLT() {
 			CPU_Message("      Continue:");
 			SetJump8(Jump[1],m_RecompPos);
 		}
-		Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+		Map_GPR_32bit(m_Opcode.rd, true, -1);
 		MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
 	}
 }
 
 void CRecompilerOps::SPECIAL_SLTU() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsKnown(m_Opcode.rt) && IsKnown(m_Opcode.rs)) {
 		if (IsConst(m_Opcode.rt) && IsConst(m_Opcode.rs)) {
@@ -3350,8 +3424,10 @@ void CRecompilerOps::SPECIAL_SLTU() {
 				g_Notify->DisplayError(L"1");
 				CRecompilerOps::UnknownOpcode();
 			} else {
-				if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
-				m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);	
+				if (IsMapped(m_Opcode.rd))
+					UnMap_GPR(m_Opcode.rd, false);
+
+				m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 				if (GetMipsRegLo(m_Opcode.rs) < GetMipsRegLo(m_Opcode.rt)) {
 					m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd,1);
 				} else {
@@ -3367,8 +3443,8 @@ void CRecompilerOps::SPECIAL_SLTU() {
 				BYTE *Jump[2];
 
 				CompX86RegToX86Reg(
-					Is64Bit(m_Opcode.rs)?GetMipsRegMapHi(m_Opcode.rs):Map_TempReg(x86_Any,m_Opcode.rs,TRUE), 
-					Is64Bit(m_Opcode.rt)?GetMipsRegMapHi(m_Opcode.rt):Map_TempReg(x86_Any,m_Opcode.rt,TRUE)
+					Is64Bit(m_Opcode.rs) ? GetMipsRegMapHi(m_Opcode.rs) : Map_TempReg(x86_Any, m_Opcode.rs, true),
+					Is64Bit(m_Opcode.rt) ? GetMipsRegMapHi(m_Opcode.rt) : Map_TempReg(x86_Any, m_Opcode.rt, true)
 					);
 				JeLabel8("Low Compare",0);
 				Jump[0] = m_RecompPos - 1;
@@ -3384,12 +3460,12 @@ void CRecompilerOps::SPECIAL_SLTU() {
 				CPU_Message("");
 				CPU_Message("      Continue:");
 				SetJump8(Jump[1],m_RecompPos);
-				Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
 			} else {
 				CompX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rs), GetMipsRegMapLo(m_Opcode.rt));
 				SetbVariable(&m_BranchCompare,"m_BranchCompare");
-				Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
 			}
 		} else {
@@ -3409,11 +3485,11 @@ void CRecompilerOps::SPECIAL_SLTU() {
 				MappedRegLo = GetMipsRegMapLo(MappedReg);
 				MappedRegHi = GetMipsRegMapHi(MappedReg);
 				if (Is32Bit(MappedReg)) {
-					MappedRegHi = Map_TempReg(x86_Any,MappedReg,TRUE);
+					MappedRegHi = Map_TempReg(x86_Any, MappedReg, true);
 				}
 
 
-				Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				CompConstToX86reg(MappedRegHi, ConstHi);
 				JeLabel8("Low Compare",0);
 				Jump[0] = m_RecompPos - 1;
@@ -3437,7 +3513,7 @@ void CRecompilerOps::SPECIAL_SLTU() {
 				CPU_Message("");
 				CPU_Message("      Continue:");
 				SetJump8(Jump[1],m_RecompPos);
-				Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
 			} else {
 				DWORD Const = IsConst(m_Opcode.rs)?GetMipsRegLo(m_Opcode.rs):GetMipsRegLo(m_Opcode.rt);
@@ -3449,7 +3525,7 @@ void CRecompilerOps::SPECIAL_SLTU() {
 				} else {
 					SetaVariable(&m_BranchCompare,"m_BranchCompare");
 				}
-				Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
 			}
 		}		
@@ -3464,7 +3540,7 @@ void CRecompilerOps::SPECIAL_SLTU() {
 			DWORD TestReg = IsConst(KnownReg)?m_Opcode.rs:m_Opcode.rt;
 			if (IsConst(KnownReg)) {
 				DWORD Value = GetMipsRegLo(KnownReg);
-				Map_GPR_32bit(m_Opcode.rd,TRUE,-1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				CompConstToVariable(Value,&_GPR[UnknownReg].W[0],CRegName::GPR_Lo[UnknownReg]);
 			} else {
 				CompX86regToVariable(GetMipsRegMapLo(KnownReg),&_GPR[UnknownReg].W[0],CRegName::GPR_Lo[UnknownReg]);
@@ -3487,7 +3563,7 @@ void CRecompilerOps::SPECIAL_SLTU() {
 					CompX86regToVariable(GetMipsRegMapHi(KnownReg),&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
 				} else {
 					ProtectGPR(KnownReg);
-					CompX86regToVariable(Map_TempReg(x86_Any,KnownReg,TRUE),&_GPR[UnknownReg].W[1],CRegName::GPR_Hi[UnknownReg]);
+					CompX86regToVariable(Map_TempReg(x86_Any, KnownReg, true), &_GPR[UnknownReg].W[1], CRegName::GPR_Hi[UnknownReg]);
 				}			
 			}
 			JeLabel8("Low Compare",0);
@@ -3521,7 +3597,7 @@ void CRecompilerOps::SPECIAL_SLTU() {
 				SetJump8(Jump[1],m_RecompPos);
 			}
 		}
-		Map_GPR_32bit(m_Opcode.rd,TRUE,-1);
+		Map_GPR_32bit(m_Opcode.rd, true, -1);
 		MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
 	} else if (g_System->b32BitCore()) {
 		x86Reg Reg = Map_TempReg(x86_Any,m_Opcode.rs,false);
@@ -3532,7 +3608,7 @@ void CRecompilerOps::SPECIAL_SLTU() {
 	} else {
 		BYTE *Jump[2] = { NULL, NULL };
 
-		x86Reg Reg = Map_TempReg(x86_Any,m_Opcode.rs,TRUE);
+		x86Reg Reg = Map_TempReg(x86_Any, m_Opcode.rs, true);
 		CompX86regToVariable(Reg,&_GPR[m_Opcode.rt].W[1],CRegName::GPR_Hi[m_Opcode.rt]);
 		JeLabel8("Low Compare",0);
 		Jump[0] = m_RecompPos - 1;
@@ -3543,7 +3619,7 @@ void CRecompilerOps::SPECIAL_SLTU() {
 		CPU_Message("");
 		CPU_Message("      Low Compare:");
 		SetJump8(Jump[0],m_RecompPos);
-		CompX86regToVariable(Map_TempReg(Reg,m_Opcode.rs,FALSE),&_GPR[m_Opcode.rt].W[0],CRegName::GPR_Lo[m_Opcode.rt]);
+		CompX86regToVariable(Map_TempReg(Reg, m_Opcode.rs, false), &_GPR[m_Opcode.rt].W[0], CRegName::GPR_Lo[m_Opcode.rt]);
 		SetbVariable(&m_BranchCompare,"m_BranchCompare");
 		if (Jump[1])
 		{
@@ -3551,17 +3627,20 @@ void CRecompilerOps::SPECIAL_SLTU() {
 			CPU_Message("      Continue:");
 			SetJump8(Jump[1],m_RecompPos);
 		}
-		Map_GPR_32bit(m_Opcode.rd,TRUE, -1);
+		Map_GPR_32bit(m_Opcode.rd, true, -1);
 		MoveVariableToX86reg(&m_BranchCompare,"m_BranchCompare",GetMipsRegMapLo(m_Opcode.rd));
 	}
 }
 
 void CRecompilerOps::SPECIAL_DADD() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(m_Opcode.rt)  && IsConst(m_Opcode.rs)) {
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsReg(m_Opcode.rd,
 			Is64Bit(m_Opcode.rs)?GetMipsReg(m_Opcode.rs):(__int64)GetMipsRegLo_S(m_Opcode.rs) +
 			Is64Bit(m_Opcode.rt)?GetMipsReg(m_Opcode.rt):(__int64)GetMipsRegLo_S(m_Opcode.rt)
@@ -3583,7 +3662,7 @@ void CRecompilerOps::SPECIAL_DADD() {
 			AddConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegLo(source2));
 			AddConstToX86Reg(GetMipsRegMapHi(m_Opcode.rd),GetMipsRegHi(source2));
 		} else if (IsMapped(source2)) {
-			x86Reg HiReg = Is64Bit(source2)?GetMipsRegMapHi(source2):Map_TempReg(x86_Any,source2,TRUE);
+			x86Reg HiReg = Is64Bit(source2) ? GetMipsRegMapHi(source2) : Map_TempReg(x86_Any, source2, true);
 			AddX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(source2));
 			AdcX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),HiReg);
 		} else {
@@ -3595,12 +3674,15 @@ void CRecompilerOps::SPECIAL_DADD() {
 
 void CRecompilerOps::SPECIAL_DADDU() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(m_Opcode.rt)  && IsConst(m_Opcode.rs)) {
 		__int64 ValRs = Is64Bit(m_Opcode.rs)?GetMipsReg(m_Opcode.rs):(__int64)GetMipsRegLo_S(m_Opcode.rs);
 		__int64 ValRt = Is64Bit(m_Opcode.rt)?GetMipsReg(m_Opcode.rt):(__int64)GetMipsRegLo_S(m_Opcode.rt);
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsReg(m_Opcode.rd, ValRs + ValRt);
 		if ((GetMipsRegHi(m_Opcode.rd) == 0) && (GetMipsRegLo(m_Opcode.rd) & 0x80000000) == 0) {
 			m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
@@ -3619,7 +3701,7 @@ void CRecompilerOps::SPECIAL_DADDU() {
 			AddConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegLo(source2));
 			AddConstToX86Reg(GetMipsRegMapHi(m_Opcode.rd),GetMipsRegHi(source2));
 		} else if (IsMapped(source2)) {
-			x86Reg HiReg = Is64Bit(source2)?GetMipsRegMapHi(source2):Map_TempReg(x86_Any,source2,TRUE);
+			x86Reg HiReg = Is64Bit(source2) ? GetMipsRegMapHi(source2) : Map_TempReg(x86_Any, source2, true);
 			AddX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(source2));
 			AdcX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),HiReg);
 		} else {
@@ -3631,10 +3713,13 @@ void CRecompilerOps::SPECIAL_DADDU() {
 
 void CRecompilerOps::SPECIAL_DSUB() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(m_Opcode.rt)  && IsConst(m_Opcode.rs)) {
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsReg(m_Opcode.rd,
 			Is64Bit(m_Opcode.rs)?GetMipsReg(m_Opcode.rs):(__int64)GetMipsRegLo_S(m_Opcode.rs) -
 			Is64Bit(m_Opcode.rt)?GetMipsReg(m_Opcode.rt):(__int64)GetMipsRegLo_S(m_Opcode.rt)
@@ -3648,8 +3733,8 @@ void CRecompilerOps::SPECIAL_DSUB() {
 		}
 	} else {
 		if (m_Opcode.rd == m_Opcode.rt) {
-			x86Reg HiReg = Map_TempReg(x86_Any,m_Opcode.rt,TRUE);
-			x86Reg LoReg = Map_TempReg(x86_Any,m_Opcode.rt,FALSE);
+			x86Reg HiReg = Map_TempReg(x86_Any, m_Opcode.rt, true);
+			x86Reg LoReg = Map_TempReg(x86_Any, m_Opcode.rt, false);
 			Map_GPR_64bit(m_Opcode.rd,m_Opcode.rs);
 			SubX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),LoReg);
 			SbbX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),HiReg);
@@ -3662,7 +3747,7 @@ void CRecompilerOps::SPECIAL_DSUB() {
 			SubConstFromX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegLo(m_Opcode.rt));
 			SbbConstFromX86Reg(GetMipsRegMapHi(m_Opcode.rd),GetMipsRegHi(m_Opcode.rt));
 		} else if (IsMapped(m_Opcode.rt)) {
-			x86Reg HiReg = Is64Bit(m_Opcode.rt)?GetMipsRegMapHi(m_Opcode.rt):Map_TempReg(x86_Any,m_Opcode.rt,TRUE);
+			x86Reg HiReg = Is64Bit(m_Opcode.rt) ? GetMipsRegMapHi(m_Opcode.rt) : Map_TempReg(x86_Any, m_Opcode.rt, true);
 			SubX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(m_Opcode.rt));
 			SbbX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),HiReg);
 		} else {
@@ -3674,10 +3759,13 @@ void CRecompilerOps::SPECIAL_DSUB() {
 
 void CRecompilerOps::SPECIAL_DSUBU() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(m_Opcode.rt)  && IsConst(m_Opcode.rs)) {
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsReg(m_Opcode.rd, 
 			Is64Bit(m_Opcode.rs)?GetMipsReg(m_Opcode.rs):(__int64)GetMipsRegLo_S(m_Opcode.rs) -
 			Is64Bit(m_Opcode.rt)?GetMipsReg(m_Opcode.rt):(__int64)GetMipsRegLo_S(m_Opcode.rt)
@@ -3691,8 +3779,8 @@ void CRecompilerOps::SPECIAL_DSUBU() {
 		}
 	} else {
 		if (m_Opcode.rd == m_Opcode.rt) {
-			x86Reg HiReg = Map_TempReg(x86_Any,m_Opcode.rt,TRUE);
-			x86Reg LoReg = Map_TempReg(x86_Any,m_Opcode.rt,FALSE);
+			x86Reg HiReg = Map_TempReg(x86_Any, m_Opcode.rt, true);
+			x86Reg LoReg = Map_TempReg(x86_Any, m_Opcode.rt, false);
 			Map_GPR_64bit(m_Opcode.rd,m_Opcode.rs);
 			SubX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),LoReg);
 			SbbX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),HiReg);
@@ -3704,7 +3792,7 @@ void CRecompilerOps::SPECIAL_DSUBU() {
 			SubConstFromX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegLo(m_Opcode.rt));
 			SbbConstFromX86Reg(GetMipsRegMapHi(m_Opcode.rd),GetMipsRegHi(m_Opcode.rt));
 		} else if (IsMapped(m_Opcode.rt)) {
-			x86Reg HiReg = Is64Bit(m_Opcode.rt)?GetMipsRegMapHi(m_Opcode.rt):Map_TempReg(x86_Any,m_Opcode.rt,TRUE);
+			x86Reg HiReg = Is64Bit(m_Opcode.rt) ? GetMipsRegMapHi(m_Opcode.rt) : Map_TempReg(x86_Any, m_Opcode.rt, true);
 			SubX86RegToX86Reg(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapLo(m_Opcode.rt));
 			SbbX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rd),HiReg);
 		} else {
@@ -3717,11 +3805,13 @@ void CRecompilerOps::SPECIAL_DSUBU() {
 void CRecompilerOps::SPECIAL_DSLL() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(m_Opcode.rt)) 
 	{
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
 
 		__int64 Value = Is64Bit(m_Opcode.rt)?GetMipsReg_S(m_Opcode.rt):(__int64)GetMipsRegLo_S(m_Opcode.rt);
 		m_RegWorkingSet.SetMipsReg(m_Opcode.rd, Value << m_Opcode.sa);
@@ -3737,16 +3827,18 @@ void CRecompilerOps::SPECIAL_DSLL() {
 	
 	Map_GPR_64bit(m_Opcode.rd,m_Opcode.rt);
 	ShiftLeftDoubleImmed(GetMipsRegMapHi(m_Opcode.rd),GetMipsRegMapLo(m_Opcode.rd),(BYTE)m_Opcode.sa);
-	ShiftLeftSignImmed(	GetMipsRegMapLo(m_Opcode.rd),(BYTE)m_Opcode.sa);
+	ShiftLeftSignImmed(GetMipsRegMapLo(m_Opcode.rd),(BYTE)m_Opcode.sa);
 }
 
 void CRecompilerOps::SPECIAL_DSRL() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(m_Opcode.rt)) {
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
 
 		__int64 Value = Is64Bit(m_Opcode.rt)?GetMipsReg_S(m_Opcode.rt):(__int64)GetMipsRegLo_S(m_Opcode.rt);
 		m_RegWorkingSet.SetMipsReg(m_Opcode.rd,Value >> m_Opcode.sa);
@@ -3767,10 +3859,12 @@ void CRecompilerOps::SPECIAL_DSRL() {
 void CRecompilerOps::SPECIAL_DSRA() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
 
 	if (IsConst(m_Opcode.rt)) {
-		if (IsMapped(m_Opcode.rd)) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (IsMapped(m_Opcode.rd))
+			UnMap_GPR(m_Opcode.rd, false);
 
 		__int64 Value = Is64Bit(m_Opcode.rt)?GetMipsReg_S(m_Opcode.rt):(__int64)GetMipsRegLo_S(m_Opcode.rt);
 		m_RegWorkingSet.SetMipsReg_S(m_Opcode.rd, Value >> m_Opcode.sa);
@@ -3782,7 +3876,8 @@ void CRecompilerOps::SPECIAL_DSRA() {
 			m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_64);
 		}
 		return;
-	}	
+	}
+
 	Map_GPR_64bit(m_Opcode.rd,m_Opcode.rt);
 	ShiftRightDoubleImmed(GetMipsRegMapLo(m_Opcode.rd),GetMipsRegMapHi(m_Opcode.rd),(BYTE)m_Opcode.sa);
 	ShiftRightSignImmed(GetMipsRegMapHi(m_Opcode.rd),(BYTE)m_Opcode.sa);
@@ -3791,9 +3886,13 @@ void CRecompilerOps::SPECIAL_DSRA() {
 void CRecompilerOps::SPECIAL_DSLL32() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
-	if (m_Opcode.rd == 0) { return; }
+	if (m_Opcode.rd == 0)
+		return;
+
 	if (IsConst(m_Opcode.rt)) {
-		if (m_Opcode.rt != m_Opcode.rd) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (m_Opcode.rt != m_Opcode.rd)
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsRegHi(m_Opcode.rd,GetMipsRegLo(m_Opcode.rt) << m_Opcode.sa);
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd,0);
 		if (GetMipsRegLo_S(m_Opcode.rd) < 0 && GetMipsRegHi_S(m_Opcode.rd) == -1){ 
@@ -3803,7 +3902,6 @@ void CRecompilerOps::SPECIAL_DSLL32() {
 		} else {
 			m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_64);
 		}
-
 	} else if (IsMapped(m_Opcode.rt)) {
 		ProtectGPR(m_Opcode.rt);
 		Map_GPR_64bit(m_Opcode.rd,-1);		
@@ -3833,7 +3931,9 @@ void CRecompilerOps::SPECIAL_DSRL32() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
 	if (IsConst(m_Opcode.rt)) {
-		if (m_Opcode.rt != m_Opcode.rd) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (m_Opcode.rt != m_Opcode.rd)
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_ZERO);
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd, (DWORD)(GetMipsReg(m_Opcode.rt) >> (m_Opcode.sa + 32)));
 	} else if (IsMapped(m_Opcode.rt)) {
@@ -3844,9 +3944,9 @@ void CRecompilerOps::SPECIAL_DSRL32() {
 				x86Reg HiReg = GetMipsRegMapHi(m_Opcode.rt);
 				m_RegWorkingSet.SetMipsRegMapHi(m_Opcode.rt,GetMipsRegMapLo(m_Opcode.rt));
 				m_RegWorkingSet.SetMipsRegMapLo(m_Opcode.rt,HiReg);
-				Map_GPR_32bit(m_Opcode.rd,FALSE,-1);
+				Map_GPR_32bit(m_Opcode.rd, false, -1);
 			} else {
-				Map_GPR_32bit(m_Opcode.rd,FALSE,-1);
+				Map_GPR_32bit(m_Opcode.rd, false, -1);
 				MoveX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rt),GetMipsRegMapLo(m_Opcode.rd));
 			}
 			if ((BYTE)m_Opcode.sa != 0) {
@@ -3856,7 +3956,7 @@ void CRecompilerOps::SPECIAL_DSRL32() {
 			CRecompilerOps::UnknownOpcode();
 		}
 	} else {
-		Map_GPR_32bit(m_Opcode.rd,FALSE,-1);
+		Map_GPR_32bit(m_Opcode.rd, false, -1);
 		MoveVariableToX86reg(&_GPR[m_Opcode.rt].UW[1],CRegName::GPR_Hi[m_Opcode.rt],GetMipsRegMapLo(m_Opcode.rd));
 		if ((BYTE)m_Opcode.sa != 0) {
 			ShiftRightUnsignImmed(GetMipsRegMapLo(m_Opcode.rd),(BYTE)m_Opcode.sa);
@@ -3868,7 +3968,9 @@ void CRecompilerOps::SPECIAL_DSRA32() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
 	if (IsConst(m_Opcode.rt)) {
-		if (m_Opcode.rt != m_Opcode.rd) { UnMap_GPR(m_Opcode.rd, FALSE); }
+		if (m_Opcode.rt != m_Opcode.rd)
+			UnMap_GPR(m_Opcode.rd, false);
+
 		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_SIGN);
 		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd,(DWORD)(GetMipsReg_S(m_Opcode.rt) >> (m_Opcode.sa + 32)));
 	} else if (IsMapped(m_Opcode.rt)) {
@@ -3879,9 +3981,9 @@ void CRecompilerOps::SPECIAL_DSRA32() {
 				x86Reg HiReg = GetMipsRegMapHi(m_Opcode.rt);
 				m_RegWorkingSet.SetMipsRegMapHi(m_Opcode.rt,GetMipsRegMapLo(m_Opcode.rt));
 				m_RegWorkingSet.SetMipsRegMapLo(m_Opcode.rt,HiReg);
-				Map_GPR_32bit(m_Opcode.rd,TRUE,-1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 			} else {
-				Map_GPR_32bit(m_Opcode.rd,TRUE,-1);
+				Map_GPR_32bit(m_Opcode.rd, true, -1);
 				MoveX86RegToX86Reg(GetMipsRegMapHi(m_Opcode.rt),GetMipsRegMapLo(m_Opcode.rd));
 			}
 			if ((BYTE)m_Opcode.sa != 0) {
@@ -3891,7 +3993,7 @@ void CRecompilerOps::SPECIAL_DSRA32() {
 			CRecompilerOps::UnknownOpcode();
 		}
 	} else {
-		Map_GPR_32bit(m_Opcode.rd,TRUE,-1);
+		Map_GPR_32bit(m_Opcode.rd, true, -1);
 		MoveVariableToX86reg(&_GPR[m_Opcode.rt].UW[1],CRegName::GPR_Lo[m_Opcode.rt],GetMipsRegMapLo(m_Opcode.rd));
 		if ((BYTE)m_Opcode.sa != 0) {
 			ShiftRightSignImmed(GetMipsRegMapLo(m_Opcode.rd),(BYTE)m_Opcode.sa);
@@ -3900,20 +4002,20 @@ void CRecompilerOps::SPECIAL_DSRA32() {
 }
 
 /************************** COP0 functions **************************/
-void CRecompilerOps::COP0_MF(void) {
+void CRecompilerOps::COP0_MF() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
 	switch (m_Opcode.rd) {
 	case 9: //Count
-		m_RegWorkingSet.SetBlockCycleCount(m_RegWorkingSet.GetBlockCycleCount() - g_System->CountPerOp()) ;
+		m_RegWorkingSet.SetBlockCycleCount(m_RegWorkingSet.GetBlockCycleCount() - g_System->CountPerOp());
 		UpdateCounters(m_RegWorkingSet,false, true);
-		m_RegWorkingSet.SetBlockCycleCount(m_RegWorkingSet.GetBlockCycleCount() + g_System->CountPerOp()) ;
+		m_RegWorkingSet.SetBlockCycleCount(m_RegWorkingSet.GetBlockCycleCount() + g_System->CountPerOp());
 		BeforeCallDirect(m_RegWorkingSet);
-		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);		
+		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);
 		Call_Direct(AddressOf(&CSystemTimer::UpdateTimers), "CSystemTimer::UpdateTimers");
 		AfterCallDirect(m_RegWorkingSet);
 	}
-	Map_GPR_32bit(m_Opcode.rt,TRUE,-1);
+	Map_GPR_32bit(m_Opcode.rt, true, -1);
 	MoveVariableToX86reg(&_CP0[m_Opcode.rd],CRegName::Cop0[m_Opcode.rd],GetMipsRegMapLo(m_Opcode.rt));
 }
 
@@ -3941,7 +4043,7 @@ void CRecompilerOps::COP0_MT() {
 		} else if (IsMapped(m_Opcode.rt)) {
 			MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rt), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 		} else {
-			MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rt,FALSE), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
+			MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rt, false), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 		}
 		if (m_Opcode.rd == 4) //Context
 		{
@@ -3953,7 +4055,7 @@ void CRecompilerOps::COP0_MT() {
 		UpdateCounters(m_RegWorkingSet,false, true);
 		m_RegWorkingSet.SetBlockCycleCount(m_RegWorkingSet.GetBlockCycleCount() + g_System->CountPerOp()) ;
 		BeforeCallDirect(m_RegWorkingSet);
-		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);		
+		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);
 		Call_Direct(AddressOf(&CSystemTimer::UpdateTimers), "CSystemTimer::UpdateTimers");
 		AfterCallDirect(m_RegWorkingSet);
 		if (IsConst(m_Opcode.rt)) {
@@ -3961,11 +4063,11 @@ void CRecompilerOps::COP0_MT() {
 		} else if (IsMapped(m_Opcode.rt)) {
 			MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rt), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 		} else {
-			MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rt,FALSE), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
+			MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rt, false), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 		}
 		AndConstToVariable((DWORD)~CAUSE_IP7,&g_Reg->FAKE_CAUSE_REGISTER,"FAKE_CAUSE_REGISTER");
 		BeforeCallDirect(m_RegWorkingSet);
-		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);		
+		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);
 		Call_Direct(AddressOf(&CSystemTimer::UpdateCompareTimer), "CSystemTimer::UpdateCompareTimer");
 		AfterCallDirect(m_RegWorkingSet);
 		break;
@@ -3974,7 +4076,7 @@ void CRecompilerOps::COP0_MT() {
 		UpdateCounters(m_RegWorkingSet,false, true);
 		m_RegWorkingSet.SetBlockCycleCount(m_RegWorkingSet.GetBlockCycleCount() + g_System->CountPerOp()) ;
 		BeforeCallDirect(m_RegWorkingSet);
-		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);		
+		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);
 		Call_Direct(AddressOf(&CSystemTimer::UpdateTimers), "CSystemTimer::UpdateTimers");
 		AfterCallDirect(m_RegWorkingSet);
 		if (IsConst(m_Opcode.rt)) {
@@ -3982,23 +4084,23 @@ void CRecompilerOps::COP0_MT() {
 		} else if (IsMapped(m_Opcode.rt)) {
 			MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rt), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 		} else {
-			MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rt,FALSE), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
+			MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rt, false), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 		}
 		BeforeCallDirect(m_RegWorkingSet);
-		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);		
+		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);
 		Call_Direct(AddressOf(&CSystemTimer::UpdateCompareTimer), "CSystemTimer::UpdateCompareTimer");
 		AfterCallDirect(m_RegWorkingSet);
 		break;
 	case 12: //Status
 		{
-			x86Reg OldStatusReg = Map_TempReg(x86_Any,-1,FALSE);
+			x86Reg OldStatusReg = Map_TempReg(x86_Any, -1, false);
 			MoveVariableToX86reg(&_CP0[m_Opcode.rd],CRegName::Cop0[m_Opcode.rd],OldStatusReg);
 			if (IsConst(m_Opcode.rt)) {
 				MoveConstToVariable(GetMipsRegLo(m_Opcode.rt), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 			} else if (IsMapped(m_Opcode.rt)) {
 				MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rt), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 			} else {
-				MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rt,FALSE), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
+				MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rt, false), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 			}
 			XorVariableToX86reg(&_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd],OldStatusReg);
 			TestConstToX86Reg(STATUS_FR,OldStatusReg);
@@ -4006,13 +4108,13 @@ void CRecompilerOps::COP0_MT() {
 			Jump = m_RecompPos - 1;
 			BeforeCallDirect(m_RegWorkingSet);
 			MoveConstToX86reg((DWORD)g_Reg,x86_ECX); 
-            Call_Direct(AddressOf(&CRegisters::FixFpuLocations),"CRegisters::FixFpuLocations");
+			Call_Direct(AddressOf(&CRegisters::FixFpuLocations),"CRegisters::FixFpuLocations");
 
 			AfterCallDirect(m_RegWorkingSet);
-			SetJump8(Jump,m_RecompPos);		
-			
+			SetJump8(Jump,m_RecompPos);
+
 			//TestConstToX86Reg(STATUS_FR,OldStatusReg);
-			//BreakPoint(__FILEW__,__LINE__); //m_Section->CompileExit(m_CompilePC+4,m_RegWorkingSet,ExitResetRecompCode,FALSE,JneLabel32);
+			//BreakPoint(__FILEW__,__LINE__); //m_Section->CompileExit(m_CompilePC+4,m_RegWorkingSet,ExitResetRecompCode,false,JneLabel32);
 			BeforeCallDirect(m_RegWorkingSet);
 			MoveConstToX86reg((DWORD)g_Reg,x86_ECX);
 			Call_Direct(AddressOf(&CRegisters::CheckInterrupts),"CRegisters::CheckInterrupts");
@@ -4020,12 +4122,12 @@ void CRecompilerOps::COP0_MT() {
 		}
 		break;
 	case 6: //Wired
-		m_RegWorkingSet.SetBlockCycleCount(m_RegWorkingSet.GetBlockCycleCount() - g_System->CountPerOp()) ;
+		m_RegWorkingSet.SetBlockCycleCount(m_RegWorkingSet.GetBlockCycleCount() - g_System->CountPerOp());
 		UpdateCounters(m_RegWorkingSet,false, true);
-		m_RegWorkingSet.SetBlockCycleCount(m_RegWorkingSet.GetBlockCycleCount() + g_System->CountPerOp()) ;
+		m_RegWorkingSet.SetBlockCycleCount(m_RegWorkingSet.GetBlockCycleCount() + g_System->CountPerOp());
 
 		BeforeCallDirect(m_RegWorkingSet);
-		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);		
+		MoveConstToX86reg((DWORD)g_SystemTimer,x86_ECX);
 		Call_Direct(AddressOf(&CSystemTimer::UpdateTimers), "CSystemTimer::UpdateTimers");
 		AfterCallDirect(m_RegWorkingSet);
 		if (IsConst(m_Opcode.rt)) {
@@ -4033,7 +4135,7 @@ void CRecompilerOps::COP0_MT() {
 		} else if (IsMapped(m_Opcode.rt)) {
 			MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rt), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 		} else {
-			MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rt,FALSE), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
+			MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rt, false), &_CP0[m_Opcode.rd], CRegName::Cop0[m_Opcode.rd]);
 		}
 		break;
 	case 13: //cause
@@ -4068,7 +4170,7 @@ void CRecompilerOps::COP0_CO_TLBWI( void) {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	if (!g_System->bUseTlb()) {	return; }
 	BeforeCallDirect(m_RegWorkingSet);
-	PushImm32("FALSE",FALSE);
+	PushImm32("FALSE", 0);
 	MoveVariableToX86reg(&g_Reg->INDEX_REGISTER,"INDEX_REGISTER",x86_ECX);
 	AndConstToX86Reg(x86_ECX,0x1F);
 	Push(x86_ECX);
@@ -4126,7 +4228,7 @@ void CRecompilerOps::COP0_CO_ERET( void) {
 	Call_Direct(compiler_COP0_CO_ERET,"compiler_COP0_CO_ERET");
 
 	UpdateCounters(m_RegWorkingSet,true,true);
-	m_Section->CompileExit(m_CompilePC, (DWORD)-1,m_RegWorkingSet,CExitInfo::Normal,TRUE,NULL);
+	m_Section->CompileExit(m_CompilePC, (DWORD)-1, m_RegWorkingSet, CExitInfo::Normal, true, NULL);
 	m_NextInstruction = END_BLOCK;
 }
 
@@ -4147,13 +4249,13 @@ void CRecompilerOps::COP1_MF() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	m_Section->CompileCop1Test();
 
-	UnMap_FPR(m_Opcode.fs,TRUE);
-	Map_GPR_32bit(m_Opcode.rt, TRUE, -1);
-	TempReg = Map_TempReg(x86_Any,-1,FALSE);
+	UnMap_FPR(m_Opcode.fs, true);
+	Map_GPR_32bit(m_Opcode.rt, true, -1);
+	TempReg = Map_TempReg(x86_Any, -1, false);
 	char Name[100];
 	sprintf(Name,"_FPR_S[%d]",m_Opcode.fs);
 	MoveVariableToX86reg((BYTE *)&_FPR_S[m_Opcode.fs],Name,TempReg);
-	MoveX86PointerToX86reg(GetMipsRegMapLo(m_Opcode.rt),TempReg);		
+	MoveX86PointerToX86reg(GetMipsRegMapLo(m_Opcode.rt),TempReg);
 }
 
 void CRecompilerOps::COP1_DMF() {
@@ -4163,29 +4265,34 @@ void CRecompilerOps::COP1_DMF() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	m_Section->CompileCop1Test();
 
-	UnMap_FPR(m_Opcode.fs,TRUE);
+	UnMap_FPR(m_Opcode.fs, true);
 	Map_GPR_64bit(m_Opcode.rt, -1);
-	TempReg = Map_TempReg(x86_Any,-1,FALSE);
+	TempReg = Map_TempReg(x86_Any, -1, false);
 	sprintf(Name,"_FPR_D[%d]",m_Opcode.fs);
 	MoveVariableToX86reg((BYTE *)&_FPR_D[m_Opcode.fs],Name,TempReg);
 	AddConstToX86Reg(TempReg,4);
-	MoveX86PointerToX86reg(GetMipsRegMapHi(m_Opcode.rt),TempReg);		
+	MoveX86PointerToX86reg(GetMipsRegMapHi(m_Opcode.rt),TempReg);
 	sprintf(Name,"_FPR_D[%d]",m_Opcode.fs);
 	MoveVariableToX86reg((BYTE *)&_FPR_D[m_Opcode.fs],Name,TempReg);
-	MoveX86PointerToX86reg(GetMipsRegMapLo(m_Opcode.rt),TempReg);		
+	MoveX86PointerToX86reg(GetMipsRegMapLo(m_Opcode.rt),TempReg);
 }
 
-void CRecompilerOps::COP1_CF(void) {
+void CRecompilerOps::COP1_CF() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 
 	m_Section->CompileCop1Test();
 	
-	if (m_Opcode.fs != 31 && m_Opcode.fs != 0) { UnknownOpcode(); return; }
-	Map_GPR_32bit(m_Opcode.rt,TRUE,-1);
+	if (m_Opcode.fs != 31 && m_Opcode.fs != 0)
+	{
+		UnknownOpcode();
+		return;
+	}
+
+	Map_GPR_32bit(m_Opcode.rt, true, -1);
 	MoveVariableToX86reg(&_FPCR[m_Opcode.fs],CRegName::FPR_Ctrl[m_Opcode.fs],GetMipsRegMapLo(m_Opcode.rt));
 }
 
-void CRecompilerOps::COP1_MT( void) {	
+void CRecompilerOps::COP1_MT() {
 	x86Reg TempReg;
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
@@ -4193,11 +4300,11 @@ void CRecompilerOps::COP1_MT( void) {
 	
 	if ((m_Opcode.fs & 1) != 0) {
 		if (RegInStack(m_Opcode.fs-1,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fs-1,CRegInfo::FPU_Qword)) {
-			UnMap_FPR(m_Opcode.fs-1,TRUE);
+			UnMap_FPR(m_Opcode.fs - 1, true);
 		}
 	}
-	UnMap_FPR(m_Opcode.fs,TRUE);
-	TempReg = Map_TempReg(x86_Any,-1,FALSE);
+	UnMap_FPR(m_Opcode.fs, true);
+	TempReg = Map_TempReg(x86_Any, -1, false);
 	char Name[50];
 	sprintf(Name,"_FPR_S[%d]",m_Opcode.fs);
 	MoveVariableToX86reg((BYTE *)&_FPR_S[m_Opcode.fs],Name,TempReg);
@@ -4207,11 +4314,11 @@ void CRecompilerOps::COP1_MT( void) {
 	} else if (IsMapped(m_Opcode.rt)) {
 		MoveX86regToX86Pointer(GetMipsRegMapLo(m_Opcode.rt),TempReg);
 	} else {
-		MoveX86regToX86Pointer(Map_TempReg(x86_Any, m_Opcode.rt, FALSE),TempReg);
+		MoveX86regToX86Pointer(Map_TempReg(x86_Any, m_Opcode.rt, false), TempReg);
 	}
 }
 
-void CRecompilerOps::COP1_DMT( void) {
+void CRecompilerOps::COP1_DMT() {
 	x86Reg TempReg;
 
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
@@ -4219,11 +4326,11 @@ void CRecompilerOps::COP1_DMT( void) {
 	
 	if ((m_Opcode.fs & 1) == 0) {
 		if (RegInStack(m_Opcode.fs+1,CRegInfo::FPU_Float) || RegInStack(m_Opcode.fs+1,CRegInfo::FPU_Dword)) {
-			UnMap_FPR(m_Opcode.fs+1,TRUE);
+			UnMap_FPR(m_Opcode.fs+1, true);
 		}
 	}
-	UnMap_FPR(m_Opcode.fs,TRUE);
-	TempReg = Map_TempReg(x86_Any,-1,FALSE);
+	UnMap_FPR(m_Opcode.fs, true);
+	TempReg = Map_TempReg(x86_Any, -1, false);
 	char Name[50];
 	sprintf(Name,"_FPR_D[%d]",m_Opcode.fs);
 	MoveVariableToX86reg((BYTE *)&_FPR_D[m_Opcode.fs],Name,TempReg);
@@ -4242,28 +4349,32 @@ void CRecompilerOps::COP1_DMT( void) {
 		if (Is64Bit(m_Opcode.rt)) {
 			MoveX86regToX86Pointer(GetMipsRegMapHi(m_Opcode.rt),TempReg);
 		} else {
-			MoveX86regToX86Pointer(Map_TempReg(x86_Any, m_Opcode.rt, TRUE),TempReg);
+			MoveX86regToX86Pointer(Map_TempReg(x86_Any, m_Opcode.rt, true), TempReg);
 		}
 	} else {
-		x86Reg Reg= Map_TempReg(x86_Any, m_Opcode.rt, FALSE);
+		x86Reg Reg = Map_TempReg(x86_Any, m_Opcode.rt, false);
 		MoveX86regToX86Pointer(Reg,TempReg);
 		AddConstToX86Reg(TempReg,4);
-		MoveX86regToX86Pointer(Map_TempReg(Reg, m_Opcode.rt, TRUE),TempReg);
+		MoveX86regToX86Pointer(Map_TempReg(Reg, m_Opcode.rt, true), TempReg);
 	}
 }
 
 
-void CRecompilerOps::COP1_CT(void) {
+void CRecompilerOps::COP1_CT() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	m_Section->CompileCop1Test();
-	if (m_Opcode.fs != 31) { UnknownOpcode(); return; }
+
+	if (m_Opcode.fs != 31) {
+		UnknownOpcode();
+		return;
+	}
 
 	if (IsConst(m_Opcode.rt)) {
 		MoveConstToVariable(GetMipsRegLo(m_Opcode.rt),&_FPCR[m_Opcode.fs],CRegName::FPR_Ctrl[m_Opcode.fs]);
 	} else if (IsMapped(m_Opcode.rt)) {
 		MoveX86regToVariable(GetMipsRegMapLo(m_Opcode.rt),&_FPCR[m_Opcode.fs],CRegName::FPR_Ctrl[m_Opcode.fs]);
 	} else {
-		MoveX86regToVariable(Map_TempReg(x86_Any,m_Opcode.rt,FALSE),&_FPCR[m_Opcode.fs],CRegName::FPR_Ctrl[m_Opcode.fs]);		
+		MoveX86regToVariable(Map_TempReg(x86_Any, m_Opcode.rt, false), &_FPCR[m_Opcode.fs], CRegName::FPR_Ctrl[m_Opcode.fs]);
 	}
 	BeforeCallDirect(m_RegWorkingSet);
 	Call_Direct(ChangeDefaultRoundingModel, "ChangeDefaultRoundingModel");
@@ -4278,7 +4389,7 @@ void CRecompilerOps::COP1_S_ADD() {
 	
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	FixRoundModel(CRegInfo::RoundDefault);
 
 	Load_FPR_ToTop(m_Opcode.fd,Reg1, CRegInfo::FPU_Float);
@@ -4287,33 +4398,33 @@ void CRecompilerOps::COP1_S_ADD() {
 	} else {
 		x86Reg TempReg;
 
-		UnMap_FPR(Reg2,TRUE);
-		TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		UnMap_FPR(Reg2, true);
+		TempReg = Map_TempReg(x86_Any, -1, false);
 		char Name[50];
 		sprintf(Name,"_FPR_S[%d]",Reg2);
 		MoveVariableToX86reg((BYTE *)&_FPR_S[Reg2],Name,TempReg);
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fd, CRegInfo::FPU_Float);
 		fpuAddDwordRegPointer(TempReg);
 	}
-	UnMap_FPR(m_Opcode.fd,TRUE);
+	UnMap_FPR(m_Opcode.fd, true);
 }
 
 void CRecompilerOps::COP1_S_SUB() {
 	DWORD Reg1 = m_Opcode.ft == m_Opcode.fd?m_Opcode.ft:m_Opcode.fs;
 	DWORD Reg2 = m_Opcode.ft == m_Opcode.fd?m_Opcode.fs:m_Opcode.ft;
 	x86Reg TempReg;
-	char Name[50];		
+	char Name[50];
 	
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	FixRoundModel(CRegInfo::RoundDefault);
 
 	if (m_Opcode.fd == m_Opcode.ft) {
-		UnMap_FPR(m_Opcode.fd,TRUE);
+		UnMap_FPR(m_Opcode.fd, true);
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Float);
 
-		TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_S[%d]",m_Opcode.ft);
 		MoveVariableToX86reg((BYTE *)&_FPR_S[m_Opcode.ft],Name,TempReg);
 		fpuSubDwordRegPointer(TempReg);
@@ -4322,16 +4433,16 @@ void CRecompilerOps::COP1_S_SUB() {
 		if (RegInStack(Reg2, CRegInfo::FPU_Float)) {
 			fpuSubReg(StackPosition(Reg2));
 		} else {
-			UnMap_FPR(Reg2,TRUE);
+			UnMap_FPR(Reg2, true);
 			Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fd, CRegInfo::FPU_Float);
 
-			TempReg = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg = Map_TempReg(x86_Any, -1, false);
 			sprintf(Name,"_FPR_S[%d]",Reg2);
 			MoveVariableToX86reg((BYTE *)&_FPR_S[Reg2],Name,TempReg);
-			fpuSubDwordRegPointer(TempReg);			
+			fpuSubDwordRegPointer(TempReg);
 		}
 	}
-	UnMap_FPR(m_Opcode.fd,TRUE);
+	UnMap_FPR(m_Opcode.fd, true);
 }
 
 void CRecompilerOps::COP1_S_MUL() {
@@ -4348,16 +4459,16 @@ void CRecompilerOps::COP1_S_MUL() {
 	if (RegInStack(Reg2, CRegInfo::FPU_Float)) {
 		fpuMulReg(StackPosition(Reg2));
 	} else {
-		UnMap_FPR(Reg2,TRUE);
+		UnMap_FPR(Reg2, true);
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fd, CRegInfo::FPU_Float);
 
-		TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg = Map_TempReg(x86_Any, -1, false);
 		char Name[50];
 		sprintf(Name,"_FPR_S[%d]",Reg2);
 		MoveVariableToX86reg((BYTE *)&_FPR_S[Reg2],Name,TempReg);
-		fpuMulDwordRegPointer(TempReg);			
+		fpuMulDwordRegPointer(TempReg);
 	}
-	UnMap_FPR(m_Opcode.fd,TRUE);
+	UnMap_FPR(m_Opcode.fd, true);
 }
 
 void CRecompilerOps::COP1_S_DIV() {
@@ -4372,10 +4483,10 @@ void CRecompilerOps::COP1_S_DIV() {
 	FixRoundModel(CRegInfo::RoundDefault);
 
 	if (m_Opcode.fd == m_Opcode.ft) {
-		UnMap_FPR(m_Opcode.fd,TRUE);
+		UnMap_FPR(m_Opcode.fd, true);
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Float);
 
-		TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_S[%d]",m_Opcode.ft);
 		MoveVariableToX86reg((BYTE *)&_FPR_S[m_Opcode.ft],Name,TempReg);
 		fpuDivDwordRegPointer(TempReg);
@@ -4384,49 +4495,49 @@ void CRecompilerOps::COP1_S_DIV() {
 		if (RegInStack(Reg2, CRegInfo::FPU_Float)) {
 			fpuDivReg(StackPosition(Reg2));
 		} else {
-			UnMap_FPR(Reg2,TRUE);
+			UnMap_FPR(Reg2, true);
 			Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fd, CRegInfo::FPU_Float);
 
-			TempReg = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg = Map_TempReg(x86_Any, -1, false);
 			sprintf(Name,"_FPR_S[%d]",Reg2);
 			MoveVariableToX86reg((BYTE *)&_FPR_S[Reg2],Name,TempReg);
-			fpuDivDwordRegPointer(TempReg);			
+			fpuDivDwordRegPointer(TempReg);
 		}
 	}
 
-	UnMap_FPR(m_Opcode.fd,TRUE);
+	UnMap_FPR(m_Opcode.fd, true);
 }
 
 void CRecompilerOps::COP1_S_ABS() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	FixRoundModel(CRegInfo::RoundDefault);
 	Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Float);
 	fpuAbs();
-	UnMap_FPR(m_Opcode.fd,TRUE);
+	UnMap_FPR(m_Opcode.fd, true);
 }
 
 void CRecompilerOps::COP1_S_NEG() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	FixRoundModel(CRegInfo::RoundDefault);
 	Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Float);
 	fpuNeg();
-	UnMap_FPR(m_Opcode.fd,TRUE);
+	UnMap_FPR(m_Opcode.fd, true);
 }
 
 void CRecompilerOps::COP1_S_SQRT() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	FixRoundModel(CRegInfo::RoundDefault);
 	Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Float);
 	fpuSqrt();
-	UnMap_FPR(m_Opcode.fd,TRUE);
+	UnMap_FPR(m_Opcode.fd, true);
 }
 
 void CRecompilerOps::COP1_S_MOV() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	FixRoundModel(CRegInfo::RoundDefault);
 	Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Float);
 }
@@ -4434,7 +4545,7 @@ void CRecompilerOps::COP1_S_MOV() {
 void CRecompilerOps::COP1_S_TRUNC_L() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Float)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Float); 
 	}
@@ -4546,37 +4657,37 @@ void CRecompilerOps::COP1_S_CMP() {
 	
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if ((m_Opcode.funct & 7) == 0) { CRecompilerOps::UnknownOpcode(); }
 	if ((m_Opcode.funct & 2) != 0) { cmp |= 0x4000; }
 	if ((m_Opcode.funct & 4) != 0) { cmp |= 0x0100; }
 	
 	Load_FPR_ToTop(Reg1,Reg1, CRegInfo::FPU_Float);
-	Map_TempReg(x86_EAX, 0, FALSE);
+	Map_TempReg(x86_EAX, 0, false);
 	if (RegInStack(Reg2, CRegInfo::FPU_Float)) {
-		fpuComReg(StackPosition(Reg2),FALSE);
+		fpuComReg(StackPosition(Reg2), false);
 	} else {
-		UnMap_FPR(Reg2,TRUE);
+		UnMap_FPR(Reg2, true);
 		Load_FPR_ToTop(Reg1,Reg1, CRegInfo::FPU_Float);
 
-		x86Reg TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		x86Reg TempReg = Map_TempReg(x86_Any, -1, false);
 		char Name[50];
 		sprintf(Name,"_FPR_S[%d]",Reg2);
 		MoveVariableToX86reg((BYTE *)&_FPR_S[Reg2],Name,TempReg);
-		fpuComDwordRegPointer(TempReg,FALSE);
+		fpuComDwordRegPointer(TempReg, false);
 	}
 	AndConstToVariable((DWORD)~FPCSR_C, &_FPCR[31], "_FPCR[31]");
 	fpuStoreStatus();
-	x86Reg Reg = Map_TempReg(x86_Any8Bit, 0, FALSE);
-	TestConstToX86Reg(cmp,x86_EAX);	
+	x86Reg Reg = Map_TempReg(x86_Any8Bit, 0, false);
+	TestConstToX86Reg(cmp,x86_EAX);
 	Setnz(Reg);
 	
 	if (cmp != 0) {
-		TestConstToX86Reg(cmp,x86_EAX);	
+		TestConstToX86Reg(cmp,x86_EAX);
 		Setnz(Reg);
 		
 		if ((m_Opcode.funct & 1) != 0) {
-			x86Reg Reg2 = Map_TempReg(x86_Any8Bit, 0, FALSE);
+			x86Reg Reg2 = Map_TempReg(x86_Any8Bit, 0, false);
 			AndConstToX86Reg(x86_EAX, 0x4300);
 			CompConstToX86reg(x86_EAX, 0x4300);
 			Setz(Reg2);
@@ -4600,7 +4711,7 @@ void CRecompilerOps::COP1_D_ADD() {
 	
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 
 	Load_FPR_ToTop(m_Opcode.fd,Reg1, CRegInfo::FPU_Double);
 	if (RegInStack(Reg2, CRegInfo::FPU_Double)) {
@@ -4608,12 +4719,12 @@ void CRecompilerOps::COP1_D_ADD() {
 	} else {
 		x86Reg TempReg;
 
-		UnMap_FPR(Reg2,TRUE);
-		TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		UnMap_FPR(Reg2, true);
+		TempReg = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_D[%d]",Reg2);
 		MoveVariableToX86reg((BYTE *)&_FPR_D[Reg2],Name,TempReg);
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fd, CRegInfo::FPU_Double);
-		fpuAddQwordRegPointer(TempReg);	
+		fpuAddQwordRegPointer(TempReg);
 	}
 }
 
@@ -4625,11 +4736,11 @@ void CRecompilerOps::COP1_D_SUB() {
 	
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 
 	if (m_Opcode.fd == m_Opcode.ft) {
-		UnMap_FPR(m_Opcode.fd,TRUE);
-		TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		UnMap_FPR(m_Opcode.fd, true);
+		TempReg = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_D[%d]",m_Opcode.ft);
 		MoveVariableToX86reg((BYTE *)&_FPR_D[m_Opcode.ft],Name,TempReg);
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double);
@@ -4639,9 +4750,9 @@ void CRecompilerOps::COP1_D_SUB() {
 		if (RegInStack(Reg2, CRegInfo::FPU_Double)) {
 			fpuSubReg(StackPosition(Reg2));
 		} else {
-			UnMap_FPR(Reg2,TRUE);
+			UnMap_FPR(Reg2, true);
 
-			TempReg = Map_TempReg(x86_Any,-1,FALSE);
+			TempReg = Map_TempReg(x86_Any, -1, false);
 			sprintf(Name,"_FPR_D[%d]",Reg2);
 			MoveVariableToX86reg((BYTE *)&_FPR_D[Reg2],Name,TempReg);
 			Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fd, CRegInfo::FPU_Double);
@@ -4665,9 +4776,9 @@ void CRecompilerOps::COP1_D_MUL() {
 	if (RegInStack(Reg2, CRegInfo::FPU_Double)) {
 		fpuMulReg(StackPosition(Reg2));
 	} else {
-		UnMap_FPR(Reg2,TRUE);
+		UnMap_FPR(Reg2, true);
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fd, CRegInfo::FPU_Double);
-		TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_D[%d]",Reg2);
 		MoveVariableToX86reg((BYTE *)&_FPR_D[Reg2],Name,TempReg);
 		fpuMulQwordRegPointer(TempReg);
@@ -4682,11 +4793,11 @@ void CRecompilerOps::COP1_D_DIV() {
 	
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 
 	if (m_Opcode.fd == m_Opcode.ft) {
-		UnMap_FPR(m_Opcode.fd,TRUE);
-		TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		UnMap_FPR(m_Opcode.fd, true);
+		TempReg = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_D[%d]",m_Opcode.ft);
 		MoveVariableToX86reg((BYTE *)&_FPR_D[m_Opcode.ft],Name,TempReg);
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double);
@@ -4696,8 +4807,8 @@ void CRecompilerOps::COP1_D_DIV() {
 		if (RegInStack(Reg2, CRegInfo::FPU_Double)) {
 			fpuDivReg(StackPosition(Reg2));
 		} else {
-			UnMap_FPR(Reg2,TRUE);
-			TempReg = Map_TempReg(x86_Any,-1,FALSE);
+			UnMap_FPR(Reg2, true);
+			TempReg = Map_TempReg(x86_Any, -1, false);
 			sprintf(Name,"_FPR_D[%d]",Reg2);
 			MoveVariableToX86reg((BYTE *)&_FPR_D[Reg2],Name,TempReg);
 			Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fd, CRegInfo::FPU_Double);
@@ -4732,9 +4843,9 @@ void CRecompilerOps::COP1_D_MOV() {
 void CRecompilerOps::COP1_D_TRUNC_L() {			//added by Witten
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (RegInStack(m_Opcode.fs,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fs,CRegInfo::FPU_Qword)) {
-		UnMap_FPR(m_Opcode.fs,TRUE);
+		UnMap_FPR(m_Opcode.fs, true);
 	}
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Double)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double); 
@@ -4745,9 +4856,9 @@ void CRecompilerOps::COP1_D_TRUNC_L() {			//added by Witten
 void CRecompilerOps::COP1_D_CEIL_L() {			//added by Witten
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (RegInStack(m_Opcode.fs,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fs,CRegInfo::FPU_Qword)) {
-		UnMap_FPR(m_Opcode.fs,TRUE);
+		UnMap_FPR(m_Opcode.fs, true);
 	}
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Double)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double); 
@@ -4758,9 +4869,9 @@ void CRecompilerOps::COP1_D_CEIL_L() {			//added by Witten
 void CRecompilerOps::COP1_D_FLOOR_L() {			//added by Witten
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (RegInStack(m_Opcode.fs,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fs,CRegInfo::FPU_Qword)) {
-		UnMap_FPR(m_Opcode.fs,TRUE);
+		UnMap_FPR(m_Opcode.fs, true);
 	}
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Double)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double); 
@@ -4771,9 +4882,9 @@ void CRecompilerOps::COP1_D_FLOOR_L() {			//added by Witten
 void CRecompilerOps::COP1_D_ROUND_W() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (RegInStack(m_Opcode.fs,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fs,CRegInfo::FPU_Qword)) {
-		UnMap_FPR(m_Opcode.fs,TRUE);
+		UnMap_FPR(m_Opcode.fs, true);
 	}
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Double)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double); 
@@ -4784,9 +4895,9 @@ void CRecompilerOps::COP1_D_ROUND_W() {
 void CRecompilerOps::COP1_D_TRUNC_W() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (RegInStack(m_Opcode.fd,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fd,CRegInfo::FPU_Qword)) {
-		UnMap_FPR(m_Opcode.fd,TRUE);
+		UnMap_FPR(m_Opcode.fd, true);
 	}
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Double)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double); 
@@ -4797,9 +4908,9 @@ void CRecompilerOps::COP1_D_TRUNC_W() {
 void CRecompilerOps::COP1_D_CEIL_W() {				// added by Witten
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (RegInStack(m_Opcode.fs,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fs,CRegInfo::FPU_Qword)) {
-		UnMap_FPR(m_Opcode.fs,TRUE);
+		UnMap_FPR(m_Opcode.fs, true);
 	}
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Double)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double); 
@@ -4810,9 +4921,9 @@ void CRecompilerOps::COP1_D_CEIL_W() {				// added by Witten
 void CRecompilerOps::COP1_D_FLOOR_W() {			//added by Witten
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (RegInStack(m_Opcode.fs,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fs,CRegInfo::FPU_Qword)) {
-		UnMap_FPR(m_Opcode.fs,TRUE);
+		UnMap_FPR(m_Opcode.fs, true);
 	}
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Double)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double); 
@@ -4823,9 +4934,9 @@ void CRecompilerOps::COP1_D_FLOOR_W() {			//added by Witten
 void CRecompilerOps::COP1_D_CVT_S() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (RegInStack(m_Opcode.fd,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fd,CRegInfo::FPU_Qword)) {
-		UnMap_FPR(m_Opcode.fd,TRUE);
+		UnMap_FPR(m_Opcode.fd, true);
 	}
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Double)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double); 
@@ -4836,9 +4947,9 @@ void CRecompilerOps::COP1_D_CVT_S() {
 void CRecompilerOps::COP1_D_CVT_W() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (RegInStack(m_Opcode.fs,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fs,CRegInfo::FPU_Qword)) {
-		UnMap_FPR(m_Opcode.fs,TRUE);
+		UnMap_FPR(m_Opcode.fs, true);
 	}
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Double)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double); 
@@ -4849,9 +4960,9 @@ void CRecompilerOps::COP1_D_CVT_W() {
 void CRecompilerOps::COP1_D_CVT_L() {
 	CPU_Message("  %X %s",m_CompilePC,R4300iOpcodeName(m_Opcode.Hex,m_CompilePC));
 	
-	m_Section->CompileCop1Test();	
+	m_Section->CompileCop1Test();
 	if (RegInStack(m_Opcode.fs,CRegInfo::FPU_Double) || RegInStack(m_Opcode.fs,CRegInfo::FPU_Qword)) {
-		UnMap_FPR(m_Opcode.fs,TRUE);
+		UnMap_FPR(m_Opcode.fs, true);
 	}
 	if (m_Opcode.fd != m_Opcode.fs || !RegInStack(m_Opcode.fd,CRegInfo::FPU_Double)) { 
 		Load_FPR_ToTop(m_Opcode.fd,m_Opcode.fs,CRegInfo::FPU_Double); 
@@ -4877,30 +4988,30 @@ void CRecompilerOps::COP1_D_CMP() {
 	if ((m_Opcode.funct & 4) != 0) { cmp |= 0x0100; }
 	
 	Load_FPR_ToTop(Reg1,Reg1, CRegInfo::FPU_Double);
-	Map_TempReg(x86_EAX, 0, FALSE);
+	Map_TempReg(x86_EAX, 0, false);
 	if (RegInStack(Reg2, CRegInfo::FPU_Double)) {
-		fpuComReg(StackPosition(Reg2),FALSE);
+		fpuComReg(StackPosition(Reg2), false);
 	} else {
 		char Name[50];
 
-		UnMap_FPR(Reg2,TRUE);
-		x86Reg TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		UnMap_FPR(Reg2, true);
+		x86Reg TempReg = Map_TempReg(x86_Any, -1, false);
 		sprintf(Name,"_FPR_D[%d]",Reg2);
 		MoveVariableToX86reg((BYTE *)&_FPR_D[Reg2],Name,TempReg);
 		Load_FPR_ToTop(Reg1,Reg1, CRegInfo::FPU_Double);
-		fpuComQwordRegPointer(TempReg,FALSE);
+		fpuComQwordRegPointer(TempReg, false);
 	}
 	AndConstToVariable((DWORD)~FPCSR_C, &_FPCR[31], "_FPCR[31]");
 	fpuStoreStatus();
-	x86Reg Reg = Map_TempReg(x86_Any8Bit, 0, FALSE);
-	TestConstToX86Reg(cmp,x86_EAX);	
+	x86Reg Reg = Map_TempReg(x86_Any8Bit, 0, false);
+	TestConstToX86Reg(cmp,x86_EAX);
 	Setnz(Reg);
 	if (cmp != 0) {
-		TestConstToX86Reg(cmp,x86_EAX);	
+		TestConstToX86Reg(cmp,x86_EAX);
 		Setnz(Reg);
 		
 		if ((m_Opcode.funct & 1) != 0) {
-			x86Reg Reg2 = Map_TempReg(x86_Any8Bit, 0, FALSE);
+			x86Reg Reg2 = Map_TempReg(x86_Any8Bit, 0, false);
 			AndConstToX86Reg(x86_EAX, 0x4300);
 			CompConstToX86reg(x86_EAX, 0x4300);
 			Setz(Reg2);
@@ -5083,35 +5194,40 @@ void CRecompilerOps::CompileSystemCheck (DWORD TargetPC, const CRegInfo & RegSet
 	SetJump32(Jump,(DWORD *)m_RecompPos);	
 }
 
-void CRecompilerOps::OverflowDelaySlot (BOOL TestTimer)
+void CRecompilerOps::OverflowDelaySlot(bool TestTimer)
 {
 	m_RegWorkingSet.WriteBackRegisters();
 	UpdateCounters(m_RegWorkingSet,false,true);
 	MoveConstToVariable(CompilePC() + 4,_PROGRAM_COUNTER,"PROGRAM_COUNTER");
-	if (g_SyncSystem) { 
-		MoveConstToX86reg((DWORD)g_BaseSystem,x86_ECX);
-		Call_Direct(AddressOf(&CN64System::SyncSystem), "CN64System::SyncSystem"); 
-	}
-	MoveConstToVariable(JUMP,&R4300iOp::m_NextInstruction,"R4300iOp::m_NextInstruction");
-	if (TestTimer)
+
+	if (g_SyncSystem)
 	{
-		MoveConstToVariable(TestTimer,&R4300iOp::m_TestTimer,"R4300iOp::m_TestTimer");
+		MoveConstToX86reg((DWORD)g_BaseSystem,x86_ECX);
+		Call_Direct(AddressOf(&CN64System::SyncSystem), "CN64System::SyncSystem");
 	}
+
+	MoveConstToVariable(JUMP,&R4300iOp::m_NextInstruction,"R4300iOp::m_NextInstruction");
+
+	if (TestTimer)
+		MoveConstToVariable(TestTimer,&R4300iOp::m_TestTimer,"R4300iOp::m_TestTimer");
+
 	PushImm32("g_System->CountPerOp()",g_System->CountPerOp());
 	Call_Direct(CInterpreterCPU::ExecuteOps, "CInterpreterCPU::ExecuteOps");
 	AddConstToX86Reg(x86_ESP,4);
+
 	if (g_System->bFastSP() && g_Recompiler)
 	{
-		MoveConstToX86reg((DWORD)g_Recompiler,x86_ECX);		
+		MoveConstToX86reg((DWORD)g_Recompiler,x86_ECX);
 		Call_Direct(AddressOf(&CRecompiler::ResetMemoryStackPos), "CRecompiler::ResetMemoryStackPos");
 	}
 
-	if (g_SyncSystem) 
-	{ 
+	if (g_SyncSystem)
+	{
 		UpdateSyncCPU(m_RegWorkingSet,g_System->CountPerOp());
 		MoveConstToX86reg((DWORD)g_BaseSystem,x86_ECX);
-		Call_Direct(AddressOf(&CN64System::SyncSystem), "CN64System::SyncSystem"); 
+		Call_Direct(AddressOf(&CN64System::SyncSystem), "CN64System::SyncSystem");
 	}
+
 	ExitCodeBlock();
 	m_NextInstruction = END_BLOCK;
 }

--- a/Source/Project64/N64 System/Recompiler/Recompiler Ops.h
+++ b/Source/Project64/N64 System/Recompiler/Recompiler Ops.h
@@ -28,8 +28,8 @@ protected:
 	typedef void ( * BranchFunction )();
 	
 	/************************** Branch functions  ************************/
-	static void Compile_Branch         ( BranchFunction CompareFunc, BRANCH_TYPE BranchType, BOOL Link);
-	static void Compile_BranchLikely   ( BranchFunction CompareFunc, BOOL Link);
+	static void Compile_Branch         ( BranchFunction CompareFunc, BRANCH_TYPE BranchType, bool Link);
+	static void Compile_BranchLikely   ( BranchFunction CompareFunc, bool Link);
 	static void BNE_Compare();
 	static void BEQ_Compare();
 	static void BGTZ_Compare();
@@ -209,7 +209,7 @@ protected:
 	static void UpdateCounters(CRegInfo & RegSet, bool CheckTimer, bool ClearValues = false);
 	static void CompileSystemCheck(DWORD TargetPC, const CRegInfo & RegSet);
 	static void ChangeDefaultRoundingModel();
-	static void OverflowDelaySlot(BOOL TestTimer);
+	static void OverflowDelaySlot(bool TestTimer);
 
 
 
@@ -256,7 +256,7 @@ protected:
 	{
 		m_RegWorkingSet.Load_FPR_ToTop(Reg,RegToLoad,Format); 
 	}
-	static BOOL RegInStack ( int Reg, CRegInfo::FPU_STATE Format )
+	static bool RegInStack ( int Reg, CRegInfo::FPU_STATE Format )
 	{
 		return m_RegWorkingSet.RegInStack(Reg,Format); 
 	}
@@ -297,9 +297,9 @@ protected:
 	{
 		return m_RegWorkingSet.Map_MemoryStack(Reg,bMapRegister,LoadValue);
 	}
-	static x86Reg Map_TempReg ( x86Reg Reg, int MipsReg, BOOL LoadHiWord )
+	static x86Reg Map_TempReg ( x86Reg Reg, int MipsReg, bool LoadHiWord )
 	{
-		return m_RegWorkingSet.Map_TempReg(Reg,MipsReg,LoadHiWord); 
+		return m_RegWorkingSet.Map_TempReg(Reg,MipsReg,LoadHiWord);
 	}
 	static void ProtectGPR ( DWORD Reg )
 	{

--- a/Source/Project64/N64 System/Recompiler/Reg Info.cpp
+++ b/Source/Project64/N64 System/Recompiler/Reg Info.cpp
@@ -141,15 +141,15 @@ void CRegInfo::FixRoundModel(FPU_ROUND RoundMethod )
 	}
 	CPU_Message("    FixRoundModel: CurrentRoundingModel: %s  targetRoundModel: %s",RoundingModelName(GetRoundingModel()),RoundingModelName(RoundMethod));
 
-	m_fpuControl = 0;			
+	m_fpuControl = 0;
 	fpuStoreControl(&m_fpuControl, "m_fpuControl");
-	x86Reg reg = Map_TempReg(x86_Any,-1,FALSE);
+	x86Reg reg = Map_TempReg(x86_Any, -1, false);
 	MoveVariableToX86reg(&m_fpuControl, "m_fpuControl", reg);
 	AndConstToX86Reg(reg, 0xF3FF);
-		
+
 	if (RoundMethod == RoundDefault)
-	{ 
-		x86Reg RoundReg = Map_TempReg(x86_Any,-1,FALSE);
+	{
+		x86Reg RoundReg = Map_TempReg(x86_Any, -1, false);
 		MoveVariableToX86reg(&g_Reg->m_RoundingModel,"m_RoundingModel", RoundReg);
 		ShiftLeftSignImmed(RoundReg,2);
 		OrX86RegToX86Reg(reg,RoundReg);
@@ -179,8 +179,8 @@ void CRegInfo::ChangeFPURegFormat (int Reg, FPU_STATE OldFormat, FPU_STATE NewFo
 			continue;
 		}
 		if (x86fpu_State[i] != OldFormat || x86fpu_StateChanged[i])
-		{		
-			UnMap_FPR(Reg,TRUE);
+		{
+			UnMap_FPR(Reg, true);
 			Load_FPR_ToTop(Reg,Reg,OldFormat);
 		} else {
 			CPU_Message("    regcache: Changed format of ST(%d) from %s to %s", (i - StackTopPos() + 8) & 7,Format_Name[OldFormat],Format_Name[NewFormat]);			
@@ -210,14 +210,14 @@ void CRegInfo::Load_FPR_ToTop ( int Reg, int RegToLoad, FPU_STATE Format)
 	if (Reg < 0) { g_Notify->DisplayError(L"Load_FPR_ToTop\nReg < 0 ???"); return; }
 
 	if (Format == FPU_Double || Format == FPU_Qword) {
-		UnMap_FPR(Reg + 1,TRUE);
-		UnMap_FPR(RegToLoad + 1,TRUE);
+		UnMap_FPR(Reg + 1, true);
+		UnMap_FPR(RegToLoad + 1, true);
 	} else {
 		if ((Reg & 1) != 0) {
 			for (i = 0; i < 8; i++) {
 				if (x86fpu_MappedTo[i] == (Reg - 1)) {
 					if (x86fpu_State[i] == FPU_Double || x86fpu_State[i] == FPU_Qword) {
-						UnMap_FPR(Reg,TRUE);
+						UnMap_FPR(Reg, true);
 					}
 					i = 8;
 				}
@@ -227,7 +227,7 @@ void CRegInfo::Load_FPR_ToTop ( int Reg, int RegToLoad, FPU_STATE Format)
 			for (i = 0; i < 8; i++) {
 				if (x86fpu_MappedTo[i] == (RegToLoad - 1)) {
 					if (x86fpu_State[i] == FPU_Double || x86fpu_State[i] == FPU_Qword) {
-						UnMap_FPR(RegToLoad,TRUE);
+						UnMap_FPR(RegToLoad, true);
 					}
 					i = 8;
 				}
@@ -243,7 +243,7 @@ void CRegInfo::Load_FPR_ToTop ( int Reg, int RegToLoad, FPU_STATE Format)
 				continue;
 			}
 			if (x86fpu_State[i] != Format) {
-				UnMap_FPR(Reg,TRUE);
+				UnMap_FPR(Reg, true);
 			}
 			break;
 		}
@@ -263,15 +263,15 @@ void CRegInfo::Load_FPR_ToTop ( int Reg, int RegToLoad, FPU_STATE Format)
 	if (RegInStack(RegToLoad,Format)) {
 		if (Reg != RegToLoad) {
 			if (x86fpu_MappedTo[(StackTopPos() - 1) & 7] != RegToLoad) {
-				UnMap_FPR(x86fpu_MappedTo[(StackTopPos() - 1) & 7],TRUE);
+				UnMap_FPR(x86fpu_MappedTo[(StackTopPos() - 1) & 7], true);
 				CPU_Message("    regcache: allocate ST(0) to %s", CRegName::FPR[Reg]);
-				fpuLoadReg(&StackTopPos(),StackPosition(RegToLoad));		
+				fpuLoadReg(&StackTopPos(),StackPosition(RegToLoad));
 				FpuRoundingModel(StackTopPos())    = RoundDefault;
 				x86fpu_MappedTo[StackTopPos()]     = Reg;
 				x86fpu_State[StackTopPos()]        = Format;
 				x86fpu_StateChanged[StackTopPos()] = false;
 			} else {
-				UnMap_FPR(x86fpu_MappedTo[(StackTopPos() - 1) & 7],TRUE);
+				UnMap_FPR(x86fpu_MappedTo[(StackTopPos() - 1) & 7], true);
 				Load_FPR_ToTop (Reg, RegToLoad, Format);
 			}
 		} else {
@@ -306,15 +306,15 @@ void CRegInfo::Load_FPR_ToTop ( int Reg, int RegToLoad, FPU_STATE Format)
 		char Name[50];
 		x86Reg TempReg;
 
-		UnMap_FPR(x86fpu_MappedTo[(StackTopPos() - 1) & 7],TRUE);
+		UnMap_FPR(x86fpu_MappedTo[(StackTopPos() - 1) & 7], true);
 		for (i = 0; i < 8; i++) {
 			if (x86fpu_MappedTo[i] == RegToLoad) {
-				UnMap_FPR(RegToLoad,TRUE);
+				UnMap_FPR(RegToLoad, true);
 				i = 8;
 			}
 		}
 		CPU_Message("    regcache: allocate ST(0) to %s", CRegName::FPR[Reg]);
-		TempReg = Map_TempReg(x86_Any,-1,FALSE);
+		TempReg = Map_TempReg(x86_Any, -1, false);
 		switch (Format) {
 		case FPU_Dword:
 			sprintf(Name,"m_FPR_S[%d]",RegToLoad);
@@ -339,7 +339,7 @@ void CRegInfo::Load_FPR_ToTop ( int Reg, int RegToLoad, FPU_STATE Format)
 		default:
 			if (bHaveDebugger()) { g_Notify->DisplayError(L"Load_FPR_ToTop\nUnkown format to load %d",Format); }
 		}
-		SetX86Protected(TempReg,FALSE);
+		SetX86Protected(TempReg, false);
 		FpuRoundingModel(StackTopPos()) = RoundDefault;
 		x86fpu_MappedTo[StackTopPos()]      = Reg;
 		x86fpu_State[StackTopPos()]         = Format;
@@ -470,11 +470,11 @@ CX86Ops::x86Reg CRegInfo::UnMap_8BitTempReg()
 	for (count = 0; count < 10; count ++) {
 		if (!Is8BitReg((x86Reg)count)) { continue; }
 		if (GetMipsRegState((x86Reg)count) == Temp_Mapped) {
-			if (GetX86Protected((x86Reg)count) == FALSE) {
+			if (GetX86Protected((x86Reg)count) == false) {
 				CPU_Message("    regcache: unallocate %s from temp storage",x86_Name((x86Reg)count));
 				SetX86Mapped((x86Reg)count, CRegInfo::NotMapped);
 				return (x86Reg)count;
-			}		
+			}
 		}
 	}
 	return x86_Unknown;
@@ -573,7 +573,7 @@ void CRegInfo::Map_GPR_32bit (int MipsReg, bool SignValue, int MipsRegToLoad)
 			CPU_Message("    regcache: unallocate %s from high 32bit of %s",x86_Name(GetMipsRegMapHi(MipsReg)),CRegName::GPR_Hi[MipsReg]);
 			SetX86MapOrder(GetMipsRegMapHi(MipsReg),0);
 			SetX86Mapped(GetMipsRegMapHi(MipsReg),NotMapped);
-			SetX86Protected(GetMipsRegMapHi(MipsReg),FALSE);
+			SetX86Protected(GetMipsRegMapHi(MipsReg), false);
 			SetMipsRegHi(MipsReg,0);
 		}
 		Reg = GetMipsRegMapLo(MipsReg);
@@ -605,7 +605,7 @@ void CRegInfo::Map_GPR_32bit (int MipsReg, bool SignValue, int MipsRegToLoad)
 		XorX86RegToX86Reg(Reg,Reg);
 	}
 	SetX86Mapped(Reg,GPR_Mapped);
-	SetX86Protected(Reg,TRUE);
+	SetX86Protected(Reg, true);
 	SetMipsRegMapLo(MipsReg,Reg);
 	SetMipsRegState(MipsReg,SignValue ? STATE_MAPPED_32_SIGN : STATE_MAPPED_32_ZERO);
 }
@@ -628,25 +628,25 @@ void CRegInfo::Map_GPR_64bit ( int MipsReg, int MipsRegToLoad)
 			if (bHaveDebugger()) { g_Notify->DisplayError(L"Map_GPR_64bit\n\nOut of registers"); }
 			return; 
 		}
-		SetX86Protected(x86Hi,TRUE);
+		SetX86Protected(x86Hi, true);
 
 		x86lo = FreeX86Reg();
 		if (x86lo < 0) {  g_Notify->DisplayError(L"Map_GPR_64bit\n\nOut of registers"); return; }
-		SetX86Protected(x86lo,TRUE);
+		SetX86Protected(x86lo, true);
 		
 		CPU_Message("    regcache: allocate %s to hi word of %s",x86_Name(x86Hi),CRegName::GPR[MipsReg]);
 		CPU_Message("    regcache: allocate %s to low word of %s",x86_Name(x86lo),CRegName::GPR[MipsReg]);
 	} else {
 		x86lo = GetMipsRegMapLo(MipsReg);
 		if (Is32Bit(MipsReg)) {
-			SetX86Protected(x86lo,TRUE);
+			SetX86Protected(x86lo, true);
 			x86Hi = FreeX86Reg();
 			if (x86Hi == x86_Unknown)
 			{
 				g_Notify->BreakPoint(__FILEW__,__LINE__); 
 				return;
 			}
-			SetX86Protected(x86Hi,TRUE);
+			SetX86Protected(x86Hi, true);
 
 			CPU_Message("    regcache: allocate %s to hi word of %s",x86_Name(x86Hi),CRegName::GPR[MipsReg]);
 		} else {
@@ -710,7 +710,7 @@ CPU_Message("Map_GPR_64bit 11");
 	SetMipsRegState(MipsReg,STATE_MAPPED_64);
 }
 
-CX86Ops::x86Reg CRegInfo::Map_TempReg (CX86Ops::x86Reg Reg, int MipsReg, BOOL LoadHiWord)
+CX86Ops::x86Reg CRegInfo::Map_TempReg (CX86Ops::x86Reg Reg, int MipsReg, bool LoadHiWord)
 {
 	int count;
 
@@ -771,7 +771,7 @@ CX86Ops::x86Reg CRegInfo::Map_TempReg (CX86Ops::x86Reg Reg, int MipsReg, BOOL Lo
 			{
 				if (NewReg == x86_Unknown)
 				{
-					UnMap_GPR(count,TRUE);
+					UnMap_GPR(count, true);
 					break;
 				}
 				CPU_Message("    regcache: change allocation of %s from %s to %s",CRegName::GPR[count],x86_Name(Reg),x86_Name(NewReg));
@@ -779,14 +779,15 @@ CX86Ops::x86Reg CRegInfo::Map_TempReg (CX86Ops::x86Reg Reg, int MipsReg, BOOL Lo
 				SetX86MapOrder(NewReg,GetX86MapOrder(Reg));
 				SetMipsRegMapLo(count,NewReg);
 				MoveX86RegToX86Reg(Reg,NewReg);
-				if (MipsReg == count && LoadHiWord == FALSE) { MipsReg = -1; }
+				if (MipsReg == count && !LoadHiWord)
+					MipsReg = -1;
 				break;
 			}
-			if (Is64Bit(count) && GetMipsRegMapHi(count) == Reg) 
+			if (Is64Bit(count) && GetMipsRegMapHi(count) == Reg)
 			{
-				if (NewReg == x86_Unknown) 
+				if (NewReg == x86_Unknown)
 				{
-					UnMap_GPR(count,TRUE);
+					UnMap_GPR(count, true);
 					break;
 				}
 				CPU_Message("    regcache: change allocation of %s from %s to %s",CRegName::GPR_Hi[count],x86_Name(Reg),x86_Name(NewReg));
@@ -794,7 +795,8 @@ CX86Ops::x86Reg CRegInfo::Map_TempReg (CX86Ops::x86Reg Reg, int MipsReg, BOOL Lo
 				SetX86MapOrder(NewReg,GetX86MapOrder(Reg));
 				SetMipsRegMapHi(count,NewReg);
 				MoveX86RegToX86Reg(Reg,NewReg);
-				if (MipsReg == count && LoadHiWord == TRUE) { MipsReg = -1; }
+				if (MipsReg == count && LoadHiWord)
+					MipsReg = -1;
 				break;
 			}
 		}
@@ -822,7 +824,7 @@ CX86Ops::x86Reg CRegInfo::Map_TempReg (CX86Ops::x86Reg Reg, int MipsReg, BOOL Lo
 					MoveConstToX86reg(0,Reg);
 				}
 			} else {
-				if (Is64Bit(MipsReg)) 
+				if (Is64Bit(MipsReg))
 				{
 					MoveConstToX86reg(GetMipsRegHi(MipsReg),Reg);
 				} else {
@@ -840,11 +842,11 @@ CX86Ops::x86Reg CRegInfo::Map_TempReg (CX86Ops::x86Reg Reg, int MipsReg, BOOL Lo
 		}
 	}
 	SetX86Mapped(Reg,Temp_Mapped);
-	SetX86Protected(Reg,TRUE);
-	for (count = 0; count < 10; count ++) 
+	SetX86Protected(Reg, true);
+	for (count = 0; count < 10; count++)
 	{
 		int MapOrder = GetX86MapOrder((x86Reg)count);
-		if (MapOrder > 0) { 
+		if (MapOrder > 0) {
 			SetX86MapOrder((x86Reg)count,MapOrder + 1);
 		}
 	}
@@ -853,18 +855,24 @@ CX86Ops::x86Reg CRegInfo::Map_TempReg (CX86Ops::x86Reg Reg, int MipsReg, BOOL Lo
 }
 
 void CRegInfo::ProtectGPR(DWORD Reg) {
-	if (IsUnknown(Reg) || IsConst(Reg)) { return; }
-	if (Is64Bit(Reg)) {
-		SetX86Protected(GetMipsRegMapHi(Reg),TRUE);
+	if (IsUnknown(Reg) || IsConst(Reg)) {
+		return;
 	}
-	SetX86Protected(GetMipsRegMapLo(Reg),TRUE);
+	if (Is64Bit(Reg)) {
+		SetX86Protected(GetMipsRegMapHi(Reg), true);
+	}
+
+	SetX86Protected(GetMipsRegMapLo(Reg), true);
 }
 
 void CRegInfo::UnProtectGPR(DWORD Reg) {
-	if (IsUnknown(Reg) || IsConst(Reg)) { return; }
-	if (Is64Bit(Reg)) {
-		SetX86Protected(GetMipsRegMapHi(Reg),false);
+	if (IsUnknown(Reg) || IsConst(Reg)) {
+		return;
 	}
+	if (Is64Bit(Reg)) {
+		SetX86Protected(GetMipsRegMapHi(Reg), false);
+	}
+
 	SetX86Protected(GetMipsRegMapLo(Reg),false);
 }
 
@@ -876,21 +884,21 @@ void CRegInfo::ResetX86Protection()
 	}
 }
 
-BOOL CRegInfo::RegInStack( int Reg, FPU_STATE Format) {
-	int i;
-
-	for (i = 0; i < 8; i++) 
+bool CRegInfo::RegInStack( int Reg, FPU_STATE Format) {
+	for (int i = 0; i < 8; i++)
 	{
-		if (x86fpu_MappedTo[i] == Reg) 
+		if (x86fpu_MappedTo[i] == Reg)
 		{
-			if (x86fpu_State[i] == Format || Format == FPU_Any) 
-			{ 
-				return TRUE; 
+			if (x86fpu_State[i] == Format || Format == FPU_Any)
+			{
+				return true;
 			}
-			return FALSE;
+
+			return false;
 		}
 	}
-	return FALSE;
+
+	return false;
 }
 
 void CRegInfo::UnMap_AllFPRs()
@@ -898,7 +906,7 @@ void CRegInfo::UnMap_AllFPRs()
 	for (;;) {
 		int StackPos = StackTopPos();
 		if (x86fpu_MappedTo[StackPos] != -1 ) {
-			UnMap_FPR(x86fpu_MappedTo[StackPos],TRUE);
+			UnMap_FPR(x86fpu_MappedTo[StackPos], true);
 			continue;
 		}
 		//see if any more registers mapped
@@ -931,7 +939,7 @@ void CRegInfo::UnMap_FPR (int Reg, int WriteBackValue )
 				} else {
 					CRegInfo::FPU_ROUND RoundingModel = FpuRoundingModel(StackTopPos());
 					FPU_STATE RegState  = x86fpu_State[StackTopPos()];
-					BOOL Changed        = x86fpu_StateChanged[StackTopPos()];
+					bool Changed        = x86fpu_StateChanged[StackTopPos()];
 					DWORD MappedTo      = x86fpu_MappedTo[StackTopPos()];
 					FpuRoundingModel(StackTopPos()) = FpuRoundingModel(i);
 					x86fpu_MappedTo[StackTopPos()]      = x86fpu_MappedTo[i];
@@ -948,37 +956,37 @@ void CRegInfo::UnMap_FPR (int Reg, int WriteBackValue )
 			FixRoundModel(FpuRoundingModel(i));
 
 			RegPos = StackTopPos();
-			x86Reg TempReg = Map_TempReg(x86_Any,-1,FALSE);
+			x86Reg TempReg = Map_TempReg(x86_Any, -1, false);
 			switch (x86fpu_State[StackTopPos()]) {
 			case FPU_Dword: 
 				sprintf(Name,"_FPR_S[%d]",x86fpu_MappedTo[StackTopPos()]);
 				MoveVariableToX86reg(&_FPR_S[x86fpu_MappedTo[StackTopPos()]],Name,TempReg);
-				fpuStoreIntegerDwordFromX86Reg(&StackTopPos(),TempReg, TRUE); 
+				fpuStoreIntegerDwordFromX86Reg(&StackTopPos(),TempReg, true);
 				break;
 			case FPU_Qword: 
 				sprintf(Name,"_FPR_D[%d]",x86fpu_MappedTo[StackTopPos()]);
 				MoveVariableToX86reg(&_FPR_D[x86fpu_MappedTo[StackTopPos()]],Name,TempReg);
-				fpuStoreIntegerQwordFromX86Reg(&StackTopPos(),TempReg, TRUE); 
+				fpuStoreIntegerQwordFromX86Reg(&StackTopPos(),TempReg, true);
 				break;
 			case FPU_Float: 
 				sprintf(Name,"_FPR_S[%d]",x86fpu_MappedTo[StackTopPos()]);
 				MoveVariableToX86reg(&_FPR_S[x86fpu_MappedTo[StackTopPos()]],Name,TempReg);
-				fpuStoreDwordFromX86Reg(&StackTopPos(),TempReg, TRUE); 
+				fpuStoreDwordFromX86Reg(&StackTopPos(),TempReg, true);
 				break;
 			case FPU_Double: 
 				sprintf(Name,"_FPR_D[%d]",x86fpu_MappedTo[StackTopPos()]);
 				MoveVariableToX86reg(&_FPR_D[x86fpu_MappedTo[StackTopPos()]],Name,TempReg);
-				fpuStoreQwordFromX86Reg(&StackTopPos(),TempReg, TRUE); 
+				fpuStoreQwordFromX86Reg(&StackTopPos(),TempReg, true);
 				break;
 			default:
 				if (bHaveDebugger()) { g_Notify->DisplayError(__FUNCTIONW__ L"\nUnknown format to load %d",x86fpu_State[StackTopPos()]); }
 			}
-			SetX86Protected(TempReg,FALSE);
+			SetX86Protected(TempReg, false);
 			FpuRoundingModel(RegPos) = RoundDefault;
 			x86fpu_MappedTo[RegPos]      = -1;
 			x86fpu_State[RegPos]         = FPU_Unknown;
 			x86fpu_StateChanged[RegPos]  = false;
-		} else {				
+		} else {
 			fpuFree((x86FpuValues)((i - StackTopPos()) & 7));
 			FpuRoundingModel(i) = RoundDefault;
 			x86fpu_MappedTo[i]      = -1;
@@ -1022,11 +1030,11 @@ void CRegInfo::UnMap_GPR (DWORD Reg, bool WriteBackValue)
 	if (Is64Bit(Reg)) {
 		CPU_Message("    regcache: unallocate %s from %s",x86_Name(GetMipsRegMapHi(Reg)),CRegName::GPR_Hi[Reg]);
 		SetX86Mapped(GetMipsRegMapHi(Reg),NotMapped);
-		SetX86Protected(GetMipsRegMapHi(Reg),FALSE);
+		SetX86Protected(GetMipsRegMapHi(Reg), false);
 	}
 	CPU_Message("    regcache: unallocate %s from %s",x86_Name(GetMipsRegMapLo(Reg)),CRegName::GPR_Lo[Reg]);
 	SetX86Mapped(GetMipsRegMapLo(Reg),NotMapped);
-	SetX86Protected(GetMipsRegMapLo(Reg),FALSE);
+	SetX86Protected(GetMipsRegMapLo(Reg), false);
 	if (!WriteBackValue)
 	{ 
 		SetMipsRegState(Reg,STATE_UNKNOWN);
@@ -1075,7 +1083,7 @@ CX86Ops::x86Reg CRegInfo::UnMap_TempReg()
 	return Reg;
 }
 
-bool CRegInfo::UnMap_X86reg ( CX86Ops::x86Reg Reg )
+bool CRegInfo::UnMap_X86reg(CX86Ops::x86Reg Reg)
 {
 	int count;
 
@@ -1083,47 +1091,53 @@ bool CRegInfo::UnMap_X86reg ( CX86Ops::x86Reg Reg )
 	{
 		if (!GetX86Protected(Reg))
 		{
-			return TRUE; 
+			return true;
 		}
-	} else if (GetX86Mapped(Reg) == CRegInfo::GPR_Mapped) {
+	}
+	else if (GetX86Mapped(Reg) == CRegInfo::GPR_Mapped)
+	{
 		for (count = 1; count < 32; count ++) 
 		{
 			if (!IsMapped(count)) 
-			{
 				continue;
-			}
+
 			if (Is64Bit(count) && GetMipsRegMapHi(count) == Reg) 
 			{
-				if (GetX86Protected(Reg) == FALSE) 
+				if (!GetX86Protected(Reg))
 				{
-					UnMap_GPR(count,TRUE);
-					return TRUE;
+					UnMap_GPR(count, true);
+					return true;
 				}
 				break;
 			} 
-			if (GetMipsRegMapLo(count) == Reg) 
+			if (GetMipsRegMapLo(count) == Reg)
 			{
-				if (GetX86Protected(Reg) == FALSE) 
+				if (!GetX86Protected(Reg))
 				{
-					UnMap_GPR(count,TRUE);
-					return TRUE;
+					UnMap_GPR(count, true);
+					return true;
 				}
 				break;
 			}
 		}
-	} else if (GetX86Mapped(Reg) == CRegInfo::Temp_Mapped) { 
-		if (GetX86Protected(Reg) == FALSE) {
+	}
+	else if (GetX86Mapped(Reg) == CRegInfo::Temp_Mapped)
+	{
+		if (!GetX86Protected(Reg)) {
 			CPU_Message("    regcache: unallocate %s from temp storage",x86_Name(Reg));
 			SetX86Mapped(Reg,NotMapped);
-			return TRUE;
+			return true;
 		}
-	} else if (GetX86Mapped(Reg) == CRegInfo::Stack_Mapped) { 
+	}
+	else if (GetX86Mapped(Reg) == CRegInfo::Stack_Mapped)
+	{
 		CPU_Message("    regcache: unallocate %s from Memory Stack",x86_Name(Reg));
 		MoveX86regToVariable(Reg,&(g_Recompiler->MemoryStackPos()),"MemoryStack");
 		SetX86Mapped(Reg,NotMapped);
-		return TRUE;
+		return true;
 	}
-	return FALSE;
+
+	return false;
 }
 
 void CRegInfo::WriteBackRegisters()
@@ -1131,12 +1145,12 @@ void CRegInfo::WriteBackRegisters()
 	UnMap_AllFPRs();
 
 	int count;
-	bool bEdiZero = FALSE;
-	bool bEsiSign = FALSE;
+	bool bEdiZero = false;
+	bool bEsiSign = false;
 
 	int X86RegCount = sizeof(x86_Registers)/ sizeof(x86_Registers[0]);
-	for (int i = 0; i < X86RegCount; i++) { SetX86Protected(x86_Registers[i],FALSE); } 
-	for (int i = 0; i < X86RegCount; i++) { UnMap_X86reg(x86_Registers[i]); } 
+	for (int i = 0; i < X86RegCount; i++) { SetX86Protected(x86_Registers[i], false); }
+	for (int i = 0; i < X86RegCount; i++) { UnMap_X86reg(x86_Registers[i]); }
 
 	/*************************************/
 	
@@ -1149,12 +1163,12 @@ void CRegInfo::WriteBackRegisters()
 				if (!bEdiZero && (!GetMipsRegLo(count) || !(GetMipsRegLo(count) & 0x80000000))) 
 				{
 					XorX86RegToX86Reg(x86_EDI, x86_EDI);
-					bEdiZero = TRUE;
+					bEdiZero = true;
 				}
 				if (!bEsiSign && (GetMipsRegLo(count) & 0x80000000))
 				{
 					MoveConstToX86reg(0xFFFFFFFF, x86_ESI);
-					bEsiSign = TRUE;
+					bEsiSign = true;
 				}
 				if ((GetMipsRegLo(count) & 0x80000000) != 0) 
 				{
@@ -1173,7 +1187,7 @@ void CRegInfo::WriteBackRegisters()
 					if (!bEdiZero)
 					{
 						XorX86RegToX86Reg(x86_EDI, x86_EDI);
-						bEdiZero = TRUE;
+						bEdiZero = true;
 					}
 				}
 				MoveX86regToVariable(x86_EDI,&_GPR[count].UW[0],CRegName::GPR_Lo[count]);
@@ -1185,7 +1199,7 @@ void CRegInfo::WriteBackRegisters()
 					if (!bEsiSign)
 					{
 						MoveConstToX86reg(0xFFFFFFFF, x86_ESI);
-						bEsiSign = TRUE;
+						bEsiSign = true;
 					}
 				}
 				MoveX86regToVariable(x86_ESI,&_GPR[count].UW[0],CRegName::GPR_Lo[count]);
@@ -1203,7 +1217,7 @@ void CRegInfo::WriteBackRegisters()
 				if (!bEdiZero) 
 				{
 					XorX86RegToX86Reg(x86_EDI, x86_EDI);
-					bEdiZero = TRUE;
+					bEdiZero = true;
 				}
 				MoveX86regToVariable(x86_EDI,&_GPR[count].UW[1],CRegName::GPR_Hi[count]);
 			}
@@ -1215,7 +1229,7 @@ void CRegInfo::WriteBackRegisters()
 					if (!bEdiZero)
 					{
 						XorX86RegToX86Reg(x86_EDI, x86_EDI);
-						bEdiZero = TRUE;
+						bEdiZero = true;
 					}
 				}
 				MoveX86regToVariable(x86_EDI,&_GPR[count].UW[0],CRegName::GPR_Lo[count]);
@@ -1230,11 +1244,11 @@ void CRegInfo::WriteBackRegisters()
 		case CRegInfo::STATE_CONST_64:
 			if (GetMipsRegLo(count) == 0 || GetMipsRegHi(count) == 0) {
 				XorX86RegToX86Reg(x86_EDI, x86_EDI);
-				bEdiZero = TRUE;
+				bEdiZero = true;
 			}
 			if (GetMipsRegLo(count) == 0xFFFFFFFF || GetMipsRegHi(count) == 0xFFFFFFFF) {
 				MoveConstToX86reg(0xFFFFFFFF, x86_ESI);
-				bEsiSign = TRUE;
+				bEsiSign = true;
 			}
 
 			if (GetMipsRegHi(count) == 0) {

--- a/Source/Project64/N64 System/Recompiler/Reg Info.h
+++ b/Source/Project64/N64 System/Recompiler/Reg Info.h
@@ -73,7 +73,7 @@ public:
 	void   FixRoundModel      ( FPU_ROUND RoundMethod );
 	void   ChangeFPURegFormat ( int Reg, FPU_STATE OldFormat, FPU_STATE NewFormat, FPU_ROUND RoundingModel );
 	void   Load_FPR_ToTop     ( int Reg, int RegToLoad, FPU_STATE Format);
-	BOOL   RegInStack         ( int Reg, FPU_STATE Format );
+	bool   RegInStack         ( int Reg, FPU_STATE Format );
 	void   UnMap_AllFPRs      ();
 	void   UnMap_FPR          ( int Reg, int WriteBackValue );
 	x86FpuValues StackPosition( int Reg );
@@ -84,7 +84,7 @@ public:
 	void   Map_GPR_64bit      ( int MipsReg, int MipsRegToLoad );
 	x86Reg Get_MemoryStack    () const;
 	x86Reg Map_MemoryStack    ( x86Reg Reg, bool bMapRegister, bool LoadValue = true );
-	x86Reg Map_TempReg        ( x86Reg Reg, int MipsReg, BOOL LoadHiWord );
+	x86Reg Map_TempReg        ( x86Reg Reg, int MipsReg, bool LoadHiWord );
 	void   ProtectGPR         ( DWORD Reg );
 	void   UnProtectGPR       ( DWORD Reg );
 	void   ResetX86Protection ();
@@ -169,7 +169,7 @@ private:
 	int         m_Stack_TopPos;
 	int         x86fpu_MappedTo[8];
 	FPU_STATE   x86fpu_State[8];
-	BOOL        x86fpu_StateChanged[8];
+	bool        x86fpu_StateChanged[8];
 	FPU_ROUND   x86fpu_RoundingModel[8];
 	
 	bool        m_Fpu_Used;

--- a/Source/Project64/N64 System/Recompiler/X86ops.cpp
+++ b/Source/Project64/N64 System/Recompiler/X86ops.cpp
@@ -3007,13 +3007,13 @@ void CX86Ops::fpuAddRegPop(int * StackPos, x86FpuValues reg) {
 	}
 }
 
-void CX86Ops::fpuComDword(void *Variable, const char * VariableName, BOOL Pop) {
+void CX86Ops::fpuComDword(void *Variable, const char * VariableName, bool Pop) {
 	CPU_Message("      fcom%s ST(0), dword ptr [%s]", m_fpupop[Pop], VariableName);
-	PUTDST16(m_RecompPos, (Pop == TRUE) ? 0x1DD8 : 0x15D8);
+	PUTDST16(m_RecompPos, Pop ? 0x1DD8 : 0x15D8);
 	PUTDST32(m_RecompPos,Variable);
 }
 
-void CX86Ops::fpuComDwordRegPointer(x86Reg x86Pointer, BOOL Pop) {
+void CX86Ops::fpuComDwordRegPointer(x86Reg x86Pointer, bool Pop) {
 	WORD x86Command;
 
 	CPU_Message("      fcom%s ST(0), dword ptr [%s]",m_fpupop[Pop],x86_Name(x86Pointer));
@@ -3027,17 +3027,22 @@ void CX86Ops::fpuComDwordRegPointer(x86Reg x86Pointer, BOOL Pop) {
 	default:
 		g_Notify->BreakPoint(__FILEW__,__LINE__);
 	}
-	if (Pop) { x86Command |= 0x0800; }
+
+	if (Pop)
+	{
+		x86Command |= 0x0800;
+	}
+
 	PUTDST16(m_RecompPos,x86Command);
 }
 
-void CX86Ops::fpuComQword(void *Variable, const char * VariableName, BOOL Pop) {
+void CX86Ops::fpuComQword(void *Variable, const char * VariableName, bool Pop) {
 	CPU_Message("      fcom%s ST(0), qword ptr [%s]", m_fpupop[Pop], VariableName);
-	PUTDST16(m_RecompPos, (Pop == TRUE) ? 0x1DDC : 0x15DC);
+	PUTDST16(m_RecompPos, Pop ? 0x1DDC : 0x15DC);
 	PUTDST32(m_RecompPos,Variable);
 }
 
-void CX86Ops::fpuComQwordRegPointer(x86Reg x86Pointer, BOOL Pop) {
+void CX86Ops::fpuComQwordRegPointer(x86Reg x86Pointer, bool Pop) {
 	WORD x86Command;
 
 	CPU_Message("      fcom%s ST(0), qword ptr [%s]",m_fpupop[Pop],x86_Name(x86Pointer));
@@ -3051,12 +3056,17 @@ void CX86Ops::fpuComQwordRegPointer(x86Reg x86Pointer, BOOL Pop) {
 	default:
 		g_Notify->BreakPoint(__FILEW__,__LINE__);
 	}
-	if (Pop) { x86Command |= 0x0800; }
+
+	if (Pop)
+	{
+		x86Command |= 0x0800;
+	}
+
 	PUTDST16(m_RecompPos,x86Command);
 }
 
-void CX86Ops::fpuComReg(x86FpuValues x86reg, BOOL Pop) {
-	int s = (Pop == TRUE) ? 0x0800 : 0x0000;
+void CX86Ops::fpuComReg(x86FpuValues x86reg, bool Pop) {
+	int s = Pop ? 0x0800 : 0x0000;
 	CPU_Message("      fcom%s ST(0), %s", m_fpupop[Pop], fpu_Name(x86reg));
 
 	switch (x86reg) {
@@ -3460,18 +3470,24 @@ void CX86Ops::fpuStoreControl(void *Variable, const char * VariableName) {
 	PUTDST32(m_RecompPos,Variable);
 }
 
-void CX86Ops::fpuStoreDword(int * StackPos,void *Variable, const char * VariableName, BOOL pop) {
+void CX86Ops::fpuStoreDword(int * StackPos,void *Variable, const char * VariableName, bool pop) {
 	CPU_Message("      fst%s dword ptr [%s]", m_fpupop[pop], VariableName);
-	if (pop) { *StackPos = (*StackPos + 1) & 7; }
-	PUTDST16(m_RecompPos,(pop == FALSE) ? 0x15D9 : 0x1DD9);
+
+	if (pop)
+		*StackPos = (*StackPos + 1) & 7;
+
+	PUTDST16(m_RecompPos, pop ? 0x1DD9 : 0x15D9);
 	PUTDST32(m_RecompPos,Variable);
 }
 
-void CX86Ops::fpuStoreDwordFromX86Reg(int * StackPos,x86Reg x86reg, BOOL pop) {
+void CX86Ops::fpuStoreDwordFromX86Reg(int * StackPos,x86Reg x86reg, bool pop) {
 	BYTE Command = 0;
 
 	CPU_Message("      fst%s dword ptr [%s]", m_fpupop[pop], x86_Name(x86reg));
-	if (pop) { *StackPos = (*StackPos + 1) & 7; }
+
+	if (pop)
+		*StackPos = (*StackPos + 1) & 7;
+
 	PUTDST8(m_RecompPos,0xD9);
 
 	switch (x86reg) {
@@ -3484,14 +3500,17 @@ void CX86Ops::fpuStoreDwordFromX86Reg(int * StackPos,x86Reg x86reg, BOOL pop) {
 	default:
 		g_Notify->BreakPoint(__FILEW__,__LINE__);
 	}
-	PUTDST8(m_RecompPos, (pop == FALSE) ? Command : (Command + 0x8));
+
+	PUTDST8(m_RecompPos, pop ? (Command + 0x8) : Command);
 }
 
-void CX86Ops::fpuStoreDwordToN64Mem(int * StackPos,x86Reg x86reg, BOOL Pop) {
-	int s = (Pop == TRUE) ? 0x0800 : 0;
+void CX86Ops::fpuStoreDwordToN64Mem(int * StackPos,x86Reg x86reg, bool Pop) {
+	int s = Pop ? 0x0800 : 0;
 
 	CPU_Message("      fst%s dword ptr [%s+N64mem]", m_fpupop[Pop], x86_Name(x86reg));
-	if (Pop) { *StackPos = (*StackPos + 1) & 7; }
+
+	if (Pop)
+		*StackPos = (*StackPos + 1) & 7;
 
 	switch (x86reg) {
 	case x86_EAX: PUTDST16(m_RecompPos,0x90D9|s); break;
@@ -3504,21 +3523,30 @@ void CX86Ops::fpuStoreDwordToN64Mem(int * StackPos,x86Reg x86reg, BOOL Pop) {
 	default:
 		g_Notify->BreakPoint(__FILEW__,__LINE__);
 	}
+
 	PUTDST32(m_RecompPos,g_MMU->Rdram());
 }
 
-void CX86Ops::fpuStoreIntegerDword(int * StackPos,void *Variable, const char * VariableName, BOOL pop) {
+void CX86Ops::fpuStoreIntegerDword(int * StackPos,void *Variable, const char * VariableName, bool pop) {
 	CPU_Message("      fist%s dword ptr [%s]", m_fpupop[pop], VariableName);
-	if (pop) { *StackPos = (*StackPos + 1) & 7; }
-	PUTDST16(m_RecompPos, (pop == FALSE) ? 0x15DB : 0x1DDB);
+
+	if (pop)
+		*StackPos = (*StackPos + 1) & 7;
+
+	PUTDST16(m_RecompPos, pop ? 0x1DDB : 0x15DB);
 	PUTDST32(m_RecompPos,Variable);
 }
 
-void CX86Ops::fpuStoreIntegerDwordFromX86Reg(int * StackPos,x86Reg x86reg, BOOL pop) {
+void CX86Ops::fpuStoreIntegerDwordFromX86Reg(int * StackPos,x86Reg x86reg, bool pop) {
 	BYTE Command = 0;
 
 	CPU_Message("      fist%s dword ptr [%s]", m_fpupop[pop], x86_Name(x86reg));
-	if (pop) { *StackPos = (*StackPos + 1) & 7; }
+
+	if (pop)
+	{
+		*StackPos = (*StackPos + 1) & 7;
+	}
+
 	PUTDST8(m_RecompPos,0xDB);
 	
 	switch (x86reg) {
@@ -3531,22 +3559,37 @@ void CX86Ops::fpuStoreIntegerDwordFromX86Reg(int * StackPos,x86Reg x86reg, BOOL 
 	default:
 		g_Notify->BreakPoint(__FILEW__,__LINE__);
 	}
-	PUTDST8(m_RecompPos, (pop == FALSE) ? Command : (Command + 0x8));
+
+	PUTDST8(m_RecompPos, pop ? (Command + 0x8) : Command);
 }
 
-void CX86Ops::fpuStoreIntegerQword(int * StackPos,void *Variable, const char * VariableName, BOOL pop) {
+void CX86Ops::fpuStoreIntegerQword(int * StackPos,void *Variable, const char * VariableName, bool pop) {
 	CPU_Message("      fist%s qword ptr [%s]", m_fpupop[pop], VariableName);
-	if (pop) { *StackPos = (*StackPos + 1) & 7; }
-	PUTDST16(m_RecompPos, (pop == FALSE) ? 0x35DF : 0x3DDF);
+
+	if (pop)
+	{
+		*StackPos = (*StackPos + 1) & 7;
+	}
+
+	PUTDST16(m_RecompPos, pop ? 0x3DDF : 0x35DF);
 	PUTDST32(m_RecompPos,Variable);
-	if (!pop) { X86BreakPoint(__FILEW__,__LINE__); }
+
+	if (!pop)
+	{
+		X86BreakPoint(__FILEW__,__LINE__);
+	}
 }
 
-void CX86Ops::fpuStoreIntegerQwordFromX86Reg(int * StackPos, x86Reg x86reg, BOOL pop) {
+void CX86Ops::fpuStoreIntegerQwordFromX86Reg(int * StackPos, x86Reg x86reg, bool pop) {
 	BYTE Command = 0;
 
 	CPU_Message("      fist%s qword ptr [%s]", m_fpupop[pop], x86_Name(x86reg));
-	if (pop) { *StackPos = (*StackPos + 1) & 7; }
+
+	if (pop)
+	{
+		*StackPos = (*StackPos + 1) & 7;
+	}
+
 	PUTDST8(m_RecompPos,0xDF);
 
 	switch (x86reg) {
@@ -3559,14 +3602,20 @@ void CX86Ops::fpuStoreIntegerQwordFromX86Reg(int * StackPos, x86Reg x86reg, BOOL
 	default:
 		g_Notify->BreakPoint(__FILEW__,__LINE__);
 	}
-	PUTDST8(m_RecompPos, (pop == FALSE) ? Command : (Command + 0x8));
+
+	PUTDST8(m_RecompPos, pop ? (Command + 0x8) : Command);
 }
 
-void CX86Ops::fpuStoreQwordFromX86Reg(int * StackPos, x86Reg x86reg, BOOL pop) {
+void CX86Ops::fpuStoreQwordFromX86Reg(int * StackPos, x86Reg x86reg, bool pop) {
 	BYTE Command = 0;
 
 	CPU_Message("      fst%s qword ptr [%s]", m_fpupop[pop], x86_Name(x86reg));
-	if (pop) { *StackPos = (*StackPos + 1) & 7; }
+
+	if (pop)
+	{
+		*StackPos = (*StackPos + 1) & 7;
+	}
+
 	PUTDST8(m_RecompPos,0xDD);
 
 	switch (x86reg) {
@@ -3579,7 +3628,8 @@ void CX86Ops::fpuStoreQwordFromX86Reg(int * StackPos, x86Reg x86reg, BOOL pop) {
 	default:
 		g_Notify->BreakPoint(__FILEW__,__LINE__);
 	}
-	PUTDST8(m_RecompPos, (pop == FALSE) ? Command : (Command + 0x8));
+
+	PUTDST8(m_RecompPos, pop ? (Command + 0x8) : Command);
 }
 
 void CX86Ops::fpuStoreStatus(void) {
@@ -3739,13 +3789,13 @@ const char * CX86Ops::fpu_Name ( x86FpuValues Reg ) {
 	return "???";
 }
 
-BOOL CX86Ops::Is8BitReg ( x86Reg Reg )
+bool CX86Ops::Is8BitReg(x86Reg Reg)
 {
-	if (Reg == x86_EAX) { return TRUE; }
-	if (Reg == x86_EBX) { return TRUE; }
-	if (Reg == x86_ECX) { return TRUE; }
-	if (Reg == x86_EDX) { return TRUE; }
-	return FALSE;
+	return (Reg == x86_EAX) ||
+	       (Reg == x86_EBX) ||
+	       (Reg == x86_ECX) ||
+	       (Reg == x86_EDX);
+
 }
 
 BYTE CX86Ops::CalcMultiplyCode (Multipler Multiply)

--- a/Source/Project64/N64 System/Recompiler/X86ops.h
+++ b/Source/Project64/N64 System/Recompiler/X86ops.h
@@ -231,11 +231,11 @@ protected:
 	static void fpuAddQwordRegPointer           ( x86Reg X86Pointer );
 	static void fpuAddReg                       ( x86FpuValues reg );
 	static void fpuAddRegPop                    ( int * StackPos, x86FpuValues reg );
-	static void fpuComDword                     ( void * Variable, const char * VariableName, BOOL Pop );
-	static void fpuComDwordRegPointer           ( x86Reg X86Pointer, BOOL Pop );
-	static void fpuComQword                     ( void * Variable, const char * VariableName, BOOL Pop );
-	static void fpuComQwordRegPointer           ( x86Reg X86Pointer, BOOL Pop );
-	static void fpuComReg                       ( x86FpuValues reg, BOOL Pop );
+	static void fpuComDword                     ( void * Variable, const char * VariableName, bool Pop );
+	static void fpuComDwordRegPointer           ( x86Reg X86Pointer, bool Pop );
+	static void fpuComQword                     ( void * Variable, const char * VariableName, bool Pop );
+	static void fpuComQwordRegPointer           ( x86Reg X86Pointer, bool Pop );
+	static void fpuComReg                       ( x86FpuValues reg, bool Pop );
 	static void fpuDivDword                     ( void * Variable, const char * VariableName );
 	static void fpuDivDwordRegPointer           ( x86Reg X86Pointer );
 	static void fpuDivQword                     ( void * Variable, const char * VariableName );
@@ -269,15 +269,14 @@ protected:
 	static void fpuRound                        ();
 	static void fpuSqrt                         ();
 	static void fpuStoreControl                 ( void * Variable, const char * VariableName );
-	static void fpuStoreDword                   ( int * StackPos, void * Variable, const char * VariableName, BOOL pop );
-	static void fpuStoreDwordFromX86Reg         ( int * StackPos,x86Reg Reg, BOOL pop );
-	static void fpuStoreDwordToN64Mem           ( int * StackPos, x86Reg reg, BOOL Pop );
-	static void fpuStoreIntegerDword            ( int * StackPos, void * Variable, const char * VariableName, BOOL pop );
-	static void fpuStoreIntegerDwordFromX86Reg  ( int * StackPos,x86Reg Reg, BOOL pop );
-	static void fpuStoreIntegerQword            ( int * StackPos, void * Variable, const char * VariableName, BOOL pop );
-	static void fpuStoreIntegerQwordFromX86Reg  ( int * StackPos, x86Reg Reg, BOOL pop );
-	static void fpuStoreQword                   ( int * StackPos, void * Variable, const char * VariableName, BOOL pop );
-	static void fpuStoreQwordFromX86Reg         ( int * StackPos, x86Reg Reg, BOOL pop );
+	static void fpuStoreDword                   ( int * StackPos, void * Variable, const char * VariableName, bool pop );
+	static void fpuStoreDwordFromX86Reg         ( int * StackPos,x86Reg Reg, bool pop );
+	static void fpuStoreDwordToN64Mem           ( int * StackPos, x86Reg reg, bool Pop );
+	static void fpuStoreIntegerDword            ( int * StackPos, void * Variable, const char * VariableName, bool pop );
+	static void fpuStoreIntegerDwordFromX86Reg  ( int * StackPos,x86Reg Reg, bool pop );
+	static void fpuStoreIntegerQword            ( int * StackPos, void * Variable, const char * VariableName, bool pop );
+	static void fpuStoreIntegerQwordFromX86Reg  ( int * StackPos, x86Reg Reg, bool pop );
+	static void fpuStoreQwordFromX86Reg         ( int * StackPos, x86Reg Reg, bool pop );
 	static void fpuStoreStatus                  ();
 	static void fpuSubDword                     ( void * Variable, const char * VariableName );
 	static void fpuSubDwordRegPointer           ( x86Reg X86Pointer );
@@ -288,7 +287,7 @@ protected:
 	static void fpuSubReg                       ( x86FpuValues reg );
 	static void fpuSubRegPop                    ( x86FpuValues reg );	
 	
-	static BOOL Is8BitReg                       ( x86Reg Reg );
+	static bool Is8BitReg                       ( x86Reg Reg );
 	static BYTE CalcMultiplyCode                ( Multipler Multiply );
 	static BYTE * m_RecompPos;
 

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -1203,16 +1203,15 @@ bool CRomBrowser::RomListDrawItem(int idCtrl, DWORD lParam)
 	RECT rcItem, rcDraw;
 	char String[300];
 	LV_ITEM lvItem;
-	BOOL bSelected;
 	HBRUSH hBrush;
-    LV_COLUMN lvc; 
+	LV_COLUMN lvc; 
 	int nColumn;
 
 	lvItem.mask = LVIF_PARAM;
 	lvItem.iItem = ditem->itemID;
 	if (!ListView_GetItem((HWND)m_hRomList, &lvItem)) { return false; }
 	lvItem.state = ListView_GetItemState((HWND)m_hRomList, ditem->itemID, -1);
-	bSelected = (lvItem.state & LVIS_SELECTED);
+	bool bSelected = (lvItem.state & LVIS_SELECTED) != 0;
 
 	if (lvItem.lParam < 0 || lvItem.lParam >= (LPARAM)m_RomInfo.size())
 	{


### PR DESCRIPTION
Quite large, however it removes almost all usages of BOOL related defines/typedefs from the core, save for the Windows API where it requires BOOL specifically.