### PR TITLE
[RSP] Execute recompiler CPU without SEH for non-MSVC.

### DIFF
--- a/Source/RSP/Recompiler CPU.c
+++ b/Source/RSP/Recompiler CPU.c
@@ -904,8 +904,8 @@ DWORD RunRecompilerCPU ( DWORD Cycles ) {
 				StartTimer((DWORD)Timer_Compiling);
 			}
 
+			memset(&RspCode, 0, sizeof(RspCode));
 			__try {
-				memset(&RspCode, 0, sizeof(RspCode));
 				BuildBranchLabels();
 				DetectGPRConstants(&RspCode);
 				CompilerRSPBlock();

--- a/Source/RSP/Recompiler CPU.c
+++ b/Source/RSP/Recompiler CPU.c
@@ -905,6 +905,7 @@ DWORD RunRecompilerCPU ( DWORD Cycles ) {
 			}
 
 			memset(&RspCode, 0, sizeof(RspCode));
+#if defined(_MSC_VER)
 			__try {
 				BuildBranchLabels();
 				DetectGPRConstants(&RspCode);
@@ -914,6 +915,11 @@ DWORD RunRecompilerCPU ( DWORD Cycles ) {
 				ClearAllx86Code();
 				continue;
 			}
+#else
+			BuildBranchLabels();
+			DetectGPRConstants(&RspCode);
+			CompilerRSPBlock();
+#endif
 			
 			Block = *(JumpTable + (*PrgCount >> 2));
 


### PR DESCRIPTION
SEH is the last of the remaining compiler errors.

There are no more compiler errors with MinGW after this pull request, just linker errors.

I moved the `memset()` on a whim that it shouldn't be able to generate exceptions within the __try __except block, mostly so I could copy-paste only 3 lines of code instead of 4 repeated lines.