### PR TITLE
Temporarily force interpreter mode when running 64-bit PJ64.

### DIFF
--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -911,8 +911,11 @@ void CN64System::ExecuteCPU()
 
 	switch ((CPU_TYPE)g_Settings->LoadDword(Game_CpuType))
 	{
+// Currently the compiler is 32-bit only.  We might have to ignore that RDB setting for now.
+#ifndef _WIN64
 	case CPU_Recompiler: ExecuteRecompiler(); break;
 	case CPU_SyncCores:  ExecuteSyncCPU();    break;
+#endif
 	default:             ExecuteInterpret();  break;
 	}
 	g_Settings->SaveBool(GameRunning_CPU_Running,(DWORD)false);


### PR DESCRIPTION
This isn't necessary for portability; it's just more pragmatic and saves time.

When I was doing my own 64-bit Project64 1.4, I found it to save me a lot of time when I forced it to use the interpreter mode, regardless of recompiler is set, so that I didn't have to change the RDB/CFG every single time I wanted to test a new ROM.

This change results in the following warning being added:
```
N64 System\N64 Class.cpp(920):
warning C4065: switch statement contains 'default' but no 'case' labels
```
Maybe it can serve as a reminder for there to someday be a 64-bit recompiler I guess.