### PR TITLE
Include some system headers explicitly to fix non-ATL builds.

### DIFF
--- a/Source/Project64/N64 System/C Core/Logging.cpp
+++ b/Source/Project64/N64 System/C Core/Logging.cpp
@@ -10,6 +10,8 @@
 ****************************************************************************/
 #include "stdafx.h"
 
+#include <prsht.h>
+
 void LoadLogSetting (HKEY hKey,char * String, BOOL * Value);
 void SaveLogOptions (void);
 

--- a/Source/Project64/N64 System/Cheat Class.cpp
+++ b/Source/Project64/N64 System/Cheat Class.cpp
@@ -11,6 +11,7 @@
 #include "stdafx.h"
 
 #include <commctrl.h>
+#include <windowsx.h>
 #include "Settings/SettingType/SettingsType-Cheats.h"
 
 enum { WM_EDITCHEAT           = WM_USER + 0x120 };

--- a/Source/Project64/N64 System/Cheat Class.cpp
+++ b/Source/Project64/N64 System/Cheat Class.cpp
@@ -10,6 +10,7 @@
 ****************************************************************************/
 #include "stdafx.h"
 
+#include <commctrl.h>
 #include "Settings/SettingType/SettingsType-Cheats.h"
 
 enum { WM_EDITCHEAT           = WM_USER + 0x120 };

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -13,6 +13,7 @@
 #pragma warning(disable:4355) // Disable 'this' : used in base member initializer list
 
 #include <windows.h>
+#include <commdlg.h>
 
 CN64System::CN64System ( CPlugins * Plugins, bool SavesReadOnly ) :
 	CSystemEvents(this, Plugins),

--- a/Source/Project64/User Interface/Gui Class.cpp
+++ b/Source/Project64/User Interface/Gui Class.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#include <commctrl.h>
 #include "Settings/SettingType/SettingsType-Application.h"
 
 extern "C" 

--- a/Source/Project64/User Interface/Main Menu Class.cpp
+++ b/Source/Project64/User Interface/Main Menu Class.cpp
@@ -1,5 +1,8 @@
 #include "stdafx.h"
 
+#include <windows.h>
+#include <commdlg.h>
+
 CMainMenu::CMainMenu ( CMainGui * hMainWindow ):
 	CBaseMenu(),
     m_ResetAccelerators(true)

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 
+#include <commctrl.h>
+
 CRomBrowser::CRomBrowser (HWND & MainWindow, HWND & StatusWindow ) :
 	m_MainWindow(MainWindow), 
 	m_StatusWindow(StatusWindow),

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 
 #include <commctrl.h>
+#include <shlobj.h>
 
 CRomBrowser::CRomBrowser (HWND & MainWindow, HWND & StatusWindow ) :
 	m_MainWindow(MainWindow), 

--- a/Source/Project64/User Interface/Settings Config.h
+++ b/Source/Project64/User Interface/Settings Config.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <commctrl.h>
+
 class CConfigSettingSection;
 class CSettingsPage;
 

--- a/Source/Project64/User Interface/Settings/Settings Page.h
+++ b/Source/Project64/User Interface/Settings/Settings Page.h
@@ -10,6 +10,8 @@
 ****************************************************************************/
 #pragma once
 
+#include <prsht.h>
+
 class CSettingsPage 
 {
 public:


### PR DESCRIPTION
Many of the thousands of compiler errors that ensue once I remove the inclusion of ATL and/or WTL interfaces are things like, not knowing what PSN_APPLY or LPCRECT is.

Those errors of course were just a matter of including other Windows API headers, like `<commctrl.h>`.  I guess that when ATL is included, that stuff was meant to be included implicitly.  Therefore I'm not really sure how much use this pull request is, practically, but I did want to give it a shot to see about simplifying the error list a bit, to help get a better understanding of just how much I might have to remove/replace to get a non-ATL VS Express build working.

Also not sure that I did it correctly.  I see a lot of `#include "afxres.h"` everywhere; maybe I was supposed to have all the includes put there instead?