### PR TITLE
Fix linker error due to missing LanguageSelector files in VXCPROJ

### DIFF
--- a/Source/Project64/Project64.vcxproj
+++ b/Source/Project64/Project64.vcxproj
@@ -42,6 +42,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="Multilanguage\LanguageSelector.cpp" />
     <ClCompile Include="N64 System\Mips\Rumblepak.cpp" />
     <ClCompile Include="Plugins\Plugin Base.cpp" />
     <ClCompile Include="stdafx.cpp">
@@ -177,6 +178,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Multilanguage.h" />
+    <ClInclude Include="Multilanguage\LanguageSelector.h" />
     <ClInclude Include="N64 System.h" />
     <ClInclude Include="N64 System\Mips\Rumblepak.h" />
     <ClInclude Include="Plugin.h" />

--- a/Source/Project64/Project64.vcxproj.filters
+++ b/Source/Project64/Project64.vcxproj.filters
@@ -414,6 +414,9 @@
     <ClCompile Include="N64 System\Mips\Rumblepak.cpp">
       <Filter>Source Files\N64 System Source\Mips Source</Filter>
     </ClCompile>
+    <ClCompile Include="Multilanguage\LanguageSelector.cpp">
+      <Filter>Source Files\Multilanguage Source</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Image Include="User Interface\Bitmaps\AboutScreenBottom.bmp">
@@ -835,6 +838,9 @@
     </ClInclude>
     <ClInclude Include="N64 System\Mips\Rumblepak.h">
       <Filter>Source Files\N64 System Source\Mips Source</Filter>
+    </ClInclude>
+    <ClInclude Include="Multilanguage\LanguageSelector.h">
+      <Filter>Header Files\Multilanguage Headers</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Building with VS2010 or later, there is a linker error (not finding CLanguageSelector.Select()).

Adding LanguageSelector.h and .cpp to Project64.vcxproj fixes this.