### PR TITLE
[RSP] Disable __cpuid() detection for non-MSVC compiles.

### DIFF
--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -272,8 +272,9 @@ void DetectCpuSpecs(void)
 	DWORD Intel_Features = 0;
 	DWORD AMD_Features = 0;
 
+#if defined(_MSC_VER)
 	__try {
-#if defined(_M_IX86) && defined(_MSC_VER)
+#ifdef _M_IX86
 		_asm {
 			/* Intel features */
 			mov eax, 1
@@ -296,6 +297,13 @@ void DetectCpuSpecs(void)
 	__except (EXCEPTION_EXECUTE_HANDLER) {
 		AMD_Features = Intel_Features = 0;
     }
+#else
+/*
+ * To do:  With GCC, there is <cpuid.h>, but __cpuid() there is a macro and
+ *         needs five arguments, not two.  Also, GCC lacks SEH.
+ */
+	AMD_Features = Intel_Features = 0;
+#endif
 
 	if (Intel_Features & 0x02000000)
 	{


### PR DESCRIPTION
More information about how in the future we could implement this for MinGW here:
http://stackoverflow.com/questions/17758409/intrinsics-for-cpuid-like-informations

For starters it could help to remove the inline asm for _M_IX86 && MSVC, since there is a non-inline-asm version for this code already.  (This way we would have only one #ifdef and not an #ifdef inside of a parent #ifdef.)  The non-inline-asm version however still does not work on GCC, which does have the `__cpuid()` intrinsic except in the form of a macro with slightly different rules.