### PR TITLE
(x64) fixed MSVC "loss of precision" warning during RAM realloc

### DIFF
--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -5422,7 +5422,12 @@ void CMipsMemoryVM::RdramChanged ( CMipsMemoryVM * _this )
 			g_Notify -> FatalError(GS(MSG_MEM_ALLOC_ERROR));
 		}
 	}
-	_this->m_AllocatedRdramSize = new_size;
+
+	if (new_size > 0xFFFFFFFFul)
+	{ // should be unreachable because:  size_t new_size = g_Settings->(DWORD)
+		g_Notify -> BreakPoint(__FILEW__, __LINE__);
+	} // ...However, FFFFFFFF also is a limit to RCP addressing, so we care.
+	_this->m_AllocatedRdramSize = (uint32_t)new_size;
 }
 
 void CMipsMemoryVM::ChangeSpStatus()


### PR DESCRIPTION
Just fixes a 64-bit build warning about "loss of precision".

For `_WIN64`, size_t is a uint64_t.
Storing `m_AllocatedRdramSize = new_size` is a warning because l-value is declared as DWORD.

The straightforward fix would just simply be to add the typecast to either `(DWORD)new_size` or `(uint32_t)new_size` also works, but I felt like adding the check to notify a break point anyway to be thorough in case maybe Project64 ever has a bug in the distant future where the configuration setting read out to m_AllocatedRdramSize was greater than UINT32_MAX...but also the maximum plausible RCP memory map address (which is only 32-bit anyway).  So the `if` may be _currently_ redundant, but it's safer.