### PR TITLE
Remove external linkage of swap32by8()--now static.

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -40,9 +40,9 @@ CMipsMemoryVM::CMipsMemoryVM( CMipsMemory_CallBack * CallBack, bool SavesReadOnl
 	m_IMEM       = NULL;
 }
 
-unsigned long swap32by8(unsigned long word)
+static uint32_t swap32by8(uint32_t word)
 {
-    const unsigned long swapped =
+    const uint32_t swapped =
 #if defined(_MSC_VER)
         _byteswap_ulong(word)
 #elif defined(__GNUC__)
@@ -282,7 +282,7 @@ bool CMipsMemoryVM::LB_VAddr(DWORD VAddr, BYTE& Value)
 		return false;
 	}
 
-	Value = *(BYTE*)(m_TLB_ReadMap[VAddr >> 12] + (VAddr ^ 3));
+	Value = *(uint8_t *)(m_TLB_ReadMap[VAddr >> 12] + (VAddr ^ 3));
 	return true;
 }
 
@@ -293,7 +293,7 @@ bool CMipsMemoryVM::LH_VAddr(DWORD VAddr, WORD& Value)
 		return false;
 	}
 
-	Value = *(WORD*)(m_TLB_ReadMap[VAddr >> 12] + (VAddr ^ 2));
+	Value = *(uint16_t *)(m_TLB_ReadMap[VAddr >> 12] + (VAddr ^ 2));
 	return true;
 }
 
@@ -344,7 +344,7 @@ bool CMipsMemoryVM::LB_PAddr(DWORD PAddr, BYTE& Value)
 {
 	if (PAddr < RdramSize())
 	{
-		Value = *(BYTE*)(m_RDRAM + (PAddr ^ 3));
+		Value = *(uint8_t *)(m_RDRAM + (PAddr ^ 3));
 		return true;
 	}
 
@@ -361,7 +361,7 @@ bool CMipsMemoryVM::LH_PAddr(DWORD PAddr, WORD& Value)
 {
 	if (PAddr < RdramSize())
 	{
-		Value = *(WORD*)(m_RDRAM + (PAddr ^ 2));
+		Value = *(uint16_t *)(m_RDRAM + (PAddr ^ 2));
 		return true;
 	}
 
@@ -416,7 +416,7 @@ bool CMipsMemoryVM::SB_VAddr(DWORD VAddr, BYTE Value)
 		return false;
 	}
 
-	*(BYTE*)(m_TLB_WriteMap[VAddr >> 12] + (VAddr ^ 3)) = Value;
+	*(uint8_t *)(m_TLB_WriteMap[VAddr >> 12] + (VAddr ^ 3)) = Value;
 	return true;
 }
 
@@ -427,7 +427,7 @@ bool CMipsMemoryVM::SH_VAddr(DWORD VAddr, WORD Value)
 		return false;
 	}
 
-	*(WORD*)(m_TLB_WriteMap[VAddr >> 12] + (VAddr ^ 2)) = Value;
+	*(uint16_t *)(m_TLB_WriteMap[VAddr >> 12] + (VAddr ^ 2)) = Value;
 	return true;
 }
 
