### PR TITLE
fixed 20 repeated warnings about undeclared intrinsic

### DIFF
--- a/Source/3rd Party/7zip/CpuArch.h
+++ b/Source/3rd Party/7zip/CpuArch.h
@@ -98,6 +98,7 @@ Stop_Compiling_Bad_Endian
 #endif
 
 #if defined(MY_CPU_LE_UNALIGN) && defined(_WIN64) && (_MSC_VER >= 1300)
+#include <stdlib.h>
 
 #pragma intrinsic(_byteswap_ulong)
 #pragma intrinsic(_byteswap_uint64)


### PR DESCRIPTION
The easiest mass of 64-bit compile warnings to fix, is I think this one.
```
  XzIn.c
(102): warning C4164: '_byteswap_ulong' : intrinsic function not declared
(103): warning C4164: '_byteswap_uint64' : intrinsic function not declared
  XzEnc.c
  XzDec.c
  Xz.c
(102): warning C4164: '_byteswap_ulong' : intrinsic function not declared
(103): warning C4164: '_byteswap_uint64' : intrinsic function not declared
  Ppmd7Enc.c
(102): warning C4164: '_byteswap_ulong' : intrinsic function not declared
(103): warning C4164: '_byteswap_uint64' : intrinsic function not declared
  Ppmd7Dec.c
(102): warning C4164: '_byteswap_ulong' : intrinsic function not declared
(103): warning C4164: '_byteswap_uint64' : intrinsic function not declared
  Ppmd7.c
(102): warning C4164: '_byteswap_ulong' : intrinsic function not declared
(103): warning C4164: '_byteswap_uint64' : intrinsic function not declared
  CpuArch.c
(102): warning C4164: '_byteswap_ulong' : intrinsic function not declared
(103): warning C4164: '_byteswap_uint64' : intrinsic function not declared
  7zIn.c
(102): warning C4164: '_byteswap_ulong' : intrinsic function not declared
(103): warning C4164: '_byteswap_uint64' : intrinsic function not declared
  7zDec.c
(102): warning C4164: '_byteswap_ulong' : intrinsic function not declared
(103): warning C4164: '_byteswap_uint64' : intrinsic function not declared
  7zCrcOpt.c
(102): warning C4164: '_byteswap_ulong' : intrinsic function not declared
(103): warning C4164: '_byteswap_uint64' : intrinsic function not declared
  7zCrc.c
(102): warning C4164: '_byteswap_ulong' : intrinsic function not declared
(103): warning C4164: '_byteswap_uint64' : intrinsic function not declared
```

According to a page on MSDN, the byte-swapping intrinsics are sourced from `<stdlib.h>`.
https://msdn.microsoft.com/en-us/library/a3140177.aspx