### PR TITLE
Fixed incorrect file name causing plugins to fail to load

### DIFF
--- a/Source/Project64/Plugins/Plugin List.cpp
+++ b/Source/Project64/Plugins/Plugin List.cpp
@@ -98,7 +98,9 @@ void CPluginList::AddPluginFromDir ( CPath Dir)
 			}
 
 			Plugin.FullPath = Dir;
-			Plugin.FileName = Dir.GetDirectory().substr(m_PluginDir.GetDirectory().length());
+			std::string& fullPath = Dir;
+			std::string& pluginPath = m_PluginDir;
+			Plugin.FileName = fullPath.substr(pluginPath.length());
 
 			if (GetProcAddress(hLib,"DllAbout") != NULL) 
 			{


### PR DESCRIPTION
This is a fix for #703 and #704. `Plugin.FileName` was being set to an invalid string in 74355d34d8bddc4f93a94bce32bb44482ab0114f. 