### PR TITLE
more Unicode compile ref. errors to _T() fixed

### DIFF
--- a/Source/Project64/Multilanguage/Language Class.cpp
+++ b/Source/Project64/Multilanguage/Language Class.cpp
@@ -765,7 +765,7 @@ LRESULT CALLBACK LangSelectProc (HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 				CLIP_DEFAULT_PRECIS,
 				PROOF_QUALITY,
 				DEFAULT_PITCH|FF_DONTCARE,
-				_T("Arial")
+				"Arial"
 			);
 			SendDlgItemMessage(hDlg,IDC_SELECT_LANG,WM_SETFONT,(WPARAM)hTextFont,TRUE);
 		}

--- a/Source/Project64/N64 System/C Core/Logging.cpp
+++ b/Source/Project64/N64 System/C Core/Logging.cpp
@@ -896,8 +896,8 @@ void StartLog (void)
 	}
 
 	CPath LogFile(CPath::MODULE_DIRECTORY);
-	LogFile.AppendDirectory(_T("Logs"));
-	LogFile.SetNameExtension(_T("cpudebug.log"));
+	LogFile.AppendDirectory("Logs");
+	LogFile.SetNameExtension("cpudebug.log");
 		
 	hLogFile = CreateFile(LogFile,GENERIC_WRITE, FILE_SHARE_READ,NULL,CREATE_ALWAYS,
 		FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);

--- a/Source/Project64/N64 System/Recompiler/x86CodeLog.cpp
+++ b/Source/Project64/N64 System/Recompiler/x86CodeLog.cpp
@@ -31,7 +31,7 @@ void Start_x86_Log (void) {
 
 	CPath LogFileName(CPath::MODULE_DIRECTORY);
 	LogFileName.AppendDirectory("Logs");
-	LogFileName.SetNameExtension(_T("CPUoutput.log"));
+	LogFileName.SetNameExtension("CPUoutput.log");
 		
 	if (hCPULogFile) { Stop_x86_Log(); }
 	hCPULogFile = CreateFile(LogFileName,GENERIC_WRITE, FILE_SHARE_READ|FILE_SHARE_WRITE,NULL,

--- a/Source/Project64/User Interface/Gui Class.cpp
+++ b/Source/Project64/User Interface/Gui Class.cpp
@@ -1057,7 +1057,7 @@ DWORD CALLBACK AboutBoxProc (HWND hWnd, DWORD uMsg, DWORD wParam, DWORD lParam)
 				CLIP_DEFAULT_PRECIS,
 				PROOF_QUALITY,
 				DEFAULT_PITCH|FF_DONTCARE,
-				_T("Arial")
+				"Arial"
 			);
 
 			hAuthorFont = ::CreateFont
@@ -1075,7 +1075,7 @@ DWORD CALLBACK AboutBoxProc (HWND hWnd, DWORD uMsg, DWORD wParam, DWORD lParam)
 				CLIP_DEFAULT_PRECIS,
 				PROOF_QUALITY,
 				DEFAULT_PITCH|FF_DONTCARE,
-				_T("Arial")
+				"Arial"
 			);
 
 			hPageHeadingFont = ::CreateFont
@@ -1093,7 +1093,7 @@ DWORD CALLBACK AboutBoxProc (HWND hWnd, DWORD uMsg, DWORD wParam, DWORD lParam)
 				CLIP_DEFAULT_PRECIS,
 				PROOF_QUALITY,
 				DEFAULT_PITCH|FF_DONTCARE,
-				_T("Arial Bold")
+				"Arial Bold"
 			);
 
 			SendDlgItemMessage(hWnd,IDC_VERSION,WM_SETFONT,(WPARAM)hTextFont,TRUE);


### PR DESCRIPTION
Some more Unicode compile errors that have cumulatively cropped up from continued attempts at a working VS2008 Express build environment.

I still doubt that I've gotten them all, just all the ones in the current build errors list so far.