### PR TITLE
Make sure main.cpp does include <tchar.h>.

### DIFF
--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include <tchar.h>
 #include <Tlhelp32.h>
 
 CTraceFileLog * LogFile = NULL;


### PR DESCRIPTION
Fixes more VS2008 Express compiler errors, this time in `main.cpp`, because the main source file uses the `_T()` macro a few times.

The errors don't happen on non-Express VS because there you have access to WTL and ATL, so:
* `afxres.h` includes `User Interface.h`,
* which includes `WTL App.h`,
* which includes `<atlbase.h>`,
* which includes `<atlcomcli.h>`,
* which includes `<atlcore.h>`,
* which **finally** includes `<tchar.h>`.

But to port to other platforms, or compile in VS2008 Express, `main.cpp` needs to be independent of WTL or such things, when it's really just the functions and features from `<tchar.h>` that it needs.