### PR TITLE
Disable Data Execution Prevention for Project64.exe (Visual Studio 2010+)

### DIFF
--- a/Source/Project64/Project64.vcxproj
+++ b/Source/Project64/Project64.vcxproj
@@ -36,6 +36,7 @@
       <SubSystem>Windows</SubSystem>
       <MinimumRequiredVersion>5.01</MinimumRequiredVersion>
       <StackReserveSize>1</StackReserveSize>
+      <DataExecutionPrevention>false</DataExecutionPrevention>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
See forum post http://forum.pj64-emu.com/showpost.php?p=63666&postcount=19
(Pointed out by @Frank-74)

Builds based on VCXPROJ (VS2010 and later) don't currently disable DEP, making the program unable to unload old plugins (1.6 DLLs).

This simple setting change fixes the problem.
Built and tested on VS2015.