### PR TITLE
Copy V8 combiner from GLideN64 to Glide64.

### DIFF
--- a/Source/Glide64/Combine.cpp
+++ b/Source/Glide64/Combine.cpp
@@ -15901,7 +15901,11 @@ void CombineBlender ()
       }
       A_BLEND (GR_BLEND_SRC_ALPHA, GR_BLEND_ONE);
       break;
-
+      
+      case 0x5000: /* Vigilante 8 explosions */
+      A_BLEND (GR_BLEND_ONE_MINUS_SRC_ALPHA, GR_BLEND_SRC_ALPHA);
+      break;
+            
     default:
       A_BLEND (GR_BLEND_SRC_ALPHA, GR_BLEND_ONE_MINUS_SRC_ALPHA);
     }


### PR DESCRIPTION
This isn't hugely useful, since Vigilante 8 is a complete mess on Glide64, but this fixes one graphics issue.