### PR TITLE
Fix threading problem with AiUpdate

### DIFF
--- a/Source/Project64/Plugins/Audio Plugin.cpp
+++ b/Source/Project64/Plugins/Audio Plugin.cpp
@@ -135,7 +135,7 @@ bool CAudioPlugin::Initiate(CN64System * System, CMainGui * RenderWindow)
 
 	if (System != NULL)
 	{
-		if (AiUpdate)
+		if (AiUpdate && !m_hAudioThread)
 		{ 
 			m_hAudioThread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)AudioThread, (LPVOID)this, 0, &ThreadID);
 		}


### PR DESCRIPTION
When you reset a game or switch to another game, it keep creating a new
thread even if one already exists. This can cause the emulator to crash.