### PR TITLE
MemoryFilter starts to compile (now with 32-bit support!).

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
@@ -10,6 +10,26 @@
 ****************************************************************************/
 #pragma once
 
+/*
+ * 64-bit Windows exception recovery facilities will expect to interact with
+ * the 64-bit registers of the Intel architecture (e.g., rax instead of eax).
+ *
+ * Attempting to read the 32-bit subsets seems to be erroneous and forbidden.
+ * Refer to "MemoryFilter" in `Memory Virtual Mem.cpp`.
+ */
+#ifdef _WIN64
+#define Eax     Rax
+#define Ebx     Rbx
+#define Ecx     Rcx
+#define Edx     Rdx
+#define Esp     Rsp
+#define Ebp     Rbp
+#define Esi     Rsi
+#define Edi     Rdi
+
+#define Eip     Rip
+#endif
+
 extern unsigned long swap32by8(unsigned long word);
 
 class CMipsMemoryVM :


### PR DESCRIPTION
I've re-conducted PR https://github.com/project64/project64/pull/639 to account for WIN32-only builds.

Differences between this pull request and my old one JunielKatarn reverted:
* moved my macro defs from the main source into the virtual memory header file
* little readability change--I prefer `Reg = &(a -> b -> c)` over `Reg = &a->b->c`.
* Instead of always defining `Reg` as `size_t`, it now uses a macro to #ifndef _WIN64, then declare `DWORD Reg`, not `size_t Reg`.

The reason for the third point (which is what fixes the build error tony and Juniel noticed) is because these two types are actually the same under both 32- and 64-bit Windows LLP64 ABI:  both DWORD and size_t are matching 32-bit or matching 64-bit types, depending on the build being done.

The problem was that Microsoft introduces a subtle difference in their ABI:  with 32-bit builds only, size_t is `unsigned int`, while DWORD is `unsigned long`.  Again, a minor grammatical difference that C compilers are free to disregard, but C++ compilers may treat as an error--incorrectly claiming that there is no satisfactory relationship between these two types, when there is of course.