@@ -469,7 +469,7 @@ bool CMipsMemoryVM::SB_PAddr(DWORD PAddr, BYTE Value)
 {
 	if (PAddr < RdramSize())
 	{
-		*(BYTE*)(m_RDRAM + (PAddr ^ 3)) = Value;
+		*(uint8_t *)(m_RDRAM + (PAddr ^ 3)) = Value;
 		return true;
 	}
 
@@ -486,7 +486,7 @@ bool CMipsMemoryVM::SH_PAddr(DWORD PAddr, WORD Value)
 {
 	if (PAddr < RdramSize())
 	{
-		*(WORD*)(m_RDRAM + (PAddr ^ 2)) = Value;
+		*(uint16_t *)(m_RDRAM + (PAddr ^ 2)) = Value;
 		return true;
 	}
 

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
@@ -31,24 +31,15 @@
 #endif
 
 /*
- * This will help us gradually be able to port Project64 for big-endian CPUs
- * later.  Currently it is written to assume 32-bit little-endian, like so:
+ * To do:  Have address translation functions here?
+ * `return` either the translated address or the mask to XOR by?
+ *
+ * This will help us gradually be able to port Project64 for big-endian CPUs.
+ * Currently it is written to assume 32-bit little-endian, like so:
  *
  * 0xAABBCCDD EEFFGGHH --> 0xDDCCBBAA HHGGFFEE
  *   GPR bits[63..0]         b1b2b3b4 b5b6b7b8
  */
-#define BYTE_SWAP_MASK          3u
-#define HALF_SWAP_MASK          ((BYTE_SWAP_MASK) & ~1u)
-#define WORD_SWAP_MASK          ((BYTE_SWAP_MASK) & ~3u)
-
-// Convert MIPS server-native byte order to client-native endian.
-#define BES(offset)             ((offset) ^ (BYTE_SWAP_MASK))
-
-// Convert MIPS server-native halfword order to client-native int16_t order.
-#define HES(offset)             ((offset) ^ (HALF_SWAP_MASK))
-
-// Convert MIPS server-native word order to client-native int32_t order.
-#define WES(offset)             ((offset) ^ (WORD_SWAP_MASK))
 
 class CMipsMemoryVM :
 	public CMipsMemory,

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
@@ -30,7 +30,25 @@
 #define Eip     Rip
 #endif
 
-extern unsigned long swap32by8(unsigned long word);
+/*
+ * This will help us gradually be able to port Project64 for big-endian CPUs
+ * later.  Currently it is written to assume 32-bit little-endian, like so:
+ *
+ * 0xAABBCCDD EEFFGGHH --> 0xDDCCBBAA HHGGFFEE
+ *   GPR bits[63..0]         b1b2b3b4 b5b6b7b8
+ */
+#define BYTE_SWAP_MASK          3u
+#define HALF_SWAP_MASK          ((BYTE_SWAP_MASK) & ~1u)
+#define WORD_SWAP_MASK          ((BYTE_SWAP_MASK) & ~3u)
+
+// Convert MIPS server-native byte order to client-native endian.
+#define BES(offset)             ((offset) ^ (BYTE_SWAP_MASK))
+
+// Convert MIPS server-native halfword order to client-native int16_t order.
+#define HES(offset)             ((offset) ^ (HALF_SWAP_MASK))
+
+// Convert MIPS server-native word order to client-native int32_t order.
+#define WES(offset)             ((offset) ^ (WORD_SWAP_MASK))
 
 class CMipsMemoryVM :
 	public CMipsMemory,

--- a/Source/Project64/N64 System/Mips/Pif Ram.cpp
+++ b/Source/Project64/N64 System/Mips/Pif Ram.cpp
@@ -297,19 +297,14 @@ void CPifRam::SI_DMA_READ()
 			{
 				continue;
 			}
-			RDRAM[RdramPos ^3] = m_PifRam[count];
+			RDRAM[RdramPos ^ 3] = m_PifRam[count];
 		}
 	}
 	else
 	{
-		for (size_t i = 0; i < 64; i += 4)
+		for (size_t i = 0; i < 64; i++)
 		{
-			unsigned __int32 pif_ram_dword;
-			std::memcpy(&pif_ram_dword, &PifRamPos[i], sizeof(unsigned __int32));
-
-			pif_ram_dword = swap32by8(pif_ram_dword);
-
-			std::memcpy(&RDRAM[SI_DRAM_ADDR_REG + i], &pif_ram_dword, sizeof(unsigned __int32));
+			RDRAM[(SI_DRAM_ADDR_REG + i) ^ 3] = PifRamPos[i];
 		}
 	}
 	
@@ -393,14 +388,9 @@ void CPifRam::SI_DMA_WRITE()
 	}
 	else
 	{
-		for (size_t i = 0; i < 64; i += 4)
+		for (size_t i = 0; i < 64; i++)
 		{
-			unsigned __int32 rdram_dword;
-			std::memcpy(&rdram_dword, &RDRAM[SI_DRAM_ADDR_REG + i], sizeof(unsigned __int32));
-
-			rdram_dword = swap32by8(rdram_dword);
-
-			std::memcpy(&PifRamPos[i], &rdram_dword, sizeof(unsigned __int32));
+			PifRamPos[i] = RDRAM[(SI_DRAM_ADDR_REG + i) ^ 3];
 		}
 	}
 	


### PR DESCRIPTION
Well actually this PR does at least two things.
* keeps `swap32by8()` (which I introduced a while back) to a single translation unit with `static` linkage, instead of making it `extern` within the headers to access it across more than one module
* adds some constants and functions/macro functions to help port platform endianness

I'd say the second is more important.

I don't have a clue what platforms like Android might do for byte order, but on x86 we have all kinds of code saying `x ^ 3` all the time.  I think this is not good in the long term for releasing Project64 with a big-endian memory spec either on platforms that have it for their native endian, or just simply to test plugins of the zilmar spec with `PluginInfo -> MemorySwapped = FALSE;`

Sorry about macro functions, don't know how those work with MSVC's debugger for people who use that more often.  In theory we could convert the macro functions to C external functions without macros.