### PR TITLE
got it compiling on Express

### DIFF
--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Debugger UI.h"
 
 CDumpMemory::CDumpMemory(CDebugger * debugger) :
@@ -593,3 +595,4 @@ bool CDumpMemory::DumpMemory ( LPCSTR FileName,DumpFormat Format, DWORD StartPC,
 //	}
 //	return false;
 //}
+#endif

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Search.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Search.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Debugger UI.h"
 
 CDebugMemorySearch::CDebugMemorySearch(CDebugger * debugger) :
@@ -787,3 +789,4 @@ bool CDebugMemorySearch::SearchForValue (DWORD Value, MemorySize Size, DWORD &St
 	}
 	return false;
 }
+#endif

--- a/Source/Project64/N64 System/Debugger/Debugger - TLB.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - TLB.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Debugger UI.h"
 
 CDebugTlb::CDebugTlb(CDebugger * debugger) :
@@ -285,3 +287,4 @@ void CDebugTlb::RefreshTLBWindow (void)
 		}
 	}
 }
+#endif

--- a/Source/Project64/N64 System/Debugger/Debugger - View Memory.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - View Memory.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Debugger UI.h"
 
 CDebugMemoryView::CDebugMemoryView(CDebugger * debugger) :
@@ -470,3 +472,4 @@ void CDebugMemoryView::RefreshMemory ( bool ResetCompare )
 		Insert_MemoryLineDump ( count );
 	}
 }
+#endif

--- a/Source/Project64/N64 System/Debugger/Debugger.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Debugger UI.h"
 
 CPj64Module _Module;
@@ -130,3 +132,4 @@ void CDebugger::Debug_ShowMemorySearch()
 		m_MemorySearch->ShowWindow();
 	}
 }
+#endif

--- a/Source/Project64/User Interface.h
+++ b/Source/Project64/User Interface.h
@@ -44,8 +44,14 @@ struct WINDOWS_PAINTSTRUCT {
 
 class CN64System;
 
+#define WINDOWS_UI
+// Remove this to test compilation outside of the Windows ATL environment.
+
+#ifdef WINDOWS_UI
 #include <WTL App.h>
+#endif
 #include <User Interface/MenuShortCuts.h>
+
 #include ".\\User Interface\\Rom Browser.h"
 #include ".\\User Interface\\Gui Class.h"
 #include ".\\User Interface\\Menu Class.h"
@@ -54,4 +60,6 @@ class CN64System;
 #include ".\\User Interface\\Notification Class.h"
 #include ".\\User Interface\\Frame Per Second Class.h"
 #include ".\\User Interface\\resource.h"
+#ifdef WINDOWS_UI
 #include ".\\User Interface\\Settings Config.h"
+#endif

--- a/Source/Project64/User Interface/Gui Class.cpp
+++ b/Source/Project64/User Interface/Gui Class.cpp
@@ -10,6 +10,7 @@
 ****************************************************************************/
 #include "stdafx.h"
 
+#ifdef WINDOWS_UI
 #include <commctrl.h>
 #include "Settings/SettingType/SettingsType-Application.h"
 
@@ -1253,3 +1254,4 @@ BOOL set_about_field(
         temp_string
     );
 }
+#endif

--- a/Source/Project64/User Interface/Main Menu Class.cpp
+++ b/Source/Project64/User Interface/Main Menu Class.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 
+#ifdef WINDOWS_UI
 #include <windows.h>
 #include <commdlg.h>
 
@@ -1240,3 +1241,4 @@ void CMainMenu::ResetMenu(void)
 
 	WriteTrace(TraceDebug,__FUNCTION__ ": Done");
 }
+#endif

--- a/Source/Project64/User Interface/Settings Config.cpp
+++ b/Source/Project64/User Interface/Settings Config.cpp
@@ -1,4 +1,6 @@
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Config.h"
 #include "Settings/Settings Page.h"
 #include "Settings/SettingType/SettingsType-Application.h"
@@ -339,4 +341,4 @@ void CSettingConfig::BoldChangedPages ( HTREEITEM hItem )
 		::EnableWindow(GetDlgItem(IDC_RESET_ALL), true);
 	}
 }
-
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page - Advanced Options.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Advanced Options.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 
 CAdvancedOptionsPage::CAdvancedOptionsPage (HWND hParent, const RECT & rcDispay )
@@ -70,3 +72,4 @@ void CAdvancedOptionsPage::ResetPage()
 {
 	CSettingsPageImpl<CAdvancedOptionsPage>::ResetPage();
 }
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page - Directories.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Directories.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 
 COptionsDirectoriesPage::COptionsDirectoriesPage (HWND hParent, const RECT & rcDispay ) :
@@ -351,3 +353,4 @@ void COptionsDirectoriesPage::ResetPage()
 
 	SendMessage(GetParent(),PSM_CHANGED,(WPARAM)m_hWnd,0);
 }
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - General.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - General.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 #include "Settings Page - Game - General.h"
 
@@ -113,3 +115,4 @@ void CGameGeneralPage::ResetPage()
 {
 	CSettingsPageImpl<CGameGeneralPage>::ResetPage();
 }
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - Plugin.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - Plugin.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 #include "Settings Page - Game - Plugin.h"
 
