### PR TITLE
Remove incompatible in-line asm from DepthBufferRender.

### DIFF
--- a/Source/Glide64/DepthBufferRender.cpp
+++ b/Source/Glide64/DepthBufferRender.cpp
@@ -97,31 +97,7 @@ __inline int imul14(int x, int y)        // (x * y) >> 14
 
 __inline int idiv16(int x, int y)        // (x << 16) / y
 {
-    //x = (((long long)x) << 16) / ((long long)y);
- /*   
-  eax = x;
-  ebx = y;
-  edx = x;
-  (x << 16) | ()
-   */ 
-#if !defined(__GNUC__) && !defined(NO_ASM)
-  __asm {
-        mov   eax, x
-        mov   ebx, y
-        mov   edx,eax   
-        sar   edx,16
-        shl   eax,16    
-        idiv  ebx  
-        mov   x, eax
-    }
-#elif !defined(NO_ASM)
-    int reminder;
-    asm ("idivl %[divisor]"
-          : "=a" (x), "=d" (reminder)
-          : [divisor] "g" (y), "d" (x >> 16), "a" (x << 16));
-#else
-	x = (((long long)x) << 16) / ((long long)y);
-#endif
+    x = ((int64_t)x << 16) / (int64_t)y;
     return x;
 }
 

--- a/Source/Glide64/DepthBufferRender.cpp
+++ b/Source/Glide64/DepthBufferRender.cpp
@@ -87,12 +87,12 @@ static int left_z, left_dzdy;
 
 __inline int imul16(int x, int y)        // (x * y) >> 16
 {
-    return (((long long)x) * ((long long)y)) >> 16;
+    return ((int64_t)x * (int64_t)y) >> 16;
 }
 
 __inline int imul14(int x, int y)        // (x * y) >> 14
 {
-    return (((long long)x) * ((long long)y)) >> 14;
+    return ((int64_t)x * (int64_t)y) >> 14;
 }
 
 __inline int idiv16(int x, int y)        // (x << 16) / y


### PR DESCRIPTION
The chosen in-line assembly for GCC assumes -masm=att or not -masm=intel and is still not portable, regardless of the chain of `#ifdef`s being done here.  It is wisest to simply neutralize usage of any and all inline asm into plain C code.

Otherwise we get this:
```
as.exe: Assembler messages:
$project64\Source\Script\MinGW\Glide64\DepthBufferRender.asm: Assembler messages:
$project64\Source\Script\MinGW\Glide64\DepthBufferRender.asm:90:
Error: no such instruction: `idivl esi'
$project64\Source\Script\MinGW\Glide64\DepthBufferRender.asm:171:
Error: no such instruction: `idivl esi'
$project64\Source\Script\MinGW\Glide64\DepthBufferRender.asm:182:
Error: no such instruction: `idivl esi'
```

I also replaced the instances of `long long` with `int64_t` ... not because I am a fan of C99, but because `long long` isn't really portable (and is also C99) and runs the risk of being greater than 64 bits wide where just plain `long` could have sufficed for this type definition on LP64 platforms, etc..