### PR TITLE
Added 64DD CIC support for Zoinkity's cartridge conversions of 64DD games.

### DIFF
--- a/Source/Project64/N64 System/Mips/Dma.cpp
+++ b/Source/Project64/N64 System/Mips/Dma.cpp
@@ -22,6 +22,7 @@ void CDMA::OnFirstDMA()
 	switch (g_Rom->CicChipID())
 	{
 	case CIC_NUS_6101: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
+	case CIC_NUS_8303: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
 	case CIC_UNKNOWN:
 	case CIC_NUS_6102: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
 	case CIC_NUS_6103: *(DWORD *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -810,6 +810,9 @@ void CN64System::InitRegisters( bool bPostPif, CMipsMemory & MMU )
 		case CIC_NUS_6101: 
 			m_Reg.m_GPR[22].DW=0x000000000000003F; 
 			break;
+		case CIC_NUS_8303:		//64DD CIC
+			m_Reg.m_GPR[22].DW=0x00000000000000DD;
+			break;
 		case CIC_UNKNOWN:
 		case CIC_NUS_6102: 
 			m_Reg.m_GPR[1].DW=0x0000000000000001;

--- a/Source/Project64/N64 System/N64 Rom Class.cpp
+++ b/Source/Project64/N64 System/N64 Rom Class.cpp
@@ -245,6 +245,7 @@ void CN64Rom::CalculateCicChip()
 	case 0x000000D6497E414B: m_CicChip = CIC_NUS_6103; break;
 	case 0x0000011A49F60E96: m_CicChip = CIC_NUS_6105; break;
 	case 0x000000D6D5BE5580: m_CicChip = CIC_NUS_6106; break;
+	case 0x000001053B8A9870: m_CicChip = CIC_NUS_8303; break;	//64DD CIC
 	default:
 		if (bHaveDebugger())
 			g_Notify->DisplayError(L"Unknown CIC checksum:\n%I64d.", CRC);

--- a/Source/Project64/N64 System/N64 Types.h
+++ b/Source/Project64/N64 System/N64 Types.h
@@ -51,7 +51,7 @@ enum SYSTEM_TYPE {
 
 enum CICChip { 
 	CIC_UNKNOWN  = -1, CIC_NUS_6101 = 1, CIC_NUS_6102 = 2, CIC_NUS_6103 = 3, 
-	CIC_NUS_6104 = 4,  CIC_NUS_6105 = 5, CIC_NUS_6106 = 6
+	CIC_NUS_6104 = 4,  CIC_NUS_6105 = 5, CIC_NUS_6106 = 6, CIC_NUS_8303 = 7
 };
 
 enum Country { 


### PR DESCRIPTION
Still requires to change settings for each game to have 8MB of memory, and maybe change to CPU Interpreter.