### PR TITLE
Add support for Visual Studio 2015, xdebug appears to no longer be av…

### DIFF
--- a/Source/3rd Party/wx/include/msvc/wx/setup.h
+++ b/Source/3rd Party/wx/include/msvc/wx/setup.h
@@ -62,6 +62,10 @@
         #define wxCOMPILER_PREFIX vc100
     #elif _MSC_VER == 1700
         #define wxCOMPILER_PREFIX vc110
+	#elif _MSC_VER == 1800
+		#define wxCOMPILER_PREFIX vc120
+	#elif _MSC_VER == 1900
+		#define wxCOMPILER_PREFIX vc140
     #else
         #error "Unknown MSVC compiler version, please report to wx-dev."
     #endif

--- a/Source/3rd Party/wx/include/wx/platform.h
+++ b/Source/3rd Party/wx/include/wx/platform.h
@@ -437,7 +437,9 @@
 #   elif __VISUALC__ < 1800
 #       define __VISUALC11__
 #   elif __VISUALC__ < 1900
-# define __VISUALC12__
+#       define __VISUALC12__
+#   elif __VISUALC__ < 2000
+#       define __VISUALC14__
 #   else
 #       pragma message("Please update wx/platform.h to recognize this VC++ version")
 #   endif
@@ -523,7 +525,7 @@
 #   define wxVISUALC_VERSION(major) 0
 #   define wxCHECK_VISUALC_VERSION(major) 0
 #else
-#   define wxVISUALC_VERSION(major) ( (6 + major) * 100 )
+#   define wxVISUALC_VERSION(major) ( (6 + (major >= 14 ? 1 : 0) + major) * 100 )
 #   define wxCHECK_VISUALC_VERSION(major) ( __VISUALC__ >= wxVISUALC_VERSION(major) )
 #endif
 

--- a/Source/Common/MemTest.h
+++ b/Source/Common/MemTest.h
@@ -1,5 +1,8 @@
 #ifdef _DEBUG
+
+#if (defined(_MSC_VER) && (_MSC_VER < 1900))
 #define MEM_LEAK_TEST
+#endif
 
 #ifdef MEM_LEAK_TEST
 


### PR DESCRIPTION
…ailable in Visual Studio 2015. So for now memtest must be disabled for Debug builds to operate correctly.