### PR TITLE
Fix LoadState audio issue with Fixed Audio Timing

### DIFF
--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -1747,6 +1747,11 @@ bool CN64System::LoadState(LPCSTR FileName)
 		g_Reg->MI_INTR_REG |= MI_INTR_AI;
 	}
 	
+	if (bFixedAudio())
+	{
+		m_Audio.SetFrequency(m_Reg.AI_DACRATE_REG, g_System->SystemType());
+	}
+	
 	//Fix Random Register
 	while ((int)m_Reg.RANDOM_REGISTER < (int)m_Reg.WIRED_REGISTER)
 	{


### PR DESCRIPTION
When Fixed Audio Timing was enabled and AI count per byte = 0, the
frequency was not being properly set, after loading a save state.