### PR TITLE
Fix issue with most D3D plugins

### DIFF
--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -561,6 +561,9 @@ void CN64System::PluginReset()
 	{
 		m_SyncCPU->m_Plugins->RomOpened();
 	}
+#ifndef _WIN64
+	_controlfp(_PC_53, _MCW_PC);
+#endif
 }
 
 void CN64System::Reset (bool bInitReg, bool ClearMenory) 
@@ -909,6 +912,9 @@ void CN64System::ExecuteCPU()
 	{
 		m_SyncCPU->m_Plugins->RomOpened();
 	}
+#ifndef _WIN64
+	_controlfp(_PC_53, _MCW_PC);
+#endif
 
 	switch ((CPU_TYPE)g_Settings->LoadDword(Game_CpuType))
 	{


### PR DESCRIPTION
Basically, D3DCreate() changes the FPU precision to 24bit unless
D3DCREATE_FPU_PRESERVE is enabled, which I don't think any D3D plugin
does, besides maybe Jabo's.