### PR TITLE
[Glide64] fixed DllMain conflict against <winbase.h> prototype

### DIFF
--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -1197,7 +1197,7 @@ int DllUnload(void)
 void wxSetInstance(HINSTANCE hInstance);
 
 extern "C" int WINAPI DllMain (HINSTANCE hinst,
-                     wxUint32 fdwReason,
+                     DWORD fdwReason,
                      LPVOID /*lpReserved*/)
 {
   sprintf (out_buf, "DllMain (%0p - %d)\n", hinst, fdwReason);


### PR DESCRIPTION
Since before April 4, 2013 when Glide64 was first imported into the repository, this `DllMain` function has been declared with the wx uint32_t type definition.  This reinstantiates the fundamental `unsigned int` versus `unsigned long` problem because DWORD !== uint32_t, but DllMain and `<winbase.h>` prototype of it is all Win32-specific stuff anyway, so it's fine for us to say DWORD here.
```
In file included from c:\mingw\include\windows.h:62:0,
                 from $project64\Source\3rd Party\wx\include/wx/msw/wrapwin.h:51,
                 from $project64\Source\3rd Party\wx\include/wx/msw/app.h:92,
                 from $project64\Source\3rd Party\wx\include/wx/app.h:562,
                 from $project64\Source\3rd Party\wx\include/wx/wx.h:26,
                 from $project64\Source\Script\MinGW\..\..\Glide64\winlnxdefs.h:45,
                 from $project64\Source\Script\MinGW\..\..\Glide64\Gfx_1.3.h:65,
                 from $project64\Source\Script\MinGW\..\..\Glide64\Main.cpp:41:
c:\mingw\include\winbase.h:1051:13: error:
previous declaration 'BOOL DllMain(HINSTANCE, DWORD, LPVOID)' here
 BOOL WINAPI DllMain(HINSTANCE, DWORD, LPVOID);
             ^
```