### PR TITLE
MemoryFilter starts to compile.

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -1987,7 +1987,21 @@ void CMipsMemoryVM::ResetMemoryStack()
 
 int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer ) 
 {
-#ifdef _M_IX86
+#if defined(_M_IX86) && defined(_WIN32)
+// to do:  Remove the _M_IX86 criteria.  This can compile on 64-bit Windows.
+
+#ifdef _WIN64
+#define Eax     Rax
+#define Ebx     Rbx
+#define Ecx     Rcx
+#define Edx     Rdx
+#define Esp     Rsp
+#define Ebp     Rbp
+#define Esi     Rsi
+#define Edi     Rdi
+
+#define Eip     Rip
+#endif
 	if (dwExptCode != EXCEPTION_ACCESS_VIOLATION) 
 	{
 		if (bHaveDebugger())
@@ -2010,7 +2024,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 		return EXCEPTION_EXECUTE_HANDLER; 
 	}
 
-	DWORD * Reg = NULL;
+	size_t * Reg = NULL;
 	
 	BYTE * TypePos = (unsigned char *)lpEP->ContextRecord->Eip;
 	EXCEPTION_RECORD exRec = *lpEP->ExceptionRecord;


### PR DESCRIPTION
Since tony reported issue https://github.com/project64/project64/issues/638, I decided it can be partially understandable to use MemoryFilter on 64-bit Windows.  So I guess I don't care not to implement it.

It basically compiles just fine now, but you need to have the LB, LW, SW etc. functions not be "DWORD"-centric for the physical address and use more portable MIPS code instead of x86/WINAPI stuff.  That remaining business can be tended to in a later PR.