### PR TITLE
Implement edge case in SPECIAL_DSRL32

### DIFF
--- a/Source/Project64/N64 System/Recompiler/Recompiler Ops.cpp
+++ b/Source/Project64/N64 System/Recompiler/Recompiler Ops.cpp
@@ -3933,9 +3933,16 @@ void CRecompilerOps::SPECIAL_DSRL32() {
 	if (IsConst(m_Opcode.rt)) {
 		if (m_Opcode.rt != m_Opcode.rd)
 			UnMap_GPR(m_Opcode.rd, false);
-
-		m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_ZERO);
-		m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd, (DWORD)(GetMipsReg(m_Opcode.rt) >> (m_Opcode.sa + 32)));
+		
+		if (m_Opcode.sa == 0) {
+			MIPS_DWORD Value;
+			Value.UW[0] = Value.UW[1] = GetMipsRegHi(m_Opcode.rt);
+			m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_64);
+			m_RegWorkingSet.SetMipsReg(m_Opcode.rd, Value.UDW);
+		} else {
+			m_RegWorkingSet.SetMipsRegState(m_Opcode.rd,CRegInfo::STATE_CONST_32_ZERO);
+			m_RegWorkingSet.SetMipsRegLo(m_Opcode.rd, (DWORD)(GetMipsReg(m_Opcode.rt) >> (m_Opcode.sa + 32)));
+		}
 	} else if (IsMapped(m_Opcode.rt)) {
 		ProtectGPR(m_Opcode.rt);
 		if (Is64Bit(m_Opcode.rt)) {


### PR DESCRIPTION
When m_Opcode.sa == 0, the results for cpu recompiler do not match cpu
interpreter. For example with dsrl32 t9, t8, 0x0, and t8 =
0xC0C0C0C000000000 the result of t9 for cpu recompiler =
0xFFFFFFFFC0C0C0C0, while cpu interpreter = 0xC0C0C0C0C0C0C0C0.

This commit fixes the Killer Instinct health bar issue.