### PR TITLE
Write to VI_V_CURRENT_LINE_REG

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -3426,6 +3426,7 @@ void CMipsMemoryVM::UpdateHalfLine()
 	m_HalfLine = (DWORD)(*g_NextTimer / g_System->ViRefreshRate());
 	m_HalfLine &= ~1;
 	m_HalfLine |= m_FieldSerration;
+	g_Reg->VI_V_CURRENT_LINE_REG = m_HalfLine;
 	m_HalfLineCheck = NextViTimer;
 }
 


### PR DESCRIPTION
As of now, it's never being written to, so graphics plugins do not have
any access to the value generated by the cpu core, for that register. z64gl reads this register, so that's why it has this screen shaking problem in certain games like Star Wars Rogue Squadron.