### PR TITLE
A question about J-type instructions encoding 26-bit target.

### DIFF
--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -1153,9 +1153,9 @@ char * RSPOpcodeName ( DWORD OpCode, DWORD PC )
 		break;
 	case RSP_J:
 	case RSP_JAL:
-		sprintf(CommandName, "%s\t0x%03X",
+		sprintf(CommandName, "%s\t0x%07X",
 			mnemonics_primary[command.op],
-			(command.target << 2) & 0xFFC
+			command.target << 2
 		);
 		break;
 	case RSP_BEQ:


### PR DESCRIPTION
May be less of a pull request, more of a question.

I was wondering if it could be beneficial to show the full 28-bit address in a J or JAL instruction in the RSP command window when stepping through the instruction cache.

Examples of what happens when I made this change:
```
J       0x4001064 # instead of 0x064

JAL     0x400103C # instead of 0x03C

J       0x00011B8 # happens when I boot Banjo-Tooie or Zelda
```

I start to think it's an interesting sign of whether an RSP assembler was used to refer to a symbolic label, a fixed address or hard-coded in an RSP library.  The 0x0001000 in 0x00011B8 in the third example I assume is because IMEM = DMEM + 0x1000 in the memory map.  The 0x400000 in the first two examples I think is just because of #define SP_DMEM_START or one of those base macros that I can't remember what it was called.

It could also help people debug whether they're looking at potentially corrupt/undefined instruction memory.  If we saw `JAL 0xAF704331` or something we likely would guess that this was not intended code to be DMA'd for the purpose of running or could even be corrupted as the result of a bug in the ROM/emulator.  If we just saw it truncated to `JAL 0x331` it wouldn't be as easy to deduce that.