### PR TITLE
Improve LoadState

### DIFF
--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -1576,9 +1576,10 @@ bool CN64System::LoadState()
 
 bool CN64System::LoadState(LPCSTR FileName) 
 {
-	DWORD dwRead, Value,SaveRDRAMSize, NextVITimer = 0, old_status;
+	DWORD dwRead, Value,SaveRDRAMSize, NextVITimer = 0, old_status, old_width;
 	bool LoadedZipFile = false, AudioResetOnLoad;
 	old_status = g_Reg->VI_STATUS_REG;
+	old_width = g_Reg->VI_WIDTH_REG;
 	
 	WriteTraceF((TraceType)(TraceDebug | TraceRecompiler),__FUNCTION__ "(%s): Start",FileName);
 
@@ -1757,6 +1758,11 @@ bool CN64System::LoadState(LPCSTR FileName)
 	if (old_status != g_Reg->VI_STATUS_REG)
 	{
 		g_Plugins->Gfx()->ViStatusChanged();
+	}
+	
+	if (old_width != g_Reg->VI_WIDTH_REG)
+	{
+		g_Plugins->Gfx()->ViWidthChanged();
 	}
 	
 	//Fix Random Register

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -1576,9 +1576,10 @@ bool CN64System::LoadState()
 
 bool CN64System::LoadState(LPCSTR FileName) 
 {
-	DWORD dwRead, Value,SaveRDRAMSize, NextVITimer = 0;
+	DWORD dwRead, Value,SaveRDRAMSize, NextVITimer = 0, old_status;
 	bool LoadedZipFile = false, AudioResetOnLoad;
-
+	old_status = g_Reg->VI_STATUS_REG;
+	
 	WriteTraceF((TraceType)(TraceDebug | TraceRecompiler),__FUNCTION__ "(%s): Start",FileName);
 
 	char drive[_MAX_DRIVE] ,dir[_MAX_DIR], fname[_MAX_FNAME],ext[_MAX_EXT];
@@ -1751,6 +1752,11 @@ bool CN64System::LoadState(LPCSTR FileName)
 	if (bFixedAudio())
 	{
 		m_Audio.SetFrequency(m_Reg.AI_DACRATE_REG, g_System->SystemType());
+	}
+	
+	if (old_status != g_Reg->VI_STATUS_REG)
+	{
+		g_Plugins->Gfx()->ViStatusChanged();
 	}
 	
 	//Fix Random Register

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -1576,10 +1576,11 @@ bool CN64System::LoadState()
 
 bool CN64System::LoadState(LPCSTR FileName) 
 {
-	DWORD dwRead, Value,SaveRDRAMSize, NextVITimer = 0, old_status, old_width;
+	DWORD dwRead, Value,SaveRDRAMSize, NextVITimer = 0, old_status, old_width, old_dacrate;
 	bool LoadedZipFile = false, AudioResetOnLoad;
 	old_status = g_Reg->VI_STATUS_REG;
 	old_width = g_Reg->VI_WIDTH_REG;
+	old_dacrate = g_Reg->AI_DACRATE_REG;
 	
 	WriteTraceF((TraceType)(TraceDebug | TraceRecompiler),__FUNCTION__ "(%s): Start",FileName);
 
@@ -1763,6 +1764,11 @@ bool CN64System::LoadState(LPCSTR FileName)
 	if (old_width != g_Reg->VI_WIDTH_REG)
 	{
 		g_Plugins->Gfx()->ViWidthChanged();
+	}
+	
+	if (old_dacrate != g_Reg->AI_DACRATE_REG)
+	{
+		g_Plugins->Audio()->DacrateChanged(g_System->SystemType());
 	}
 	
 	//Fix Random Register


### PR DESCRIPTION
These commits fix issues where the value of certain registers change after loading a save state, while the plugin is relying on the emulator to call particular functions when the values of these registers change.