### PR TITLE
Introduce portable types to R4300 system types header.

### DIFF
--- a/Source/Project64/N64 System/Types.h
+++ b/Source/Project64/N64 System/Types.h
@@ -10,6 +10,28 @@
 ****************************************************************************/
 #pragma once
 
+/*
+ * Some versions of Microsoft Visual C/++ compilers before Visual Studio 2010
+ * have <stdint.h> removed in favor of these nonstandard built-in types:
+ */
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
+typedef signed __int8           int8_t;
+typedef signed __int16          int16_t;
+typedef signed __int32          int32_t;
+typedef signed __int64          int64_t;
+
+typedef unsigned __int8         uint8_t;
+typedef unsigned __int16        uint16_t;
+typedef unsigned __int32        uint32_t;
+typedef unsigned __int64        uint64_t;
+#else
+#include <stdint.h>
+#endif
+
+/*
+ * To do:  Use fixed-size types for MIPS union members, not WINAPI types.
+ * On Win32 x86, `unsigned long DWORD` versus `int32_t` is the only conflict.
+ */
 typedef unsigned char    BYTE;
 typedef unsigned short   WORD;
 typedef unsigned long    DWORD;
@@ -19,23 +41,25 @@ typedef int              BOOL;
 
 union MIPS_WORD {
 	long           W;
-	float          F;
 	unsigned long  UW;
 	short          HW[2];
 	unsigned short UHW[2];
 	char           B[4];
 	unsigned char  UB[4];
+
+    float       F;
 };
 
 union MIPS_DWORD {
-	double           D;
 	__int64          DW;
 	unsigned __int64 UDW;
 	long             W[2];
-	float            F[2];
 	unsigned long    UW[2];
 	short            HW[4];
 	unsigned short   UHW[4];
 	char             B[8];
 	unsigned char    UB[8];
+
+    double      D;
+    float       F[2];
 };


### PR DESCRIPTION
Don't like stdint.h, but it's project64's personal preference and it's good enough to me.

We've delayed doing this change for a while, but I've been getting tired these past few pull requests of saying `unsigned __int32` when we should really be using maintainable, portable types centralized to a header include somewhere.

...Well, they're not **really** as maintainable as custom `typedef`s are for complete testing since having to change their definitions for any reason would conflict with the (potentially built-in to some compilers) C99 committee's opinion of having `stdint.h` exist inside of the C specifications, but it's still better than using ambiguous types like `DWORD` from Windows defs all the time.