### PR TITLE
Make Mempak use core instead of plugin by default.

### DIFF
--- a/Source/nragev20/configs/Controller1.cpf
+++ b/Source/nragev20/configs/Controller1.cpf
@@ -1,5 +1,5 @@
 Plugged=1
-RawData=1
+RawData=0
 PakType=1
 RealN64Range=1
 RapidFireEnabled=0


### PR DESCRIPTION
This is kinda crude, but this should fix PJ64 complaining about missing mem pak files in certain situations\configurations.