### PR TITLE
cleaner RdramChanged algorithm (not biased to only 4 vs. 8 MB)

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -5386,14 +5386,12 @@ void CMipsMemoryVM::RdramChanged ( CMipsMemoryVM * _this )
 			WriteTrace(TraceError,__FUNCTION__ ": failed to allocate extended memory");
 			g_Notify->FatalError(GS(MSG_MEM_ALLOC_ERROR));
 		}
-		_this->m_AllocatedRdramSize = 0x800000;
 	}
 	else
 	{
 		VirtualFree(_this->m_RDRAM + 0x400000, 0x400000,MEM_DECOMMIT);
-		_this->m_AllocatedRdramSize = 0x400000;
 	}
-
+	_this->m_AllocatedRdramSize = new_size;
 }
 
 void CMipsMemoryVM::ChangeSpStatus()

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -5379,15 +5379,27 @@ void CMipsMemoryVM::RdramChanged ( CMipsMemoryVM * _this )
 	{
 		return;
 	}
-	if (old_size == 0x800000)
+	if (old_size > new_size)
 	{
-		VirtualFree(_this->m_RDRAM + 0x400000, 0x400000, MEM_DECOMMIT);
+		VirtualFree(
+			_this->m_RDRAM + new_size,
+			old_size - new_size,
+			MEM_DECOMMIT
+		);
 	}
 	else
-	{ 
-		if (VirtualAlloc(_this->m_RDRAM + 0x400000, 0x400000, MEM_COMMIT, PAGE_READWRITE)==NULL)
+	{
+		void * result;
+
+		result = VirtualAlloc(
+			_this->m_RDRAM + old_size,
+			new_size - old_size,
+			MEM_COMMIT,
+			PAGE_READWRITE
+		);
+		if (result == NULL)
 		{
-			WriteTrace(TraceError,__FUNCTION__ ": failed to allocate extended memory");
+			WriteTrace(TraceError, __FUNCTION__":  failed to allocate extended memory");
 			g_Notify -> FatalError(GS(MSG_MEM_ALLOC_ERROR));
 		}
 	}

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -5379,17 +5379,17 @@ void CMipsMemoryVM::RdramChanged ( CMipsMemoryVM * _this )
 	{
 		return;
 	}
-	if (old_size == 0x400000)
+	if (old_size == 0x800000)
+	{
+		VirtualFree(_this->m_RDRAM + 0x400000, 0x400000, MEM_DECOMMIT);
+	}
+	else
 	{ 
 		if (VirtualAlloc(_this->m_RDRAM + 0x400000, 0x400000, MEM_COMMIT, PAGE_READWRITE)==NULL)
 		{
 			WriteTrace(TraceError,__FUNCTION__ ": failed to allocate extended memory");
-			g_Notify->FatalError(GS(MSG_MEM_ALLOC_ERROR));
+			g_Notify -> FatalError(GS(MSG_MEM_ALLOC_ERROR));
 		}
-	}
-	else
-	{
-		VirtualFree(_this->m_RDRAM + 0x400000, 0x400000,MEM_DECOMMIT);
 	}
 	_this->m_AllocatedRdramSize = new_size;
 }

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -5372,11 +5372,14 @@ void CMipsMemoryVM::TLB_Unmaped( DWORD Vaddr, DWORD Len )
 
 void CMipsMemoryVM::RdramChanged ( CMipsMemoryVM * _this )
 {
-	if (_this->m_AllocatedRdramSize == g_Settings->LoadDword(Game_RDRamSize))
+	const size_t new_size = g_Settings -> LoadDword(Game_RDRamSize);
+	const size_t old_size = _this -> m_AllocatedRdramSize;
+
+	if (old_size == new_size)
 	{
 		return;
 	}
-	if (_this->m_AllocatedRdramSize == 0x400000)
+	if (old_size == 0x400000)
 	{ 
 		if (VirtualAlloc(_this->m_RDRAM + 0x400000, 0x400000, MEM_COMMIT, PAGE_READWRITE)==NULL)
 		{


### PR DESCRIPTION
It's just confusing to see arbitrary values like 0x400000 or 0x800000 scattered through if/else.

Should it be `if (old_size == 0x400000)`, `if (old_size != 0x800000)`, `if (old_size > 0x400000)` ... none of those are clear to what's meant for the function to do.

To be more intelligent the function should really only be caring to VirtualFree/VirtualAlloc based on this:
```c
if (old < new) {
    /* re-allocate RDRAM[old] extended up to RDRAM[new] */
} else if (old == new) {
    return;
} else {
    /* re-allocate RDRAM[old] freed down to RDRAM[new] */
}
```