### PR TITLE
System events seems to rely on remaining as an integer type. Changing it...

### DIFF
--- a/Source/Project64/N64 System/Mips/System Events.h
+++ b/Source/Project64/N64 System/Mips/System Events.h
@@ -62,7 +62,7 @@ public:
 	void ExecuteEvents();
 	void QueueEvent(SystemEvent action);
 
-	const bool& DoSomething() const
+	const int& DoSomething() const
 	{
 		return m_bDoSomething;
 	}
@@ -77,6 +77,6 @@ private:
 	CN64System    * m_System;
 	CPlugins      * m_Plugins;
 	EventList       m_Events;
-	bool            m_bDoSomething;
+	int            m_bDoSomething;
 	CriticalSection m_CS;
 };


### PR DESCRIPTION
... to bool causes the whole emulator to stop functioning correctly.