### PR TITLE
WIP DL/s and VI/s Together

### DIFF
--- a/Source/Project64/Multilanguage.h
+++ b/Source/Project64/Multilanguage.h
@@ -377,6 +377,7 @@ enum LanguageStringID{
     STR_FR_VIS              = 700,
     STR_FR_DLS              = 701,
     STR_FR_PERCENT          = 702,
+	STR_FR_DLS_VIS			= 703,
 
 // Increase speed
     STR_INSREASE_SPEED      = 710,

--- a/Source/Project64/Multilanguage/Language Class.cpp
+++ b/Source/Project64/Multilanguage/Language Class.cpp
@@ -338,6 +338,7 @@ void CLanguage::LoadDefaultStrings (void)
 	DEF_STR(ACCEL_CPUSTATE_3,        L"Game playing (windowed)");
 	DEF_STR(ACCEL_CPUSTATE_4,        L"Game playing (full-screen)");
 	DEF_STR(ACCEL_DETECTKEY,         L"Detect Key");
+	DEF_STR(STR_FR_DLS_VIS,			 L"VI/s & DL/s");
 
 // Frame Rate Option
 	DEF_STR(STR_FR_VIS,              L"Vertical interrupts per second");

--- a/Source/Project64/N64 System/N64 Types.h
+++ b/Source/Project64/N64 System/N64 Types.h
@@ -33,7 +33,7 @@ enum CPU_TYPE {
 };
 
 enum FRAMERATE_TYPE {
-	FR_VIs = 0, FR_DLs = 1, FR_PERCENT = 2,
+	FR_VIs = 0, FR_DLs = 1, FR_PERCENT = 2, FR_VIs_DLs = 3,
 };
 
 enum SAVE_CHIP_TYPE  { 

--- a/Source/Project64/User Interface/Frame Per Second Class.cpp
+++ b/Source/Project64/User Interface/Frame Per Second Class.cpp
@@ -50,7 +50,7 @@ void CFramePerSecond::Reset (bool ClearDisplay)
 		return;
 	}
 	
-	if (m_iFrameRateType == FR_VIs) 
+	if (m_iFrameRateType == FR_VIs || m_iFrameRateType == FR_VIs_DLs) 
 	{
 		DisplayViCounter(0);
 	}
@@ -58,7 +58,7 @@ void CFramePerSecond::Reset (bool ClearDisplay)
 
 void CFramePerSecond::UpdateViCounter ( void )
 {
-	if (m_iFrameRateType != FR_VIs && m_iFrameRateType != FR_PERCENT)
+	if (m_iFrameRateType != FR_VIs && m_iFrameRateType != FR_PERCENT && m_iFrameRateType != FR_VIs_DLs)
 	{
 		return;
 	}
@@ -74,7 +74,7 @@ void CFramePerSecond::UpdateViCounter ( void )
 
 void CFramePerSecond::DisplayViCounter(DWORD FrameRate) 
 {
-	if (m_iFrameRateType == FR_VIs)
+	if (m_iFrameRateType == FR_VIs || m_iFrameRateType == FR_VIs_DLs)
 	{
 		if (FrameRate != 0) 
         {
@@ -143,7 +143,7 @@ void CFramePerSecond::ScreenHertzChanged (CFramePerSecond * _this)
 
 void CFramePerSecond::UpdateDlCounter  ( void )
 {
-	if (m_iFrameRateType != FR_DLs)
+	if (m_iFrameRateType != FR_DLs && m_iFrameRateType != FR_VIs_DLs)
 	{
 		return;
 	}
@@ -158,23 +158,43 @@ void CFramePerSecond::UpdateDlCounter  ( void )
 }
 
 void CFramePerSecond::DisplayDlCounter(DWORD FrameRate) {
-	if (m_iFrameRateType != FR_DLs)
-	{
-		return;
-	}
-	if (FrameRate != 0) {
-		g_Notify->DisplayMessage2(L"DL/s: %d.00", FrameRate);
-	} else {
-		if (CurrentFrame > (NoOfFrames << 2)) {
-			__int64 Total;
-			
-			Total = 0;
-			for (int count = 0; count < NoOfFrames; count ++) {
-				Total += Frames[count];
+		if (m_iFrameRateType == FR_DLs)
+		{
+			if (FrameRate != 0) {
+				g_Notify->DisplayMessage2(L"DL/s: %d.00", FrameRate);
+			} else {
+				if (CurrentFrame > (NoOfFrames << 2)) {
+					__int64 Total;
+
+					Total = 0;
+					for (int count = 0; count < NoOfFrames; count ++) {
+						Total += Frames[count];
+					}
+					g_Notify->DisplayMessage2(L"DL/s: %.1f", Frequency/ ((double)Total / (NoOfFrames << 2)));
+				} else {
+					g_Notify->DisplayMessage2(L"DL/s: -.--");
+				}
 			}
-			g_Notify->DisplayMessage2(L"DL/s: %.1f", Frequency/ ((double)Total / (NoOfFrames << 2)));
-		} else {
-			g_Notify->DisplayMessage2(L"DL/s: -.--");
+		}
+		if (m_iFrameRateType == FR_VIs_DLs)
+		{
+			if (FrameRate != 0)
+			{
+				g_Notify->DisplayMessage(5, L"DL/s: %d.00", FrameRate);
+			}
+			else {
+				if (CurrentFrame > (NoOfFrames << 2)) {
+					__int64 Total;
+
+					Total = 0;
+					for (int count = 0; count < NoOfFrames; count++) {
+						Total += Frames[count];
+					}
+					g_Notify->DisplayMessage(5, L"DL/s: %.2f", Frequency / ((double)Total / (NoOfFrames << 2)));
+				}
+				else {
+					g_Notify->DisplayMessage(5, L"DL/s: -.--");
+				}
+			}
 		}
 	}
-}

--- a/Source/Project64/User Interface/Main Menu Class.cpp
+++ b/Source/Project64/User Interface/Main Menu Class.cpp
@@ -229,6 +229,9 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
 		case FR_DLs:
 			g_Settings->SaveDword(UserInterface_FrameDisplayType,FR_PERCENT);
 			break;
+		case FR_VIs_DLs:
+			g_Settings->SaveDword(UserInterface_FrameDisplayType,FR_VIs_DLs);
+			break;
 		default:
 			g_Settings->SaveDword(UserInterface_FrameDisplayType,FR_VIs);
 		}

--- a/Source/Project64/User Interface/Settings/Settings Page - Advanced Options.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Advanced Options.cpp
@@ -40,6 +40,7 @@ CAdvancedOptionsPage::CAdvancedOptionsPage (HWND hParent, const RECT & rcDispay 
 		ComboBox->AddItemW(GS(STR_FR_VIS), FR_VIs );
 		ComboBox->AddItemW(GS(STR_FR_DLS), FR_DLs );
 		ComboBox->AddItemW(GS(STR_FR_PERCENT), FR_PERCENT );
+		ComboBox->AddItemW(GS(STR_FR_DLS_VIS), FR_VIs_DLs);
 	}
 
 	UpdatePageSettings();

--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+#include "stdafx.h" FARTS!!!
 #include <Tlhelp32.h>
 
 CTraceFileLog * LogFile = NULL;
@@ -19,7 +19,7 @@ void InitializeLog ( void)
 	CPath LogFilePath(CPath::MODULE_DIRECTORY);
 	LogFilePath.AppendDirectory("Logs");
 	if (!LogFilePath.DirectoryExists())
-	{
+	{FARTS
 		LogFilePath.CreateDirectory();
 	}
 	LogFilePath.SetNameExtension(_T("Project64.log"));


### PR DESCRIPTION
I don't expect this to get PR approved, but I was hoping that other could look at it and see if they could improve the code.

This show the minor changes that were needed to add the option to the settings menu and actually displays to the DL/s and VI/s together, only the calculations for the DL/s and VI/s don't work when FPS limit is off.

I was only able to get the DL's to show in the bottom right hand of the screen because I was not able to create a new pane in the status bar. If anyone is able to lend me some advice I would appreciate it very much..

Thanks