### PR TITLE
Have run-time error-checking when dumping DMEM/IMEM.

### DIFF
--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -196,9 +196,23 @@ void DumpRSPCode (void)
 	SetFilePointer(hLogFile,0,NULL,FILE_BEGIN);
 
 	for (location = 0; location < 0x1000; location += 4) {
+		unsigned int characters_to_write;
+		int characters_converted;
+
 		RSP_LW_IMEM(location, &OpCode);
-		sprintf(string," 0x%03X\t%s\r\n",location, RSPOpcodeName ( OpCode, location ));
-		WriteFile( hLogFile,string,strlen(string),&dwWritten,NULL );
+		characters_converted = sprintf(
+			&string[0],
+			" 0x%03X\t%s\r\n",
+			location,
+			RSPOpcodeName(OpCode, location)
+		);
+
+		if (characters_converted < 0) {
+			DisplayError("Failed to sprintf IMEM from 0x%03X.", location);
+			break;
+		}
+		characters_to_write = (unsigned)characters_converted;
+		WriteFile(hLogFile, string, characters_to_write, &dwWritten, NULL);
 	}
 	CloseHandle(hLogFile);
 }
@@ -237,9 +251,23 @@ void DumpRSPData (void)
 
 	for (location = 0; location < 0x1000; location += 4)
 	{
+		unsigned int characters_to_write;
+		int characters_converted;
+
 		RSP_LW_DMEM(location, &value);
-		sprintf(string," 0x%03X\t0x%08X\r\n", location, value);
-		WriteFile( hLogFile,string,strlen(string),&dwWritten,NULL );
+		characters_converted = sprintf(
+			&string[0],
+			" 0x%03X\t0x%08X\r\n",
+			location,
+			value
+		);
+
+		if (characters_converted < 0) {
+			DisplayError("Failed to sprintf DMEM from 0x%03X.", location);
+			break;
+		}
+		characters_to_write = (unsigned)characters_converted;
+		WriteFile(hLogFile, string, characters_to_write, &dwWritten, NULL);
 	}
 	CloseHandle(hLogFile);
 }


### PR DESCRIPTION
This actually achieves 3 things.
* fixes Debug64 build warnings about a couple "loss of precision" conversions
* includes run-time notification of errors when C standard `sprintf` is called but fails
* should actually make SP memory dumps faster due to the removed `strlen` calls, in exchange for re-using the return slot of the `sprintf` call instead of letting that go to waste

Though really the only reason I started this PR was just point 1, as implicit conversion from `size_t` to `DWORD` can easily be fixed by simply using the `unsigned int` type for a string whose max buffer allocation is this small (only 100 characters).

The return value of the `sprintf` function is documented at:
http://www.cplusplus.com/reference/cstdio/sprintf/

Using this is essentially the same as us calling `strlen` afterwards as we were originally doing, except that we can not only avoid the extra function call to `strlen` but check to see whether the standard library function `sprintf` even succeeded as it should have in the first place, as summarised in point number 3.  This increases both compatibility and speed of the info logs to fix those 64-bit compiler warnings.