### PR TITLE
[N-Rage] undeclared functions min() and max()

### DIFF
--- a/Source/nragev20/PakIO.h
+++ b/Source/nragev20/PakIO.h
@@ -170,4 +170,16 @@ typedef struct _ADAPTOIDPAK
 	bool fRumblePak;
 } ADAPTOIDPAK, *LPADAPTOIDPAK;
 
+/*
+ * <windef.h> from under <windows.h> with MSVC defines these macros.
+ * For some reason, they are unavailable with MinGW's copy of <windows.h>.
+ */
+#ifndef max
+#define max(a, b)       (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef min
+#define min(a, b)       (((a) < (b)) ? (a) : (b))
+#endif
+
 #endif // #ifndef _PAKIO_H_


### PR DESCRIPTION
These macros were used in the original MSVC build, too, so I'm copying macros not adding them.

This does also help N-Rage compile without needing `<windows.h>`, though I would think that's relatively pointless since N-Rage depends on DirectX headers which would require WinAPI anyway.  So it's not like this plugin can get ported to Linux or anything (unless someone writes a SDL backend for it...).

Still, on the off chance somebody will prefer compiling Project64 without MSVC or Visual Studio, these min() and max() functions need to be available outside of MSVC's exclusive copy of `windef.h`.