### PR TITLE
Revert "Merge pull request #639 from cxd4/kyles-mom"

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -1987,21 +1987,7 @@ void CMipsMemoryVM::ResetMemoryStack()
 
 int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer ) 
 {
-#if defined(_M_IX86) && defined(_WIN32)
-// to do:  Remove the _M_IX86 criteria.  This can compile on 64-bit Windows.
-
-#ifdef _WIN64
-#define Eax     Rax
-#define Ebx     Rbx
-#define Ecx     Rcx
-#define Edx     Rdx
-#define Esp     Rsp
-#define Ebp     Rbp
-#define Esi     Rsi
-#define Edi     Rdi
-
-#define Eip     Rip
-#endif
+#ifdef _M_IX86
 	if (dwExptCode != EXCEPTION_ACCESS_VIOLATION) 
 	{
 		if (bHaveDebugger())
@@ -2024,7 +2010,7 @@ int CMipsMemoryVM::MemoryFilter( DWORD dwExptCode, void * lpExceptionPointer )
 		return EXCEPTION_EXECUTE_HANDLER; 
 	}
 
-	size_t * Reg = NULL;
+	DWORD * Reg = NULL;
 	
 	BYTE * TypePos = (unsigned char *)lpEP->ContextRecord->Eip;
 	EXCEPTION_RECORD exRec = *lpEP->ExceptionRecord;


### PR DESCRIPTION
Reverts #639.
It introduces the following compiler error:
```
##[error] Source\Project64\N64 System\Mips\Memory Virtual Mem.cpp(2236,0): Error C2664: 'CMipsMemoryVM::LH_NonMemory' : cannot convert parameter 2 from 'size_t *' to 'DWORD *'
20>N64 System\Mips\Memory Virtual Mem.cpp(2236): error C2664: 'CMipsMemoryVM::LH_NonMemory' : cannot convert parameter 2 from 'size_t *' to 'DWORD *' [Source\Project64\Project64.vcxproj] 
Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or function-style cast
```

Steps to reproduce:
msbuild Project64.sln (optional: Add "/p:PlatformToolset=%your VS tolset version" if not using Visual Studio 2015)