### PR TITLE
removed some surviving remnants of old Unicode refs

### DIFF
--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -22,7 +22,7 @@ void InitializeLog ( void)
 	{
 		LogFilePath.CreateDirectory();
 	}
-	LogFilePath.SetNameExtension(_T("Project64.log"));
+	LogFilePath.SetNameExtension("Project64.log");
 
 	LogFile = new CTraceFileLog(LogFilePath, g_Settings->LoadDword(Debugger_AppLogFlush) != 0, Log_New,500);
 #ifdef VALIDATE_DEBUG
@@ -97,7 +97,7 @@ void InitializeLog ( void)
 void FixDirectories ( void )
 {
 	CPath Directory(CPath::MODULE_DIRECTORY);
-	Directory.AppendDirectory(_T("Config"));
+	Directory.AppendDirectory("Config");
 	if (!Directory.DirectoryExists()) Directory.CreateDirectory();
 
 	Directory.UpDirectory();


### PR DESCRIPTION
When ATL or WTL is included, `<tchar.h>` is implicitly included.  By using VS Express 2008 (which has no available WTL and cannot include that), I saw these errors in `main.cpp` which seemed to be references to old Unicode (constant 16 bits per char, afaik) code which no longer is desired.  So by removing those the errors when compiling without WTL or with VS2008 Express are further reduced even more.

Related:  old PR where I misperceived that tchar.h was intended, https://github.com/project64/project64/pull/567