### PR TITLE
Propose a breakpoint in TranslateVaddr #ifdef _WIN64.

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -528,6 +528,15 @@ bool CMipsMemoryVM::TranslateVaddr ( DWORD VAddr, DWORD &PAddr) const
 	{
 		return false;
 	}
+
+	if (sizeof(void *) > sizeof(DWORD))
+	{
+/*
+ * might need to change TranslateVAddr to require PAddr to be a size_t, not a
+ * DWORD, to get a re-compiler in 64-bit (possibly other core features?)
+ */
+		g_Notify -> BreakPoint(__FILEW__, __LINE__);
+	}
 	PAddr = (DWORD)((BYTE *)(m_TLB_ReadMap[VAddr >> 12] + VAddr) - m_RDRAM);
 	return true;
 }

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -529,14 +529,13 @@ bool CMipsMemoryVM::TranslateVaddr ( DWORD VAddr, DWORD &PAddr) const
 		return false;
 	}
 
-	if (sizeof(void *) > sizeof(DWORD))
-	{
 /*
  * might need to change TranslateVAddr to require PAddr to be a size_t, not a
  * DWORD, to get a re-compiler in 64-bit (possibly other core features?)
  */
-		g_Notify -> BreakPoint(__FILEW__, __LINE__);
-	}
+#if defined(_M_X64) || defined(_WIN64)
+	g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 	PAddr = (DWORD)((BYTE *)(m_TLB_ReadMap[VAddr >> 12] + VAddr) - m_RDRAM);
 	return true;
 }


### PR DESCRIPTION
Since this only seems to really affect the ability to have a recompiler, I don't really care that much about this now.  I was under the initial concern that it affected the completeness of being able to run the interpreter in 64-bit (seems to not ever get reached).

However it was a part of my original pull request:  https://github.com/project64/project64/pull/530
So for that reason I have it split to this one.