### PR TITLE
got it linking & running on VS2008 Express

### DIFF
--- a/Source/Project64/N64 System/C Core/Logging.cpp
+++ b/Source/Project64/N64 System/C Core/Logging.cpp
@@ -65,7 +65,11 @@ void EnterLogOptions(HWND hwndOwner)
     psh.pfnCallback = NULL;
 
     LoadLogOptions(&TempOptions,TRUE);
-	PropertySheet(&psh);
+#if defined(WINDOWS_UI)
+    PropertySheet(&psh);
+#else
+    g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
     SaveLogOptions();
 	LoadLogOptions(&LogOptions, FALSE);
 	return;

--- a/Source/Project64/N64 System/Cheat Class.cpp
+++ b/Source/Project64/N64 System/Cheat Class.cpp
@@ -988,6 +988,7 @@ int CALLBACK CCheats::CheatListProc (HWND hDlg,DWORD uMsg,DWORD wParam, DWORD lP
 			Style = GetWindowLong((HWND)_this->m_hCheatTree,GWL_STYLE);					
 			SetWindowLong((HWND)_this->m_hCheatTree,GWL_STYLE,TVS_CHECKBOXES |TVS_SHOWSELALWAYS| Style);
 
+#if defined(WINDOWS_UI)
 			//Creats an image list from the bitmap in the resource section
 			HIMAGELIST hImageList;
 			HBITMAP hBmp;
@@ -998,6 +999,9 @@ int CALLBACK CCheats::CheatListProc (HWND hDlg,DWORD uMsg,DWORD wParam, DWORD lP
 			DeleteObject(hBmp);
 			
 			TreeView_SetImageList((HWND)_this->m_hCheatTree,hImageList,TVSIL_STATE);
+#else
+			g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 
 			_this->m_hSelectedItem = NULL;
 

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -308,11 +308,15 @@ void  CN64System::StartEmulation2   ( bool NewThread )
 		{
 			g_Notify->DisplayMessage(5,L"Copy Plugins");
 			g_Plugins->CopyPlugins(g_Settings->LoadString(Directory_PluginSync));
+#if defined(WINDOWS_UI)
 			m_SyncWindow = new CMainGui(false);
 			m_SyncPlugins = new CPlugins( g_Settings->LoadString(Directory_PluginSync) ); 
 			m_SyncPlugins->SetRenderWindows(m_SyncWindow,m_SyncWindow);
 
 			m_SyncCPU = new CN64System(m_SyncPlugins, true);
+#else
+			g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 		}
 
 		if (CpuType == CPU_Recompiler || CpuType == CPU_SyncCores)
@@ -563,7 +567,11 @@ void CN64System::Reset (bool bInitReg, bool ClearMenory)
 	RefreshGameSettings();
 	m_Audio.Reset();
 	m_MMU_VM.Reset(ClearMenory);
+#if defined(WINDOWS_UI)
 	Debug_Reset();
+#else
+	g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 	Mempak::Close();
 
 	m_CyclesToSkip = 0;
@@ -2066,5 +2074,9 @@ void CN64System::TLB_Unmaped ( DWORD VAddr, DWORD Len )
 
 void CN64System::TLB_Changed()
 {
+#if defined(WINDOWS_UI)
 	Debug_RefreshTLBWindow();
+#else
+	g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 }

--- a/Source/Project64/N64 System/N64 Class.h
+++ b/Source/Project64/N64 System/N64 Class.h
@@ -25,8 +25,12 @@ class CN64System :
 	private CSystemEvents,
 	protected CN64SystemSettings,
 	public CGameSettings,
+#if defined(WINDOWS_UI)
 	protected CDebugSettings,
 	public CDebugger
+#else
+	protected CDebugSettings
+#endif
 {
 public:
 	CN64System ( CPlugins * Plugins, bool SavesReadOnly );

--- a/Source/Project64/Plugins/Plugin Class.cpp
+++ b/Source/Project64/Plugins/Plugin Class.cpp
@@ -261,7 +261,12 @@ bool CPlugins::Initiate ( CN64System * System )
 
 bool CPlugins::ResetInUiThread ( CN64System * System )
 {
+#if defined(WINDOWS_UI)
 	return m_RenderWindow->ResetPlugins(this, System);
+#else
+	g_Notify -> BreakPoint(__FILEW__, __LINE__);
+	return false;
+#endif
 }
 
 bool CPlugins::Reset ( CN64System * System ) 

--- a/Source/Project64/User Interface/Notification Class.cpp
+++ b/Source/Project64/User Interface/Notification Class.cpp
@@ -118,7 +118,11 @@ void CNotification::DisplayMessage  ( int DisplayTime, const wchar_t * Message, 
 	} 
     else 
     {
+#if defined(WINDOWS_UI)
 		m_hWnd->SetStatusText(0, Msg);
+#else
+		g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 	}
 }
 
@@ -136,8 +140,12 @@ void CNotification::DisplayMessage2 (  const wchar_t * Message, va_list ap ) con
 	wchar_t Msg[1000];
 	_vsnwprintf( Msg,sizeof(Msg) - 1 ,Message, ap );
 	va_end( ap );
-	
+
+#if defined(WINDOWS_UI)
     m_hWnd->SetStatusText(1,Msg);
+#else
+    g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 }
 
 void CNotification::SetGfxPlugin( CGfxPlugin * Plugin )
@@ -148,11 +156,15 @@ void CNotification::SetGfxPlugin( CGfxPlugin * Plugin )
 void CNotification::SetWindowCaption (const wchar_t * Caption)
 {
 	static const size_t TITLE_SIZE = 256;
-
 	wchar_t WinTitle[TITLE_SIZE];
+
 	_snwprintf(WinTitle, TITLE_SIZE, L"%s - %s", Caption, g_Settings->LoadString(Setting_ApplicationName).ToUTF16().c_str());
 	WinTitle[TITLE_SIZE - 1] = 0;
+#if defined(WINDOWS_UI)
 	m_hWnd->Caption(WinTitle);
+#else
+	g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 }
 
 void CNotification::FatalError  ( const wchar_t * Message, ... ) const 
@@ -257,7 +269,12 @@ void CNotification::AddRecentRom ( const char * ImagePath )
 void CNotification::RefreshMenu ( void )
 {
 	if (m_hWnd == NULL) { return; }
+
+#if defined(WINDOWS_UI)
 	m_hWnd->RefreshMenu();
+#else
+	g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 }
 
 void CNotification::HideRomBrowser ( void )
@@ -280,13 +297,23 @@ void CNotification::ShowRomBrowser ( void )
 void CNotification::BringToTop ( void )
 {
 	if (m_hWnd == NULL) { return; }
+
+#if defined(WINDOWS_UI)
 	m_hWnd->BringToTop();
+#else
+	g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 }
 
 void CNotification::MakeWindowOnTop ( bool OnTop )
 {
 	if (m_hWnd == NULL) { return; }
+
+#if defined(WINDOWS_UI)
 	m_hWnd->MakeWindowOnTop(OnTop);
+#else
+	g_Notify -> BreakPoint(__FILEW__, __LINE__);
+#endif
 }
 
 void CNotification::ChangeFullScreen ( void ) const
@@ -298,7 +325,13 @@ void CNotification::ChangeFullScreen ( void ) const
 bool CNotification::ProcessGuiMessages ( void ) const
 {
 	if (m_hWnd == NULL) { return false; }
+
+#if defined(WINDOWS_UI)
 	return m_hWnd->ProcessGuiMessages();
+#else
+	g_Notify -> BreakPoint(__FILEW__, __LINE__);
+	return false;
+#endif
 }
 
 void CNotification::BreakPoint ( const wchar_t * FileName, const int LineNumber )

--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -181,13 +181,16 @@ const char * AppName ( void )
 #ifndef WINDOWS_UI
 int main(int argc, char* argv[])
 {
-#error Cross-platform [graphical?] interface has not yet been implemented.
-// Remove this #error to compile, but linking will fail with about 10 errors.
-
     while (argc >= 0)
     {
         puts(argv[--argc]);
     }
+    putchar('\n');
+
+    fprintf(
+        stderr,
+        "Cross-platform (graphical/terminal?) UI not yet implemented.\n"
+    );
     return 0;
 }
 #else

--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -181,7 +181,7 @@ const char * AppName ( void )
 #ifndef WINDOWS_UI
 int main(int argc, char* argv[])
 {
-    while (argc >= 0)
+    while (argc > 0)
     {
         puts(argv[--argc]);
     }


### PR DESCRIPTION
Project64 now "runs" without ATL or WTL compiled in, but there is no interface to communicate with or initiate the core CPU emulation functions as of this time.  Hopefully that will be able to change later.
![zomg_its_alive](https://cloud.githubusercontent.com/assets/1396303/9860544/c0e7cae6-5afa-11e5-8f9e-c88847f4bd6d.png)

The same basic result happens when doing a 64-bit VS2013 Community build, if you force the `WINDOWS_UI` macro to not be defined.  However, with VS2013 solution, the linker fails unless you change the project's linker settings to select `/SUBSYSTEM:CONSOLE` instead of `/SUBSYSTEM:WINDOWS`, due to the absence of a `WinMain` function in my changes.  I did not need to modify this linker setting for it to build straight away with the VS2008 Express build, just the VS2013 build.

I'm not sure how to fix the error on VS2013 programmatically, without making everyone change the 2013 solution file to use the "console" subsystem.  Possibly doesn't matter since most people want ATL.