### PR TITLE
[RSP] guessing an enumerated list may be more maintainable here?

### DIFF
--- a/Source/RSP/Interpreter CPU.h
+++ b/Source/RSP/Interpreter CPU.h
@@ -24,17 +24,19 @@
  *
  */
 
-#define NORMAL				    0
-#define DO_DELAY_SLOT 			1
-#define DELAY_SLOT 				2
-#define DELAY_SLOT_DONE			3
-#define DELAY_SLOT_EXIT			4
-#define DELAY_SLOT_EXIT_DONE	5
-#define JUMP	 				6
-#define SINGLE_STEP	 		    7
-#define SINGLE_STEP_DONE		8
-#define FINISH_BLOCK			9
-#define FINISH_SUB_BLOCK		10
+enum {
+    NORMAL,
+    DO_DELAY_SLOT,
+    DELAY_SLOT,
+    DELAY_SLOT_DONE,
+    DELAY_SLOT_EXIT,
+    DELAY_SLOT_EXIT_DONE,
+    JUMP,
+    SINGLE_STEP,
+    SINGLE_STEP_DONE,
+    FINISH_BLOCK,
+    FINISH_SUB_BLOCK
+};
 
 extern DWORD RSP_NextInstruction, RSP_JumpTo, RSP_MfStatusCount;
 


### PR DESCRIPTION
Now for my final OCD pull request before I take a good break from harassing the repo owner.

Looking at the interpret CPU header, none of the macros seem to need the exact integer they're defined to.  For example
```c
#define DO_DELAY_SLOT       1
```
It could be defined to 2, 3, 4, 9001, anything and still have the same effect (or so a brief scroll through the core code and testing my compiled changes from this PR with World Driver Championship suggests).

The nice thing about `enum`s is that all their values can be subtly but instantly updated without changing the actual line of text in a Git commit, but just their relative position to other lines in the enumerated list.  As long as each constant only needs a unique, arbitrary value (nothing in particular) then I think it sounds perfect that way.  It also avoids the potential language vulnerability issues of macros.