### PR TITLE
[RSP] Debug 64-bit -- Conversion:  possible loss of data.

### DIFF
--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -133,13 +133,17 @@ void Cheat_r4300iOpcodeNoMessage(p_func FunctAddress, char * FunctName) {
 
 void x86_SetBranch8b(void * JumpByte, void * Destination) {
 	/* calculate 32-bit relative offset */
-	signed int n = (BYTE*)Destination - ((BYTE*)JumpByte + 1);
+	size_t n = (BYTE*)Destination - ((BYTE*)JumpByte + 1);
+	SSIZE_T signed_n = (SSIZE_T)n;
 
 	/* check limits, no pun intended */
-	if (n > 0x80 || n < -0x7F) {
-		CompilerWarning("FATAL: Jump out of 8b range %i (PC = %04X)", n, CompilePC);
-	} else
-		*(BYTE*)(JumpByte) = (BYTE)n;
+	if (signed_n > +128 || signed_n < -127) {
+		CompilerWarning(
+			"FATAL: Jump out of 8b range %i (PC = %04X)", n, CompilePC
+		);
+	} else {
+		*(uint8_t *)(JumpByte) = (uint8_t)(n & 0xFF);
+	}
 }
 
 void x86_SetBranch32b(void * JumpByte, void * Destination) {

--- a/Source/RSP/breakpoint.c
+++ b/Source/RSP/breakpoint.c
@@ -138,12 +138,18 @@ void ShowBPPanel ( void )
 void RefreshBpoints ( HWND hList )
 {
 	char Message[100];
-	int count, location;
+	LRESULT location;
+	int count;
 
 	for (count = 0; count < NoOfBpoints; count ++ ) {
 		sprintf(Message," at 0x%03X (RSP)", BPoint[count].Location);
-		location = SendMessage(hList,LB_ADDSTRING,0,(LPARAM)Message);
-		SendMessage(hList,LB_SETITEMDATA,(WPARAM)location,(LPARAM)BPoint[count].Location);
+		location = SendMessage(hList, LB_ADDSTRING, 0, (LPARAM)Message);
+		SendMessage(
+			hList,
+			LB_SETITEMDATA,
+			(WPARAM)location,
+			(LPARAM)BPoint[count].Location
+		);
 	}
 }
 
@@ -154,9 +160,18 @@ void RemoveAllBpoint ( void )
 
 void RemoveBpoint ( HWND hList, int index )
 {
-	DWORD location;
-	
-	location = SendMessage(hList,LB_GETITEMDATA,(WPARAM)index,0);
+	LRESULT response;
+	uint32_t location;
+
+	response = SendMessage(hList, LB_GETITEMDATA, (WPARAM)index, 0);
+	if (response < 0 || response > 0x7FFFFFFFL)
+	{
+		DisplayError(
+			"LB_GETITEMDATA response for %i out of DWORD range.",
+			index
+		);
+	}
+	location = (uint32_t)response;
 	RemoveRSPBreakPoint(location);
 }
 


### PR DESCRIPTION
The first commit uses the POSIX `ssize_t` (as politely expressed with capital letters in the Windows types API) to fix type size truncation errors in a RSP recompiler file by using this signed counterpart to the `size_t` type.

The second commit primarily is to make sure that the type of `location`, for both functions, is big enough to store the full information returned by the `SendMessage` call.

I originally named this branch under the pretense that it would fix all 64-bit compile warnings for the RSP plugin, but I can see that the remaining ones are in a class of their own for a separate PR.