### PR TITLE
COP1 FP 32-bit round to integer doable with intrinsics?

### DIFF
--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
@@ -2364,7 +2364,10 @@ __inline void Float_RoundToInteger32( int * Dest, float * Source )
 		fistp dword ptr [edi]
 	}
 #else
-	g_Notify->BreakPoint(__FILEW__,__LINE__);
+    __m128 xmm;
+
+    xmm = _mm_load_ss(Source);
+    *(Dest) = _mm_cvt_ss2si(xmm);
 #endif
 }
 
@@ -2379,7 +2382,10 @@ __inline void Float_RoundToInteger64( __int64 * Dest, float * Source )
 		fistp qword ptr [edi]
 	}
 #else
-	g_Notify->BreakPoint(__FILEW__,__LINE__);
+    __m128 xmm;
+
+    xmm = _mm_load_ss(Source);
+    *(Dest) = _mm_cvtss_si64(xmm);
 #endif
 }
 


### PR DESCRIPTION
Our very first game is playable now with zilmar's Basic CFB plugin:  _Namco Museum 64_.
![namco_x64](https://cloud.githubusercontent.com/assets/1396303/9866794/05fbcf4e-5b35-11e5-837d-f5ff18c6dbf6.png)

The other games I have tested need COP1 FP 64-bit round to 32-/64-bit integers and the SQRT_S operation, which I am not tackling yet.

What I'd really like to do is just write a platform agnostic solution.  There's probably something from the standard math library for this, and from what I heard performance isn't meant as a concern for interpreters here anyway.  Unfortunately I am not the type of math guy who understands the floating-point bit-perfect stuff very well at all so am unable to confirm such a solution--I'm going to try to play it safe and start with the x64 `<emmintrin.h>` intrinsic functions that most closely resemble the inline assembly that was being used for the 32-bit builds.