### PR TITLE
[RSP] Added missing <stdio.h> include to fix undeclared sprintf().

### DIFF
--- a/Source/RSP/Profiling.cpp
+++ b/Source/RSP/Profiling.cpp
@@ -24,6 +24,7 @@
  *
  */
 
+#include <stdio.h>
 #include <windows.h>
 #include <shellapi.h>
 extern "C" {
@@ -168,8 +169,9 @@ public:
 			{
 				char Buffer[255];
 				float CpuUsage = (float)(((double)ItemList[count]->second / (double)TotalTime) * 100);
+
 				if (CpuUsage <= 0.2) { continue; }
-				sprintf(Buffer,"Func 0x%08X",ItemList[count]->first);
+				sprintf(Buffer, "Func 0x%08X", ItemList[count]->first);
 				for (int NameID = 0; NameID < (sizeof(TimerNames) / sizeof(TIMER_NAME)); NameID++)
 				{
 					if (ItemList[count]->first == (DWORD)TimerNames[NameID].Timer)

--- a/Source/RSP/log.cpp
+++ b/Source/RSP/log.cpp
@@ -23,6 +23,8 @@
  * should be forwarded to them so if they want them.
  *
  */
+
+#include <stdio.h>
 #include <windows.h>
 #include <Common/std string.h>
 #include <Common/File Class.h>
@@ -208,7 +210,6 @@ void RDP_LogLoc   ( DWORD /*PC*/ )
 #ifdef old
 
 #include <windows.h>
-#include <stdio.h>
 #include "RSP Registers.h"
 #include "log.h"
 


### PR DESCRIPTION
RSP `Profiling.cpp` and `log.cpp` both have unconditional, un-macro'd code that calls `sprintf()`, which requires the standard I/O header include.  GCC treats this as an error, but I guess with MSVC's copy of the headers it ends up implicitly including `stdio.h` or just using a built-in prototype of the function.
```
$project64\Source\Script\MinGW\..\..\RSP\log.cpp:193:40:
error: 'sprintf' was not declared in this scope
     sprintf(Ascii,"%s%c",Ascii,Mem[Pos]);
                                        ^
```