### PR TITLE
Add PJGlide and NRage MinGW compile scripts?

### DIFF
--- a/Source/Script/MinGW/glide64.cmd
+++ b/Source/Script/MinGW/glide64.cmd
@@ -1,0 +1,81 @@
+@ECHO OFF
+TITLE MinGW Compiler Suite Invocation
+
+set src=%CD%\..\..\Glide64
+set obj=%CD%\Glide64
+
+if not exist %obj% (
+mkdir %obj%
+)
+
+    set MinGW=C:\MinGW
+REM set MinGW=C:\msys64\mingw64\x86_64-w64-mingw32\..
+
+set FLAGS_x86=^
+ -I"%src%\.."^
+ -I"%src%\..\3rd Party\wx\include"^
+ -I"%src%\..\3rd Party\wx\lib\vc_lib\msw"^
+ -I"%src%\..\Glitch64\inc"^
+ -S^
+ -masm=intel^
+ -march=native^
+ -Os
+
+set C_FLAGS=%FLAGS_x86%
+
+cd %MinGW%\bin
+set CC=%MinGW%\bin\g++.exe
+set AS=%MinGW%\bin\as.exe
+
+ECHO Compiling Glide64 plugin sources...
+%CC% -o %obj%\Main.asm                  %src%\Main.cpp %C_FLAGS%
+%CC% -o %obj%\FBtoScreen.asm            %src%\FBtoScreen.cpp %C_FLAGS%
+%CC% -o %obj%\rdp.asm                   %src%\rdp.cpp %C_FLAGS%
+%CC% -o %obj%\Keys.asm                  %src%\Keys.cpp %C_FLAGS%
+%CC% -o %obj%\Config.asm                %src%\Config.cpp %C_FLAGS%
+%CC% -o %obj%\CRC.asm                   %src%\CRC.cpp %C_FLAGS%
+%CC% -o %obj%\Debugger.asm              %src%\Debugger.cpp %C_FLAGS%
+%CC% -o %obj%\Util.asm                  %src%\Util.cpp %C_FLAGS%
+%CC% -o %obj%\TexCache.asm              %src%\TexCache.cpp %C_FLAGS%
+%CC% -o %obj%\3dmath.asm                %src%\3dmath.cpp %C_FLAGS%
+%CC% -o %obj%\Combine.asm               %src%\Combine.cpp %C_FLAGS%
+%CC% -o %obj%\DepthBufferRender.asm     %src%\DepthBufferRender.cpp %C_FLAGS%
+%CC% -o %obj%\Ext_TxFilter.asm          %src%\Ext_TxFilter.cpp %C_FLAGS%
+%CC% -o %obj%\TexBuffer.asm             %src%\TexBuffer.cpp %C_FLAGS%
+
+ECHO Assembling Glide64 sources...
+%AS% -o %obj%\Main.o                    %obj%\Main.asm
+%AS% -o %obj%\FBtoScreen.o              %obj%\FBtoScreen.asm
+%AS% -o %obj%\rdp.o                     %obj%\rdp.asm
+%AS% -o %obj%\Keys.o                    %obj%\Keys.asm
+%AS% -o %obj%\Config.o                  %obj%\Config.asm
+%AS% -o %obj%\CRC.o                     %obj%\CRC.asm
+%AS% -o %obj%\Debugger.o                %obj%\Debugger.asm
+%AS% -o %obj%\Util.o                    %obj%\Util.asm
+%AS% -o %obj%\TexCache.o                %obj%\TexCache.asm
+%AS% -o %obj%\3dmath.o                  %obj%\3dmath.asm
+%AS% -o %obj%\Combine.o                 %obj%\Combine.asm
+%AS% -o %obj%\DepthBufferRender.o       %obj%\DepthBufferRender.asm
+%AS% -o %obj%\Ext_TxFilter.o            %obj%\Ext_TxFilter.asm
+%AS% -o %obj%\TexBuffer.o               %obj%\TexBuffer.asm
+ECHO.
+
+set OBJ_LIST=^
+ %obj%\TexBuffer.o^
+ %obj%\Ext_TxFilter.o^
+ %obj%\DepthBufferRender.o^
+ %obj%\Combine.o^
+ %obj%\3dmath.o^
+ %obj%\TexCache.o^
+ %obj%\Util.o^
+ %obj%\Debugger.o^
+ %obj%\CRC.o^
+ %obj%\Config.o^
+ %obj%\Keys.o^
+ %obj%\rdp.o^
+ %obj%\FBtoScreen.o^
+ %obj%\Main.o
+
+ECHO Linking PJGlide64 objects...
+%MinGW%\bin\g++.exe -o %obj%\PJ64Glide64.dll %OBJ_LIST% -shared -shared-libgcc
+PAUSE

