### PR TITLE
Fix flags for debug/validate logging.

### DIFF
--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -26,7 +26,7 @@ void InitializeLog ( void)
 
 	LogFile = new CTraceFileLog(LogFilePath, g_Settings->LoadDword(Debugger_AppLogFlush) != 0, Log_New,500);
 #ifdef VALIDATE_DEBUG
-	LogFile->SetTraceLevel((TraceLevel)(g_Settings->LoadDword(Debugger_AppLogLevel) | TraceValidate));
+	LogFile->SetTraceLevel((TraceLevel)(g_Settings->LoadDword(Debugger_AppLogLevel) | TraceValidate | TraceDebug));
 #else
 	LogFile->SetTraceLevel((TraceLevel)g_Settings->LoadDword(Debugger_AppLogLevel));
 #endif


### PR DESCRIPTION
Trace logging was not working due to wrong flag setting. This small change fixes it.

Question: is there a way to set the VALIDATE_DEBUG flag at runtime (console argument, configuration setting)?