### PR TITLE
warning fixes

### DIFF
--- a/Source/3rd Party/zlib/contrib/minizip/crypt.h
+++ b/Source/3rd Party/zlib/contrib/minizip/crypt.h
@@ -32,7 +32,7 @@
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys, const z_crc_t* pcrc_32_tab)
+static int decrypt_byte(unsigned long* pkeys)
 {
     unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                      * unpredictable manner on 16-bit systems; not a problem
@@ -77,7 +77,7 @@ static void init_keys(const char* passwd,unsigned long* pkeys,const z_crc_t* pcr
     (update_keys(pkeys,pcrc_32_tab,c ^= decrypt_byte(pkeys,pcrc_32_tab)))
 
 #define zencode(pkeys,pcrc_32_tab,c,t) \
-    (t=decrypt_byte(pkeys,pcrc_32_tab), update_keys(pkeys,pcrc_32_tab,c), t^(c))
+    (t=decrypt_byte(pkeys), update_keys(pkeys,pcrc_32_tab,c), t^(c))
 
 #ifdef INCLUDECRYPTINGCODE_IFCRYPTALLOWED
 

--- a/Source/3rd Party/zlib/contrib/minizip/crypt.h
+++ b/Source/3rd Party/zlib/contrib/minizip/crypt.h
@@ -32,14 +32,14 @@
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys)
+static Byte decrypt_byte(unsigned long* pkeys)
 {
     unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                      * unpredictable manner on 16-bit systems; not a problem
                      * with any known compiler so far, though */
 
     temp = ((unsigned)(*(pkeys+2)) & 0xffff) | 2;
-    return (int)(((temp * (temp ^ 1)) >> 8) & 0xff);
+    return (Byte)(((temp * (temp ^ 1)) >> 8) & 0xFF);
 }
 
 /***********************************************************************
@@ -95,8 +95,8 @@ static int crypthead(const char* passwd,      /* password string */
                      unsigned long crcForCrypting)
 {
     int n;                       /* index in random header */
-    int t;                       /* temporary */
-    int c;                       /* random byte */
+    Byte t;                      /* temporary */
+    Byte c;                      /* random byte */
     unsigned char header[RAND_HEAD_LEN-2]; /* random header */
     static unsigned calls = 0;   /* ensure different random header each time */
 
@@ -114,17 +114,17 @@ static int crypthead(const char* passwd,      /* password string */
     init_keys(passwd, pkeys, pcrc_32_tab);
     for (n = 0; n < RAND_HEAD_LEN-2; n++)
     {
-        c = (rand() >> 7) & 0xff;
-        header[n] = (unsigned char)zencode(pkeys, pcrc_32_tab, c, t);
+        c = (Byte)((rand() >> 7) & 0xFF);
+        header[n] = zencode(pkeys, pcrc_32_tab, c, t);
     }
     /* Encrypt random header (last two bytes is high word of crc) */
     init_keys(passwd, pkeys, pcrc_32_tab);
     for (n = 0; n < RAND_HEAD_LEN-2; n++)
     {
-        buf[n] = (unsigned char)zencode(pkeys, pcrc_32_tab, header[n], t);
+        buf[n] = zencode(pkeys, pcrc_32_tab, header[n], t);
     }
-    buf[n++] = (unsigned char)zencode(pkeys, pcrc_32_tab, (int)(crcForCrypting >> 16) & 0xff, t);
-    buf[n++] = (unsigned char)zencode(pkeys, pcrc_32_tab, (int)(crcForCrypting >> 24) & 0xff, t);
+    buf[n++] = zencode(pkeys, pcrc_32_tab, (crcForCrypting >> 16) & 0xFF, t);
+    buf[n++] = zencode(pkeys, pcrc_32_tab, (crcForCrypting >> 24) & 0xFF, t);
     return n;
 }
 

--- a/Source/3rd Party/zlib/contrib/minizip/zip.c
+++ b/Source/3rd Party/zlib/contrib/minizip/zip.c
@@ -1368,8 +1368,9 @@ local int zip64FlushWriteBuffer(zip64_internal* zi)
     {
 #ifndef NOCRYPT
         uInt i;
-        int t;
-        for (i=0;i<zi->ci.pos_in_buffered_data;i++)
+        Byte t;
+
+        for (i = 0; i < zi->ci.pos_in_buffered_data; i++)
             zi->ci.buffered_data[i] = zencode(zi->ci.keys, zi->ci.pcrc_32_tab, zi->ci.buffered_data[i],t);
 #endif
     }

--- a/Source/Project64/User Interface/Settings Config.cpp
+++ b/Source/Project64/User Interface/Settings Config.cpp
@@ -172,7 +172,7 @@ LRESULT	CSettingConfig::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*
 		
 		HTREEITEM hSectionItem = NULL;	
 
-		for (int i = 0; i < Section->GetPageCount(); i++ )
+		for (size_t i = 0; i < Section->GetPageCount(); i++)
 		{
 			CSettingsPage * Page = Section->GetPage(i);
 			if (HideAdvanced && Page == m_AdvancedPage)
@@ -227,7 +227,7 @@ LRESULT CSettingConfig::OnClicked (WORD /*wNotifyCode*/, WORD wID, HWND , BOOL& 
 		{
 			CConfigSettingSection * Section = *iter;
 			
-			for (int i = 0; i < Section->GetPageCount(); i++ )
+			for (size_t i = 0; i < Section->GetPageCount(); i++ )
 			{
 				CSettingsPage * Page = Section->GetPage(i);
 				if (Page->EnableReset())
@@ -259,7 +259,7 @@ void CSettingConfig::ApplySettings( bool UpdateScreen )
 	{
 		CConfigSettingSection * Section = *iter;
 		
-		for (int i = 0; i < Section->GetPageCount(); i++ )
+		for (size_t i = 0; i < Section->GetPageCount(); i++ )
 		{
 			CSettingsPage * Page = Section->GetPage(i);
 			Page->ApplySettings(UpdateScreen);

--- a/Source/Project64/User Interface/WTL Controls/numberctrl.h
+++ b/Source/Project64/User Interface/WTL Controls/numberctrl.h
@@ -297,9 +297,9 @@ public:
 
 		size_t Finish = strlen(text);
 		char second = Finish > 1 ? text[1] : 0;
-		int Start = (second == 'x' || second == 'X') ? 2 : 0;
+		size_t Start = (second == 'x' || second == 'X') ? 2 : 0;
 
-		if (Finish > (8 + Start)) { Finish = (8 + Start); }
+		if (Finish > 8 + Start) { Finish = 8 + Start; }
 		
 		DWORD Value = 0;
 		for (size_t i = Start; i < Finish; i++)

--- a/Source/Project64/User Interface/WTL Controls/numberctrl.h
+++ b/Source/Project64/User Interface/WTL Controls/numberctrl.h
@@ -187,7 +187,8 @@ protected:
 		
 		if (uMsg == WM_CHAR)
 		{
-			int MaxLen = 30;
+			size_t MaxLen = 30;
+
 			if (m_DisplayType == DisplayHex)
 			{
 				MaxLen = 8;
@@ -229,7 +230,7 @@ protected:
 				}
 				return true;
 			}
-			else if ( c >= 48 && c<= 57 || c >= 'A' && c<= 'F')
+			else if (c >= '0' && c <= '9' || c >= 'A' && c <= 'F')
 			{
 				if (Len >= MaxLen && start == end)
 				{


### PR DESCRIPTION
warning fixes for the 32-bit build

No reason to fix 64-bit warnings because you risk breaking the build's functionality even more without the ability to test it / isolate what the genuine fix really is first, so only 32-bit warnings fixed.

The fourth commit name:
"[Project64] fixed warning C4100: unreferenced formal parameter"
I was supposed to say [zlib] not [Project64].