### PR TITLE
Quest 64 starts to work now (x64).

### DIFF
--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
@@ -2592,7 +2592,10 @@ __inline void Double_RoundToInteger32( DWORD * Dest, double * Source )
 		fistp dword ptr [edi]
 	}
 #else
-	g_Notify->BreakPoint(__FILEW__,__LINE__);
+    __m128d xmm;
+
+    xmm = _mm_load_sd(Source);
+    *(Dest) = _mm_cvtsd_si32(xmm);
 #endif
 }
 


### PR DESCRIPTION
What's the difference between _Quest 64_ and _Superman 64_?

* It's one of only 5 RPG games ever released on the N64, with them magic wizards and such.
* kinda fun, sort of
* It works up to a point if you implement partial COP1 floating-point.

![x64_quest_mempak](https://cloud.githubusercontent.com/assets/1396303/9883343/9780db2c-5ba7-11e5-8ca1-149b38892b34.png)
![x64_quest](https://cloud.githubusercontent.com/assets/1396303/9883348/9c7abb34-5ba7-11e5-95c1-93a6612d69fe.png)

In-game does not work yet until we implement SQRT_S without using inline asm.

Related also to pull request #599.