### PR TITLE
Fix non-MSVC compiler error:  undeclared sprintf()

### DIFF
--- a/Source/Common/md5.h
+++ b/Source/Common/md5.h
@@ -42,6 +42,9 @@ documentation and/or software.
 #if !defined(AFX_MD5_H__6DD6923B_E241_40CE_81A3_4C2C88C140E4__INCLUDED_)
 #define AFX_MD5_H__6DD6923B_E241_40CE_81A3_4C2C88C140E4__INCLUDED_
 
+/* sprintf() */
+#include <stdio.h>
+
 #include <string>
 #include <functional>
 #include "path.h"


### PR DESCRIPTION
The version of `<windows.h>` used by MSVC 2013 is too new and doesn't have this error.

If removing `windows.h` or compiling with MinGW or some other compiler's version of it, we have:
```
In file included from $project64\Source\Project64\Support.h:14:0,
                 from $project64\Source\Project64\User Interface.h:14,
                 from $project64\Source\Project64\stdafx.h:22,
                 from $project64\Source\Project64\main.cpp:1:
$project64\Source\Project64\../common/md5.h:
In member function 'std::string MD5Digest::String()':
$project64\Source\Project64\../common/md5.h:
70:36: error: 'sprintf' was not declared in this scope
    sprintf(s+i*2, "%02X", digest[i]);
                                    ^
```
So including `stdio.h` fixes the error.

According to these two sources, `sprintf()` is native to exactly the stdio header:
http://www.cplusplus.com/reference/cstdio/sprintf/
http://linux.die.net/man/3/sprintf