--- a/Source/Script/MinGW/nrage.cmd
+++ b/Source/Script/MinGW/nrage.cmd
@@ -1,0 +1,61 @@
+@ECHO OFF
+TITLE MinGW Compiler Suite Invocation
+
+set src=%CD%\..\..\nragev20
+set obj=%CD%\N-Rage
+
+if not exist %obj% (
+mkdir %obj%
+)
+
+    set MinGW=C:\MinGW
+REM set MinGW=C:\msys64\mingw64\x86_64-w64-mingw32\..
+
+set FLAGS_x86=^
+ -I"%src%\..\3rd Party\directx\include"^
+ -Wno-write-strings^
+ -S^
+ -masm=intel^
+ -march=native^
+ -Os
+
+set C_FLAGS=%FLAGS_x86%
+
+cd %MinGW%\bin
+set CC=%MinGW%\bin\g++.exe
+set AS=%MinGW%\bin\as.exe
+
+ECHO Compiling N-Rage plugin sources...
+%CC% -o %obj%\NRagePluginV2.asm         %src%\NRagePluginV2.cpp %C_FLAGS%
+%CC% -o %obj%\Interface.asm             %src%\Interface.cpp %C_FLAGS%
+%CC% -o %obj%\FileAccess.asm            %src%\FileAccess.cpp %C_FLAGS%
+%CC% -o %obj%\PakIO.asm                 %src%\PakIO.cpp %C_FLAGS%
+%CC% -o %obj%\GBCart.asm                %src%\GBCart.cpp %C_FLAGS%
+%CC% -o %obj%\International.asm         %src%\International.cpp %C_FLAGS%
+%CC% -o %obj%\DirectInput.asm           %src%\DirectInput.cpp %C_FLAGS%
+%CC% -o %obj%\XInputController.asm      %src%\XInputController.cpp %C_FLAGS%
+
+ECHO Assembling N-Rage sources...
+%AS% -o %obj%\NRagePluginV2.o           %obj%\NRagePluginV2.asm
+%AS% -o %obj%\Interface.o               %obj%\Interface.asm
+%AS% -o %obj%\FileAccess.o              %obj%\FileAccess.asm
+%AS% -o %obj%\PakIO.o                   %obj%\PakIO.asm
+%AS% -o %obj%\GBCart.o                  %obj%\GBCart.asm
+%AS% -o %obj%\International.o           %obj%\International.asm
+%AS% -o %obj%\DirectInput.o             %obj%\DirectInput.asm
+%AS% -o %obj%\XInputController.o        %obj%\XInputController.asm
+ECHO.
+
+set OBJ_LIST=^
+ %obj%\XInputController.o^
+ %obj%\DirectInput.o^
+ %obj%\International.o^
+ %obj%\GBCart.o^
+ %obj%\PakIO.o^
+ %obj%\FileAccess.o^
+ %obj%\Interface.o^
+ %obj%\NRagePluginV2.o
+
+ECHO Linking N-Rage objects...
+%MinGW%\bin\g++.exe -o %obj%\PJ64_NRage.dll %OBJ_LIST% -shared -shared-libgcc
+PAUSE


### PR DESCRIPTION
Hmm...I don't want to pollute the repository (hence the directory choice of Scripts/MinGW) space/size so can understand if this pull request should be rejected, but I didn't feel like selfishly keeping the scripts to myself either in case other people wanted to use them / help port the emulator to Linux etc.

The scripts aren't really big, but they are sort of experimental.  They do however compile both Glide64 and N-Rage without warnings or errors.  (I can think of a few people who would complain that I am not using GNU `Makefile` files instead of batch scripts....)  I do have a handful of linker namespace issues to tend to, but that can come later.  So I figure if people don't have the 10-20 GB of Visual Studio version X installed but wanted to test compile their changes it could be useful.

So any comments on the new scripts / should we not have them in the repo etc.?