### PR TITLE
[N-Rage] Disabled broken pre-processor code.

### DIFF
--- a/Source/nragev20/settings.h
+++ b/Source/nragev20/settings.h
@@ -26,7 +26,7 @@
 
 #define DIRECTINPUT_VERSION 0x0800
 
-	// hacks for GNU C compilers
+// hacks for GNU C compilers // No thank you....
 #ifdef __GNUC__
 
 #ifndef WINVER
@@ -37,10 +37,10 @@
 #define _WIN32_IE 0x0300
 #endif // #ifndef _WIN32_IE
 
-#ifndef _const unsigned char *_DEFINED
-#define _const unsigned char *_DEFINED
-typedef const unsigned char *const unsigned char *;
-#endif // #ifndef _const unsigned char *_DEFINED
+//#ifndef _const unsigned char *_DEFINED
+//#define _const unsigned char *_DEFINED
+//typedef const unsigned char *const unsigned char *;
+//#endif
 
 #endif // #ifdef __GNUC__
 


### PR DESCRIPTION
I have no idea what this was for...

This "hack for GNU C compilers" was not present in N-Rage 1.83 original sources.
http://members.chello.at/n-rage/dinput8/downloads.html

So either rabiddeity or squall-leonhart or somebody added this after N-Rage 2.00.

N-Rage almost compiles now on MinGW 64-bit already.  This is one of the only obstacles there is, so unless somebody can speak for what this macro code might be intended to be used for...I'd say it's part of the broken code unique to N-Rage 2.3 where we should have used N-Rage 2.1 codebase instead.