### PR TITLE
Potential Windows 10 BSOD FIX

### DIFF
--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -208,6 +208,9 @@ bool CN64System::RunFileImage ( const char * FileLoc )
 		g_Notify->AddRecentRom(FileLoc);
         g_Notify->SetWindowCaption(g_Settings->LoadString(Game_GoodName).ToUTF16().c_str());
 
+		g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
+		g_Notify->RefreshMenu();
+
 		if (g_Settings->LoadDword(Setting_AutoStart) != 0)
 		{
 			g_BaseSystem = new CN64System(g_Plugins,false);
@@ -216,8 +219,6 @@ bool CN64System::RunFileImage ( const char * FileLoc )
 				g_BaseSystem->StartEmulation(true);
 			}
 		}
-		g_Settings->SaveBool(GameRunning_LoadingInProgress,false);
-		g_Notify->RefreshMenu();
 	}
 	else
 	{


### PR DESCRIPTION
That's not even a joke.
I tried my hardest to force a BSOD either via CLI or the ROM Browser on my Windows 10 laptop (which had that problem).

It just works now. Moving the code there somehow fixes it.

It usually takes less than 10 tentatives to BSOD my laptop, and I've tried a 100 times here.


If the placement is too problematic about "g_Settings->SaveBool(GameRunning_LoadingInProgress, false);", my other suggestion is just to put to what it was and then remove RefreshMenu from there, OR we put both lines of code inside StartEmulation2().

Either way you can still get this pull request in and find a way later.