### PR TITLE
Make Glide64 default video plugin.

### DIFF
--- a/Source/Project64/Settings/Settings Class.cpp
+++ b/Source/Project64/Settings/Settings Class.cpp
@@ -311,7 +311,7 @@ void CSettings::AddHowToHandleSetting ()
 
 	//Plugin
 	AddHandler(Plugin_RSP_Current,   new CSettingTypeApplication("Plugin","RSP Dll",       "RSP\\RSP 1.7.dll"));
-	AddHandler(Plugin_GFX_Current,   new CSettingTypeApplication("Plugin","Graphics Dll",  "GFX\\Jabo_Direct3D8.dll"));
+	AddHandler(Plugin_GFX_Current,   new CSettingTypeApplication("Plugin","Graphics Dll",  "GFX\\PJ64Glide64.dll"));
 	AddHandler(Plugin_AUDIO_Current, new CSettingTypeApplication("Plugin","Audio Dll",     "Audio\\Jabo_Dsound.dll"));
 	AddHandler(Plugin_CONT_Current,  new CSettingTypeApplication("Plugin","Controller Dll","Input\\PJ64_NRage.dll"));
 


### PR DESCRIPTION
This is a rather tricky PR request. I don't expect it to be merged straight away, if at all, since changing the plugin setting is only the first step. In my humble opinion, Glide64 should be the default plugin. And it should be treated as the compatibility baseline, especially in the RDB. So if @project64 approves of this change, I would like to remove all the game descriptions such as "bad graphics in menus - use Glide64". -- since the default would now be Glide64.

In the absence of a truly decent LLE plugin like z64 or the software accurate plugin or whatever, it may be necessary, or at least prudent, to set Jabo's as the default plugin on a per-game basis for those games that require LLE graphics.