### PR TITLE
Fix settings menu

### DIFF
--- a/Source/Project64/Plugins/Plugin List.cpp
+++ b/Source/Project64/Plugins/Plugin List.cpp
@@ -98,7 +98,7 @@ void CPluginList::AddPluginFromDir ( CPath Dir)
 			}
 
 			Plugin.FullPath = Dir;
-			Plugin.FileName = ((stdstr &)Dir).substr(((stdstr &)m_PluginDir).length());
+			Plugin.FileName = Dir.GetDirectory().substr(m_PluginDir.GetDirectory().length());
 
 			if (GetProcAddress(hLib,"DllAbout") != NULL) 
 			{


### PR DESCRIPTION
Fixes #689
See https://github.com/project64/project64/blame/master/Source/Project64/Plugins/Plugin%20List.cpp#L15
After that change, the (stdstr &) cast throws an exception.

This commit fixes the menu for both Win32 and x64 platforms.