### PR TITLE
Be able to control `WINDOWS_UI` programatically.

### DIFF
--- a/Source/Project64/User Interface.h
+++ b/Source/Project64/User Interface.h
@@ -44,8 +44,10 @@ struct WINDOWS_PAINTSTRUCT {
 
 class CN64System;
 
+#ifndef BYPASS_WINDOWS_GUI
 #define WINDOWS_UI
 // Remove this to test compilation outside of the Windows ATL environment.
+#endif
 
 #ifdef WINDOWS_UI
 #include <WTL App.h>


### PR DESCRIPTION
I've started to work on a MinGW batch file to compile the Project64 core with GCC on Windows.

Since such compilers lack ATL to their disposal, we would need to `#undef WINDOWS_UI`, a macro I added a few pull requests back (tl;dl).

I think it will be easiest if I can just pass `-DBYPASS_WINDOWS_GUI` in my MinGW script, so this way it will programatically prevent the definition of this macro when compiling without VS Professional.