### PR TITLE
[RSP] Scalar memory load/stores show signed hex offset.

### DIFF
--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -1228,10 +1228,11 @@ char * RSPOpcodeName ( DWORD OpCode, DWORD PC )
 	case RSP_SB:
 	case RSP_SH:
 	case RSP_SW:
-		sprintf(CommandName, "%s\t%s, 0x%04X(%s)",
+		sprintf(CommandName, "%s\t%s, %c0x%04X(%s)",
 			mnemonics_primary[command.op],
 			GPR_Name(command.rt),
-			command.offset,
+			((int16_t)command.offset < 0) ? '-' : '+',
+			abs((int16_t)command.offset),
 			GPR_Name(command.base)
 		);
 		break;


### PR DESCRIPTION
Forgot actually to do this before, but reminded now that #592 is merged which is related.

This time it's just the non-vector memory loads/stores in the RSP using signed hex for the offset.  I dislike the typecast (int16_t) hack I did here, but that really should be more of a temporary thing ideally if the struct bitfield were eventually to be changed from `unsigned offset : 16` to `signed offset : 16`.

Probably a more portable way would be `(offset & 0x8000u) ? (~offset + 1) & 0xFFFFu : offset`, but that would just look even uglier and force 2's compliment.