### PR TITLE
Set CN64System thread priority to TIME_CRITICAL

### DIFF
--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -395,6 +395,7 @@ void  CN64System::StartEmulation   ( bool NewThread )
 
 void CN64System::StartEmulationThread (  ThreadInfo * Info ) 
 {
+	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL );
 	CoInitialize(NULL);
 	
 	EmulationStarting(*Info->ThreadHandle,Info->ThreadID);


### PR DESCRIPTION
Changes CN64System::StartEmulationThread priority from Normal to Time Critical.