### PR TITLE
PIF RAM mutual DMA x64 breakpoints replaced with fast C

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -40,7 +40,7 @@ CMipsMemoryVM::CMipsMemoryVM( CMipsMemory_CallBack * CallBack, bool SavesReadOnl
 	m_IMEM       = NULL;
 }
 
-static unsigned long swap32by8(unsigned long word)
+unsigned long swap32by8(unsigned long word)
 {
     const unsigned long swapped =
 #if defined(_MSC_VER)

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
@@ -10,6 +10,8 @@
 ****************************************************************************/
 #pragma once
 
+extern unsigned long swap32by8(unsigned long word);
+
 class CMipsMemoryVM :
 	public CMipsMemory,
 	public CTransVaddr,

--- a/Source/Project64/N64 System/Mips/Pif Ram.cpp
+++ b/Source/Project64/N64 System/Mips/Pif Ram.cpp
@@ -302,34 +302,14 @@ void CPifRam::SI_DMA_READ()
 	}
 	else
 	{
-#ifdef _M_IX86
-		_asm
+		size_t i;
+
+		for (i = 0; i < 64; i += 4)
 		{
-			mov edi, dword ptr [SI_DRAM_ADDR_REG]
-			mov edi, dword ptr [edi]
-			add edi, RDRAM
-			mov ecx, PifRamPos
-			mov edx, 0		
-	memcpyloop:
-			mov eax, dword ptr [ecx + edx]
-			bswap eax
-			mov  dword ptr [edi + edx],eax
-			mov eax, dword ptr [ecx + edx + 4]
-			bswap eax
-			mov  dword ptr [edi + edx + 4],eax
-			mov eax, dword ptr [ecx + edx + 8]
-			bswap eax
-			mov  dword ptr [edi + edx + 8],eax
-			mov eax, dword ptr [ecx + edx + 12]
-			bswap eax
-			mov  dword ptr [edi + edx + 12],eax
-			add edx, 16
-			cmp edx, 64
-			jb memcpyloop
+			*(unsigned __int32 *)&RDRAM[SI_DRAM_ADDR_REG + i] = swap32by8(
+				*(unsigned __int32 *)&PifRamPos[i]
+			);
 		}
-#else
-		g_Notify->BreakPoint(__FILEW__,__LINE__);
-#endif
 	}
 	
 	if (LogOptions.LogPRDMAMemStores)
@@ -413,34 +393,14 @@ void CPifRam::SI_DMA_WRITE()
 	}
 	else
 	{
-#ifdef _M_IX86
-		_asm
+		size_t i;
+
+		for (i = 0; i < 64; i += 4)
 		{
-			mov ecx, dword ptr [SI_DRAM_ADDR_REG]
-			mov ecx, dword ptr [ecx]
-			add ecx, RDRAM
-			mov edi, PifRamPos
-			mov edx, 0		
-	memcpyloop:
-			mov eax, dword ptr [ecx + edx]
-			bswap eax
-			mov  dword ptr [edi + edx],eax
-			mov eax, dword ptr [ecx + edx + 4]
-			bswap eax
-			mov  dword ptr [edi + edx + 4],eax
-			mov eax, dword ptr [ecx + edx + 8]
-			bswap eax
-			mov  dword ptr [edi + edx + 8],eax
-			mov eax, dword ptr [ecx + edx + 12]
-			bswap eax
-			mov  dword ptr [edi + edx + 12],eax
-			add edx, 16
-			cmp edx, 64
-			jb memcpyloop
+			*(unsigned __int32 *)&PifRamPos[i] = swap32by8(
+				*(unsigned __int32 *)&RDRAM[SI_DRAM_ADDR_REG + i]
+			);
 		}
-#else
-		g_Notify->BreakPoint(__FILEW__,__LINE__);
-#endif
 	}
 	
 	if (LogOptions.LogPRDMAMemLoads)


### PR DESCRIPTION
Not my favorite commit to make, since pointer typecasts of this type break strict aliasing rules and may make the functionality of Project64 vulnerable to bugs in theoretical, future ports to less popular systems.  (I could have avoided these casts but figured the asm was written to force win32 performance so didn't feel like bothering with the minor chance of what would happen if the better C code didn't optimize.)

Sorry about the C extern function, but until instructed otherwise by zilmar in this pull request, that is the only way I know of to get this job done.  I don't know how to install it/define it inside one of the C++ classes or whether that's even what people want, though I will follow any necessary instructions.

Anyway, results--using the _Basic CFB Plugin_ from 2000:
![cd64mem_x64](https://cloud.githubusercontent.com/assets/1396303/9720360/50cd8ff6-555b-11e5-82fe-1260161d13a5.png)
![neon64_x64](https://cloud.githubusercontent.com/assets/1396303/9720369/608bbcce-555b-11e5-8276-b5f21ed22cf5.png)
![sp_crap_x64](https://cloud.githubusercontent.com/assets/1396303/9720405/ac82901c-555b-11e5-99f1-2a0d5d3ccbdc.png)
![bomberman_x64](https://cloud.githubusercontent.com/assets/1396303/9720381/81e96f88-555b-11e5-976e-f698929e9406.png)