### PR TITLE
reduced the compiler errors if building w/ VS2008 Express

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Class.h
+++ b/Source/Project64/N64 System/Mips/Memory Class.h
@@ -10,6 +10,15 @@
 ****************************************************************************/
 #pragma once
 
+/*
+ * If compiling without ATL included, MSVC could mis-treat `interface` as a
+ * built-in keyword, but what we want essentially is a structure.
+ */
+//#undef interface
+#ifndef interface
+#define interface       struct
+#endif
+
 interface CMipsMemory_CallBack 
 {
 	//Protected memory has been written to, returns true if that memory has been unprotected


### PR DESCRIPTION
Let me know if there is something I did incorrectly or overlooked with this change.

The idea is to start slight adjustments to be flexible to the possibility of building on some other platforms besides Microsoft Windows (or at least with the full desktop features), as well as potentially be able to compile Project64 with just the lightweight Express editions of Visual Studio installed.