### PR TITLE
Remove unnecessary struct/union typedefs

### DIFF
--- a/Source/Project64/Multilanguage/Language Class.h
+++ b/Source/Project64/Multilanguage/Language Class.h
@@ -20,11 +20,11 @@
 typedef std::map<int, std::wstring, std::less<int> > LANG_STRINGS;
 typedef LANG_STRINGS::value_type               LANG_STR;
 
-typedef struct
+struct LanguageFile
 {
 	stdstr Filename;
 	std::wstring LanguageName;
-} LanguageFile;
+};
 
 typedef std::list<LanguageFile> LanguageList;
 

--- a/Source/Project64/N64 System/Cheat Class.h
+++ b/Source/Project64/N64 System/Cheat Class.h
@@ -24,10 +24,10 @@ public:
 	inline bool CheatsSlectionChanged ( void ) const { return m_CheatSelectionChanged; }
 
 private:
-	typedef struct {
+	struct GAMESHARK_CODE {
 		DWORD Command;
 		WORD  Value;
-	} GAMESHARK_CODE;
+	};
 
 	typedef std::vector<GAMESHARK_CODE> CODES;
 	typedef std::vector<CODES>          CODES_ARRAY;

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Search.h
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Search.h
@@ -41,11 +41,11 @@ private:
 		SearchChangeState_Lessthan,
 	};
 
-	typedef struct
+	struct SearchResultItem
 	{
 		DWORD PAddr;
 		DWORD Value;
-	} SearchResultItem;
+	};
 
 	typedef std::vector<SearchResultItem> SearchResult;
 

--- a/Source/Project64/N64 System/Mips/OpCode.h
+++ b/Source/Project64/N64 System/Mips/OpCode.h
@@ -10,7 +10,7 @@
 ****************************************************************************/
 #pragma once
 
-typedef union
+union OPCODE
 {
 	unsigned long Hex;
 	unsigned char Ascii[4];
@@ -55,8 +55,8 @@ typedef union
 		unsigned ft : 5;
 		unsigned fmt : 5;
 		unsigned : 6;
-	};	
-} OPCODE;
+	};
+};
 
 enum R4300iOpCodes
 {

--- a/Source/Project64/N64 System/Mips/System Timing.h
+++ b/Source/Project64/N64 System/Mips/System Timing.h
@@ -31,11 +31,11 @@ public:
 		MaxTimer
 	};
 
-	typedef struct
+	struct TIMER_DETAILS
 	{
 		bool    Active;
 		__int64 CyclesToTimer;
-	} TIMER_DETAILS;
+	};
 
 public:
 	          CSystemTimer         ( int & NextTimer );

--- a/Source/Project64/N64 System/Mips/TLB Class.h
+++ b/Source/Project64/N64 System/Mips/TLB Class.h
@@ -24,7 +24,7 @@ class CTLB :
 	protected CSystemRegisters
 {
 public:
-	typedef struct
+	struct TLB_ENTRY
 	{
 		bool EntryDefined;
 		union
@@ -89,7 +89,7 @@ public:
 			} ;
 			
 		} EntryLo1;
-	} TLB_ENTRY;
+	};
 	
 public:
 	CTLB(CTLB_CB * CallBack);
@@ -118,7 +118,7 @@ public:
 	bool operator != (const CTLB& rTLB) const;
 
 private:
-	typedef struct
+	struct FASTTLB
 	{
 		DWORD VSTART;
 		DWORD VEND;
@@ -131,7 +131,7 @@ private:
 		bool  ValidEntry;
 		bool  Random;
 		bool  Probed;
-	} FASTTLB; 
+	};
 
 	friend CDebugTlb; // enable debug window to read class
 

