### PR TITLE
Fixed N64 Mouse detection

### DIFF
--- a/Source/nragev20/NRagePluginV2.cpp
+++ b/Source/nragev20/NRagePluginV2.cpp
@@ -602,13 +602,11 @@ EXPORT void CALL ReadController( int Control, BYTE * Command )
 #ifdef ENABLE_RAWPAK_DEBUG
 		WriteDatasA( "GetStatus-PreProcessing", Control, Command, 0);
 #endif
-		Command[3] = RD_GAMEPAD;
+		Command[3] = RD_GAMEPAD | RD_ABSOLUTE;
 		Command[4] = RD_NOEEPROM;
 
 		if (g_pcControllers[Control].fN64Mouse)		// Is Controller a mouse?
-			Command[3] |= RD_RELATIVE;
-		else
-			Command[3] |= RD_ABSOLUTE;
+			Command[3] = RD_RELATIVE;
 
 		if( g_pcControllers[Control].fPakInitialized && g_pcControllers[Control].pPakData )
 		{


### PR DESCRIPTION
Talent Studio and Polygon Studio couldn't detect the N64 Mouse, and found out it was just very dumb to fix.