### PR TITLE
Emulation time critical setting

### DIFF
--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -395,6 +395,12 @@ void  CN64System::StartEmulation   ( bool NewThread )
 
 void CN64System::StartEmulationThread (  ThreadInfo * Info ) 
 {
+	EmulationTimeCritical = g_Settings->LoadBool(Setting_EmulationTimeCritical);
+	if (EmulationTimeCritical)
+	{
+ 		SetThreadPriority(GetCurrentThread(),THREAD_PRIORITY_TIME_CRITICAL);
+	}
+
 	CoInitialize(NULL);
 	
 	EmulationStarting(*Info->ThreadHandle,Info->ThreadID);

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -395,8 +395,7 @@ void  CN64System::StartEmulation   ( bool NewThread )
 
 void CN64System::StartEmulationThread (  ThreadInfo * Info ) 
 {
-	EmulationTimeCritical = g_Settings->LoadBool(Setting_EmulationTimeCritical);
-	if (EmulationTimeCritical)
+	if (g_Settings->LoadBool(Setting_EmulationTimeCritical))
 	{
  		SetThreadPriority(GetCurrentThread(),THREAD_PRIORITY_TIME_CRITICAL);
 	}

--- a/Source/Project64/Plugins/Audio Plugin.cpp
+++ b/Source/Project64/Plugins/Audio Plugin.cpp
@@ -180,6 +180,10 @@ void CAudioPlugin::DacrateChanged(SYSTEM_TYPE Type)
 
 void CAudioPlugin::AudioThread(CAudioPlugin * _this) {
 	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+	if (g_Settings->LoadBool(Setting_EmulationTimeCritical))
+	{
+ 		SetThreadPriority(GetCurrentThread(),THREAD_PRIORITY_HIGHEST);
+	}
 	for (;;)
 	{
 		_this->AiUpdate(true);

--- a/Source/Project64/Settings.h
+++ b/Source/Project64/Settings.h
@@ -44,6 +44,7 @@ enum SettingID {
 	Setting_ApplicationName,
 	Setting_UseFromRegistry,
 	Setting_RdbEditor,
+	Setting_EmulationTimeCritical,
 	Setting_PluginPageFirst,
 	Setting_DisableScrSaver,
 	Setting_AutoSleep,

--- a/Source/Project64/Settings/Settings Class.cpp
+++ b/Source/Project64/Settings/Settings Class.cpp
@@ -109,6 +109,7 @@ void CSettings::AddHowToHandleSetting ()
 	AddHandler(Setting_ApplicationName, new CSettingTypeTempString(""));
 	AddHandler(Setting_UseFromRegistry, new CSettingTypeApplication("Settings","Use Registry",(DWORD)false));
 	AddHandler(Setting_RdbEditor,       new CSettingTypeApplication("","Rdb Editor",          false));
+	AddHandler(Setting_EmulationTimeCritical,new CSettingTypeApplication("","EmulationTimeCritical",false));
 	AddHandler(Setting_PluginPageFirst, new CSettingTypeApplication("","Plugin Page First",   false));
 	AddHandler(Setting_DisableScrSaver, new CSettingTypeApplication("","Disable Screen Saver",(DWORD)true));
 	AddHandler(Setting_AutoSleep,       new CSettingTypeApplication("","Auto Sleep",          (DWORD)true));


### PR DESCRIPTION
Adds a setting to enable Time Critical thread priority for CN64System.

To turn on, add EmulationTimeCritical=1 under the [default] section in Project64.cfg.