### PR TITLE
[Glide64] fixed pre-processor macro collision with C++ STL

### DIFF
--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -37,9 +37,9 @@
 //
 //****************************************************************
 
+#include <Common/std string.h>
 #include "Gfx_1.3.h"
 #include "Version.h"
-#include <Common/std string.h>
 #include <Settings/Settings.h>
 
 #include <wx/fileconf.h>

--- a/Source/Glide64/rdp.h
+++ b/Source/Glide64/rdp.h
@@ -830,12 +830,20 @@ extern const char *CIStatus[];
 #define FBL_D_1 2
 #define FBL_D_0 3
 
+/*
+ * taken straight from MSVC <windef.h> in case of other compilers
+ *
+ * Careful!  These macros can sabotage std::max and std::min from <vector>.
+ * The only solution is to include <vector> first, before <windef.h> or
+ * before defining the below macros (or just don't use <windows.h>).
+ */
 #ifndef max
-#define max(a,b)            (((a) > (b)) ? (a) : (b))
+#define max(a, b)       (((a) > (b)) ? (a) : (b))
 #endif
 #ifndef min
-#define min(a,b)            (((a) < (b)) ? (a) : (b))
+#define min(a, b)       (((a) < (b)) ? (a) : (b))
 #endif
+
 #ifndef TRUE
 #define TRUE 1
 #endif


### PR DESCRIPTION
`project64/Common/std string.h` does an `#include <vector>`.

`stl_vector.h` uses `std::max`, but `#include <windows.h>` defines `max()` as a macro function.

Observe:
```cpp
      size_type
      _M_check_len(size_type __n, const char* __s) const
      {
        if (max_size() - size() < __n)
          __throw_length_error(__N(__s));

        const size_type __len = size() + std::max(size(), __n);
        return (__len < size() || __len > max_size()) ? max_size() : __len;
      }
```

The simplest fix is to make sure you delay `#include <windef.h>` (or GCC's emulation of the min/max macro functions within) until after first doing `#include <vector>` and no sooner.  I cannot really think of any alternative solutions other than to a) never include windows.h, b) never include the C++ STL API

Otherwise:
```
In file included from $project64\Source\Script\MinGW\..\..\Glide64\Gfx_1.3.h:74:0,
                 from $project64\Source\Script\MinGW\..\..\Glide64\Main.cpp:40:
c:\mingw\lib\gcc\mingw32\4.8.1\include\c++\bits\stl_vector.h: In member function
 'std::vector<_Tp, _Alloc>::size_type std::vector<_Tp, _Alloc>::
 _M_check_len(std::vector<_Tp, _Alloc>::size_type, const char*) const':
$project64\Source\Script\MinGW\..\..\Glide64\rdp.h:834:25: error:
expected unqualified-id before '(' token
 #define max(a, b)       (((a) > (b)) ? (a) : (b))
                         ^
```

Of course, `Windows.h` itself makes sure to include the C++ STL first before defining its macros.