### PR TITLE
Add Duke 64 Prototype to RDB.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1708,6 +1708,12 @@ Internal Name=DUKE NUKEM
 Status=Compatible
 Plugin Note=[video] depth problem; use Glide64
 
+[FF14C1DA-167FDE92-C:45]
+Good Name=Duke Nukem 64 (Prototype)
+Internal Name=duke
+Status=Compatible
+Plugin Note=[video] depth problem; use Glide64
+
 [1E12883D-D3B92718-C:46]
 Good Name=Duke Nukem 64 (F)
 Internal Name=DUKE NUKEM


### PR DESCRIPTION
There's an article about the prototype here. It's supposedly PAL, but the rom seems to have an NTSC header - so I'm confused.

http://www.nintendoplayer.com/prototype/duke-nukem-64/