### PR TITLE
MemoryFilter support for 64-bit

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
@@ -10,6 +10,24 @@
 ****************************************************************************/
 #pragma once
 
+/*
+ * LPEXCEPTIONPOINTERS->CONTEXT needs to refer to the 64-bit Intel
+ * ISA registers when compiling as 64-bit.
+ */
+#if defined(_WIN64)
+#define Eax     Rax
+#define Ebx     Rbx
+#define Ecx     Rcx
+#define Edx     Rdx
+
+#define Esi     Rsi
+#define Edi     Rdi
+#define Ebp     Rbp
+#define Esp     Rsp
+
+#define Eip     Rip
+#endif
+
 class CMipsMemoryVM :
 	public CMipsMemory,
 	public CTransVaddr,


### PR DESCRIPTION
Whether porting to one thing or entirely another, this horrible function needs to somehow be made into something slightly less horrible.  I don't know why a function of this type of design should even exist in any emulator at all; therefore I don't fully understand all of its design and propose simply the idea until it's really taken care of.

So if this micro step to supporting this feature in 64-bit is too big or too small to be proper, then what is the proper way to change it?