### PR TITLE
[RSP] bad DMEM offsets when (offset < 0)

### DIFF
--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -26,6 +26,8 @@
 
 #include <windows.h>
 #include <stdio.h>
+#include <stdlib.h>
+
 #include "opcode.h"
 #include "RSP.h"
 #include "CPU.h"
@@ -1090,11 +1092,12 @@ char * RSPLc2Name ( DWORD OpCode, DWORD PC )
 	{
 		sprintf(
 			CommandName,
-			"%s\t$v%d[%d], 0x%04X(%s)",
+			"%s\t$v%d[%d], %c0x%03X(%s)",
 			mnemonics_lwc2[command.rd],
 			command.rt,
 			command.del,
-			command.voffset,
+			(command.voffset < 0) ? '-' : '+',
+			abs(command.voffset),
 			GPR_Name(command.base)
 		);
 	}
@@ -1123,11 +1126,12 @@ char * RSPSc2Name ( DWORD OpCode, DWORD PC )
 	{
 		sprintf(
 			CommandName,
-			"%s\t$v%d[%d], 0x%04X(%s)",
+			"%s\t$v%d[%d], %c0x%03X(%s)",
 			mnemonics_swc2[command.rd],
 			command.rt,
 			command.del,
-			command.voffset,
+			(command.voffset < 0) ? '-' : '+',
+			abs(command.voffset),
 			GPR_Name(command.base)
 		);
 	}


### PR DESCRIPTION
Here is an old issue I forgot to close which we can fix right away:
https://github.com/project64/project64/issues/103

In this case I have changed the LWC2 and SWC2 instruction formatting string from:
```c
"%s\t$v%d[%d], 0x%04X(%s)"
```
to
```c
"%s\t$v%d[%d], %c0x%03X(%s)",
```

I changed from %04X to %03X because only DMEM offsets 0x000:0xFFF are reachable.

However strictly speaking the signed 7-bit offset can only range between -64:+63 decimal, so it could really be %02X and still be consistent.  Which is why I'm not even convinced that we really need signed hexadecimals for especially this when it could be signed decimals.  But it is a bug that the signed RSP offset value is being printed as stuff like 0xFFFFFFFF instead of just -0x001, as that is the point being addressed here.