### PR TITLE
Fix ROM Browser for network shares

### DIFF
--- a/Source/Common/path.cpp
+++ b/Source/Common/path.cpp
@@ -1022,7 +1022,7 @@ void CPath::cleanPathString(stdstr& rDirectory) const
 	pos = rDirectory.find( DIR_DOUBLEDELIM );
 	while ( pos != std::string::npos )
 	{
-		rDirectory.replace( pos, 1, &DIRECTORY_DELIMITER );
+		rDirectory.replace( pos, 2, &DIRECTORY_DELIMITER );
 		pos = rDirectory.find( DIR_DOUBLEDELIM, pos + 1 );
 	}
 	if (AppendEnd)


### PR DESCRIPTION
This part of cleanPathString was supposed to de-dupe backslashes in the directory name, and then insert a backslash to the start of directory if the directory originally started with \\ (so that the string again started with \\).  However, because the call to rDirectory.replace was specifying a length of 1, it was always replacing \ with \ instead of replacing \\ with \.  When the backslash was then inserted at the start of the directory, the directory string now began with \\\ instead of \\.  This broke the ROM browser when using a network share (such as \\myserver\Emulation\Games).