--- a/Source/Project64/N64 System/N64 Class.h
+++ b/Source/Project64/N64 System/N64 Class.h
@@ -29,13 +29,13 @@ class CN64System :
 	public CDebugger
 {
 public:
-    CN64System ( CPlugins * Plugins, bool SavesReadOnly );
-    virtual ~CN64System ( void );
+	CN64System ( CPlugins * Plugins, bool SavesReadOnly );
+	virtual ~CN64System ( void );
 
-	typedef struct {
+	struct ThreadInfo {
 		HANDLE * ThreadHandle;
 		DWORD    ThreadID;
-	} ThreadInfo;
+	};
 
 	CProfiling m_Profile;
 	CCheats    m_Cheats;

--- a/Source/Project64/N64 System/Profiling Class.cpp
+++ b/Source/Project64/N64 System/Profiling Class.cpp
@@ -108,7 +108,10 @@ void CProfiling::ResetCounters() {
 	m_Entries.clear();
 }
 
-typedef struct { SPECIAL_TIMERS Timer; char * Name; } TIMER_NAME;
+struct TIMER_NAME {
+	SPECIAL_TIMERS Timer;
+	char * Name;
+};
 
 void CProfiling::GenerateLog() {
 	stdstr LogFileName;

--- a/Source/Project64/N64 System/Recompiler/Section Info.h
+++ b/Source/Project64/N64 System/Recompiler/Section Info.h
@@ -11,14 +11,11 @@
 #pragma once
 
 class CCodeSection;
-
-
 class CCodeBlock;
 
-
-typedef struct {
+struct BLOCK_PARENT {
 	CCodeSection * Parent;
-	CJumpInfo     * JumpInfo;
-} BLOCK_PARENT;
+	CJumpInfo    * JumpInfo;
+};
 
 typedef std::vector<BLOCK_PARENT> BLOCK_PARENT_LIST;

--- a/Source/Project64/N64 System/Types.h
+++ b/Source/Project64/N64 System/Types.h
@@ -17,25 +17,25 @@ typedef unsigned __int64 QWORD;
 typedef void *           HANDLE;
 typedef int              BOOL;
 
-typedef union tagUWORD {
-	long				W;
-	float				F;
-	unsigned long		UW;
-	short				HW[2];
-	unsigned short		UHW[2];
-	char				B[4];
-	unsigned char		UB[4];
-} MIPS_WORD;
+union MIPS_WORD {
+	long           W;
+	float          F;
+	unsigned long  UW;
+	short          HW[2];
+	unsigned short UHW[2];
+	char           B[4];
+	unsigned char  UB[4];
+};
 
-typedef union tagUDWORD {
-	double				D;
-	__int64				DW;
-	unsigned __int64	UDW;
-	long				W[2];
-	float				F[2];
-	unsigned long		UW[2];
-	short				HW[4];
-	unsigned short		UHW[4];
-	char				B[8];
-	unsigned char		UB[8];
-} MIPS_DWORD;
+union MIPS_DWORD {
+	double           D;
+	__int64          DW;
+	unsigned __int64 UDW;
+	long             W[2];
+	float            F[2];
+	unsigned long    UW[2];
+	short            HW[4];
+	unsigned short   UHW[4];
+	char             B[8];
+	unsigned char    UB[8];
+};

--- a/Source/Project64/Settings/Settings Class.cpp
+++ b/Source/Project64/Settings/Settings Class.cpp
@@ -1084,7 +1084,7 @@ void CSettings::UnregisterChangeCB(SettingID Type,void * Data, SettingChangedFun
 					if (item->Next)
 					{
 						SettingID Type = Callback->first;
-						_SETTING_CHANGED_CB * Next = item->Next;
+						SETTING_CHANGED_CB * Next = item->Next;
 						m_Callback.erase(Callback);
 						m_Callback.insert(SETTING_CALLBACK::value_type(Type,Next));
 					} else {

--- a/Source/Project64/Settings/Settings Class.h
+++ b/Source/Project64/Settings/Settings Class.h
@@ -31,12 +31,12 @@ private:
 	void AddHowToHandleSetting (void);
 	void UnknownSetting (SettingID Type);
 
-	typedef struct _SETTING_CHANGED_CB
+	struct SETTING_CHANGED_CB
 	{
-		void                * Data;
-		SettingChangedFunc    Func;
-		_SETTING_CHANGED_CB * Next; 
-	} SETTING_CHANGED_CB;
+		void               * Data;
+		SettingChangedFunc   Func;
+		SETTING_CHANGED_CB * Next; 
+	};
 
 	typedef std::map<SettingID, SETTING_CHANGED_CB *> SETTING_CALLBACK;
 	typedef std::map<SettingID, CSettingType *> SETTING_MAP;

--- a/Source/Project64/User Interface.h
+++ b/Source/Project64/User Interface.h
@@ -23,22 +23,22 @@ typedef unsigned __int64 QWORD;
 typedef void *           HANDLE;
 typedef const char *     LPCSTR;
 
-typedef struct
+struct RECT_STRUCT
 {
 	long left;
 	long top;
 	long right;
 	long bottom;
-} RECT_STRUCT;
+};
 
-typedef struct {
-    HDC   hdc;
-    int        fErase;
+struct WINDOWS_PAINTSTRUCT {
+    HDC         hdc;
+    int         fErase;
     RECT_STRUCT rcPaint;
-    int        fRestore;
-    int        fIncUpdate;
+    int         fRestore;
+    int         fIncUpdate;
     BYTE        rgbReserved[32];
-} WINDOWS_PAINTSTRUCT;
+};
 
 #define CALLBACK    __stdcall
 

--- a/Source/Project64/User Interface/Gui Class.h
+++ b/Source/Project64/User Interface/Gui Class.h
@@ -33,13 +33,13 @@ class CMainGui :
 
 	enum { Timer_SetWindowPos = 1 };
 
-	typedef struct 
+	struct RESET_PLUGIN
 	{
 		CN64System * system;
 		CPlugins * plugins;
 		HANDLE hEvent;
 		bool res;
-	} RESET_PLUGIN;
+	};
 public:
 		 CMainGui ( bool bMainWindow, const char * WindowTitle = "" );
 		~CMainGui ( void );

--- a/Source/Project64/User Interface/MenuShortCuts.h
+++ b/Source/Project64/User Interface/MenuShortCuts.h
@@ -10,11 +10,11 @@
 ****************************************************************************/
 #pragma once
 
-typedef struct { 
-	LPCSTR    Name; 
-	int       Key;  
-	LPCSTR    KeyName; 
-} VIRTUAL_KEY;
+struct VIRTUAL_KEY {
+	LPCSTR    Name;
+	int       Key;
+	LPCSTR    KeyName;
+};
 
 class CMenuShortCutKey {
 public:

--- a/Source/Project64/User Interface/Rom Browser.h
+++ b/Source/Project64/User Interface/Rom Browser.h
@@ -71,11 +71,11 @@ typedef std::vector<ROMBROWSER_FIELDS>   ROMBROWSER_FIELDS_LIST;
 typedef std::vector<int>                 FIELD_TYPE_LIST;
 
 class CRomBrowser;
-typedef struct {
+struct SORT_FIELD {
 	CRomBrowser * _this;
 	int           Key;
 	bool          KeyAscend;
-} SORT_FIELD;
+};
 
 class C7zip;
 class CRomBrowser 
@@ -100,7 +100,7 @@ class CRomBrowser
 		NoOfSortKeys = 3
 	};
 
-	typedef struct {
+	struct ROM_INFO {
 		char     szFullFileName[300];
 		FILE_FORMAT FileFormat;
 		char     Status[60];
@@ -126,7 +126,7 @@ class CRomBrowser
 		DWORD    CRC2;
 		int      CicChip;
 		char     ForceFeedback[15];
-	} ROM_INFO;
+	};
 
 	typedef std::vector<ROM_INFO>   ROMINFO_LIST;
 


### PR DESCRIPTION
These are superfluous in C++, structs can be declared as is.

I've left the plugin interface structs alone for obvious reasons.