### PR TITLE
re-did pull request #565 a safer way

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Class.h
+++ b/Source/Project64/N64 System/Mips/Memory Class.h
@@ -10,14 +10,7 @@
 ****************************************************************************/
 #pragma once
 
-/*
- * If compiling without ATL included, MSVC could mis-treat `interface` as a
- * built-in keyword, but what we want essentially is a structure.
- */
-//#undef interface
-#ifndef interface
-#define interface       struct
-#endif
+#include <objbase.h>
 
 interface CMipsMemory_CallBack 
 {


### PR DESCRIPTION
Earlier I sent this PR to fix a few errors when compiling in VS2008 Express, where WTL is unavailable.

I didn't really like my fix because, as with any macro-based solution, it potentially could risk macro collision and "redefinition" warnings, if by some unlucky chance the correct header file defined `interface` later on after manually defining it myself with my macro magic.

Fortunately it turns out, there is a better way.
```c
#include <objbase.h>
```
I can confirm that MinGW, VS2008 Express, and VS2013 Community all support the exposure of Microsoft's `interface` macro through this header in the same way, so this seems to be safer.