@@ -345,3 +347,4 @@ void CGamePluginPage::HleAudioChanged ( UINT /*Code*/, int id, HWND /*ctl*/ )
 		break;
 	}
 }
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - Recompiler.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - Recompiler.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 #include "Settings Page - Game - Recompiler.h"
 
@@ -94,3 +96,4 @@ void CGameRecompilePage::ResetPage()
 {
 	CSettingsPageImpl<CGameRecompilePage>::ResetPage();
 }
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - Status.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - Status.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 #include "Settings Page - Game - Status.h"
 
@@ -70,3 +72,4 @@ void CGameStatusPage::ResetPage()
 {
 	CSettingsPageImpl<CGameStatusPage>::ResetPage();
 }
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page - Game Browser.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game Browser.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 
 COptionsGameBrowserPage::COptionsGameBrowserPage (HWND hParent, const RECT & rcDispay ) :
@@ -253,3 +255,4 @@ void COptionsGameBrowserPage::ResetPage()
 	}
 	CSettingsPageImpl<COptionsGameBrowserPage>::ResetPage();
 }
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page - Keyboard Shortcuts.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Keyboard Shortcuts.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 
 COptionsShortCutsPage::COptionsShortCutsPage (HWND hParent, const RECT & rcDispay ) :
@@ -378,3 +380,4 @@ void COptionsShortCutsPage::ResetPage()
 	m_CurrentKeys.ResetContent();
 	CSettingsPageImpl<COptionsShortCutsPage>::ResetPage();
 }
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page - Options.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Options.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 
 CGeneralOptionsPage::CGeneralOptionsPage(CSettingConfig * SettingsConfig, HWND hParent, const RECT & rcDispay ) :
@@ -75,3 +77,4 @@ void CGeneralOptionsPage::OnBasicMode ( UINT Code, int id, HWND ctl )
 	CheckBoxChanged(Code,id,ctl);
 	m_SettingsConfig->UpdateAdvanced((int)::SendMessage(ctl, BM_GETCHECK, 0, 0) == 0);
 }
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page - Plugin.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Plugin.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 
 COptionPluginPage::COptionPluginPage (HWND hParent, const RECT & rcDispay )
@@ -331,3 +333,4 @@ void COptionPluginPage::HleAudioChanged ( UINT /*Code*/, int id, HWND /*ctl*/ )
 		break;
 	}
 }
+#endif

--- a/Source/Project64/User Interface/Settings/Settings Page.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page.cpp
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+
+#ifdef WINDOWS_UI
 #include "Settings Page.h"
 
 CConfigSettingSection::CConfigSettingSection( LPCWSTR PageTitle ) :
@@ -39,3 +41,4 @@ CSettingsPage * CConfigSettingSection::GetPage ( int PageNo )
 	}
 	return m_Pages[PageNo];
 }
+#endif

--- a/Source/Project64/User Interface/WTL Controls/ModifiedEditBox.cpp
+++ b/Source/Project64/User Interface/WTL Controls/ModifiedEditBox.cpp
@@ -10,6 +10,7 @@
 ****************************************************************************/
 #include "stdafx.h"
 
+#ifdef WINDOWS_UI
 CModifiedEditBox::CModifiedEditBox(bool bString /* = true */, HWND hWnd /* = NULL */) :
 	CEdit(hWnd),
 	m_Changed(false),
@@ -103,3 +104,4 @@ void CModifiedEditBox::SetTextField (HWND hWnd)
 		::SendMessage(m_TextField,WM_SETFONT,(WPARAM)m_BoldFont,0);
 	}
 }
+#endif

--- a/Source/Project64/User Interface/WTL Controls/PartialGroupBox.cpp
+++ b/Source/Project64/User Interface/WTL Controls/PartialGroupBox.cpp
@@ -10,6 +10,7 @@
 ****************************************************************************/
 #include "stdafx.h"
 
+#ifdef WINDOWS_UI
 BOOL CPartialGroupBox::Attach(HWND hWnd)
 {
 	ATLASSUME(m_hWnd == NULL);
@@ -118,5 +119,5 @@ void CPartialGroupBox::OnPaint(HDC /*hDC*/)
 
 		dc.DrawTextW(grptext,-1,fontrect,DT_SINGLELINE|DT_LEFT);
 	}
-
 }
+#endif

--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -178,7 +178,20 @@ const char * AppName ( void )
 	return Name.c_str();
 }
 
-int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /*lpszArgs*/, int /*nWinMode*/) 
+#ifndef WINDOWS_UI
+int main(int argc, char* argv[])
+{
+#error Cross-platform [graphical?] interface has not yet been implemented.
+// Remove this #error to compile, but linking will fail with about 10 errors.
+
+    while (argc >= 0)
+    {
+        puts(argv[--argc]);
+    }
+    return 0;
+}
+#else
+int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /*lpszArgs*/, int /*nWinMode*/)
 {
 	FixDirectories();
 
@@ -280,3 +293,4 @@ int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /
 	CloseTrace();
 	return true;
 }
+#endif


### PR DESCRIPTION
The unfortunate thing about this task is that there were hundreds of ways to do it.

It doesn't achieve the desired effect of organizing all the UI stuff away from the R4300 core code base, but it does mark all of the files at least which caused compilation to fail on VS2008 Express, by means of the `WINDOWS_UI` macro (apologies if the name was too generic; I can go back and change it).

Maybe this can help testing what can or can't be split of the UI from the rest of the things.