### PR TITLE
Remove SDL dependency from TexCache unit (Win32 libs fix).

### DIFF
--- a/Source/Glide64/TexCache.cpp
+++ b/Source/Glide64/TexCache.cpp
@@ -539,11 +539,10 @@ void TexCache ()
       if (ghq_dmptex_toggle_key) {
         DisplayLoadProgress(L"Texture dump - ON\n");
         ClearCache();
-        SDL_Delay(1000);
       } else {
         DisplayLoadProgress(L"Texture dump - OFF\n");
-        SDL_Delay(1000);
       }
+      SDL_Delay(1000);
     }
   }
 #endif

--- a/Source/Glide64/TexCache.cpp
+++ b/Source/Glide64/TexCache.cpp
@@ -37,8 +37,11 @@
 //
 //****************************************************************
 
+#ifndef _WIN32
 #include <SDL.h>
+#endif
 #include "Gfx_1.3.h"
+
 #include "TexCache.h"
 #include "Combine.h"
 #include "Util.h"
@@ -542,7 +545,11 @@ void TexCache ()
       } else {
         DisplayLoadProgress(L"Texture dump - OFF\n");
       }
+#if defined(_WIN32)
+      Sleep(1000);
+#else
       SDL_Delay(1000);
+#endif
     }
   }
 #endif


### PR DESCRIPTION
Okay, prior to making this pull request I still cannot compile Glide64 x64 (Debug Win32 works but not Release Win64 for some reason), due to this single linker error only:
```
error LNK2019: unresolved external symbol SDL_Delay referenced in function
"void __cdecl TexCache(void)" (?TexCache@@YAXXZ)
```

The dependency issue with libraries like SDL is a bit further of an inconvenience on Windows than it is with other platforms (which sometimes may include SDL with the operating system, so not as much reason to avoid it), but in this case I would like to begin by removing SDL from `TexCache.cpp` so that I can compile it at all to begin with before commencing any further tests.