### PR TITLE
[N-Rage] fixed broken FormatMemPak in 64-bit

### DIFF
--- a/Source/nragev20/PakIO.cpp
+++ b/Source/nragev20/PakIO.cpp
@@ -800,17 +800,19 @@ inline WORD CountBlocks( const unsigned char * bMemPakBinary, LPBYTE aNoteSizes 
 
 void FormatMemPak( LPBYTE aMemPak )
 {
-	FillMemory( aMemPak, 0x100, 0xFF );
+	size_t iRand, n;
 
+	FillMemory(aMemPak, 0x100, 0xFF);
 	aMemPak[0] = 0x81;
 
 	// generate a valid code( i hope i can calculate it one day)
 	BYTE aValidCodes[] = {	0x12, 0xC5, 0x8F, 0x6F, 0xA4, 0x28, 0x5B, 0xCA };
 	BYTE aCode[8];
 
-	int iRand = (( (ULONG)aMemPak / 4 + (ULONG)g_strEmuInfo.hMainWindow / 4 ) % (sizeof(aValidCodes)/8) );
-	for( int n = 0; n <8; n++ )
-		aCode[n] = aValidCodes[n+iRand];
+	iRand  = ((size_t)aMemPak / 4) + ((size_t)g_strEmuInfo.hMainWindow / 4);
+	iRand %= sizeof(aValidCodes) / 8;
+	for (n = 0; n < 8; n++)
+		aCode[n] = aValidCodes[n + iRand];
 
 	//----------
 


### PR DESCRIPTION
Maybe in MSVC this isn't a compiler error, but in GCC's implementation of the C++ standard it is.

If `sizeof(void *) > sizeof(ULONG)`, then `(ULONG)pointer_to_any_type` is an error.

Even if it's not a compiler error for Visual Studio compilers, I'm sure it fixes a broken feature in 64-bit builds of N-Rage for pj64.