### PR TITLE
Banjo-Kazooie (U) v1.1 works in x64 now.

### DIFF
--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
@@ -2614,7 +2614,10 @@ __inline void Double_RoundToInteger64( unsigned __int64 * Dest, double * Source 
 		fistp qword ptr [edi]
 	}
 #else
-	g_Notify->BreakPoint(__FILEW__,__LINE__);
+    __m128d xmm;
+
+    xmm = _mm_load_sd(Source);
+    *(Dest) = _mm_cvtsd_si64(xmm);
 #endif
 }
 


### PR DESCRIPTION
For some reason, the USA 1.0 ROM doesn't need this instruction implemented, but 1.1 does.

Otherwise BK 1.1 fails with the interpreter breakpoint upon booting before displaying any gfx.
Thanks to @tony971 for making me aware of this.