### PR TITLE
[RSP] Disable MSVC-specific 32-bit-only code for non-MSVC.

### DIFF
--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -273,7 +273,7 @@ void DetectCpuSpecs(void)
 	DWORD AMD_Features = 0;
 
 	__try {
-#ifdef _M_IX86
+#if defined(_M_IX86) && defined(_MSC_VER)
 		_asm {
 			/* Intel features */
 			mov eax, 1

--- a/Source/RSP/Profiling.cpp
+++ b/Source/RSP/Profiling.cpp
@@ -59,7 +59,7 @@ public:
 		DWORD OldTimerAddr = StopTimer();
 		m_CurrentTimerAddr = Address;
 
-#ifdef _M_IX86
+#if defined(_M_IX86) && defined(_MSC_VER)
 		DWORD HiValue, LoValue;
 		_asm {
 			pushad
@@ -79,7 +79,7 @@ public:
 	{		
 		if (m_CurrentTimerAddr == Timer_None) { return m_CurrentTimerAddr; }
 
-#ifdef _M_IX86
+#if defined(_M_IX86) && defined(_MSC_VER)
 		DWORD HiValue, LoValue;
 		_asm {
 			pushad

--- a/Source/RSP/Recompiler CPU.c
+++ b/Source/RSP/Recompiler CPU.c
@@ -933,7 +933,7 @@ DWORD RunRecompilerCPU ( DWORD Cycles ) {
 			StartTimer(*PrgCount);
 		}
 
-#ifdef _M_IX86
+#if defined(_M_IX86) && defined(_MSC_VER)
 		_asm {
 			pushad
 			call Block
@@ -952,7 +952,7 @@ DWORD RunRecompilerCPU ( DWORD Cycles ) {
 	}
 
 	if (IsMmxEnabled == TRUE) {
-#ifdef _M_IX86
+#if defined(_M_IX86) && defined(_MSC_VER)
 		_asm emms
 #else
 		DebugBreak();


### PR DESCRIPTION
These don't compile in GCC, for either Windows or Linux.