### PR TITLE
[RSP] Fixed all 64-bit GCC compile warnings.

### DIFF
--- a/Source/RSP/Mmx.c
+++ b/Source/RSP/Mmx.c
@@ -35,6 +35,8 @@
 #define PUTDST8(dest,value)  (*((BYTE *)(dest))=(BYTE)(value)); dest += 1;
 #define PUTDST16(dest,value) (*((WORD *)(dest))=(WORD)(value)); dest += 2;
 #define PUTDST32(dest,value) (*((DWORD *)(dest))=(DWORD)(value)); dest += 4;
+#define PUTDSTPTR(dest, value) \
+    *(void **)(dest) = (void *)(value); dest += sizeof(void *);
 
 char * mmx_Strings[8] = {
 	"mm0", "mm1", "mm2", "mm3", 
@@ -96,7 +98,7 @@ void MmxMoveQwordVariableToReg(int Dest, void *Variable, char *VariableName) {
 
 	PUTDST16(RecompPos,0x6f0f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void MmxMoveQwordRegToVariable(int Dest, void *Variable, char *VariableName) {
@@ -117,7 +119,7 @@ void MmxMoveQwordRegToVariable(int Dest, void *Variable, char *VariableName) {
 
 	PUTDST16(RecompPos,0x7f0f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void MmxPorRegToReg(int Dest, int Source) {
@@ -167,7 +169,7 @@ void MmxPorVariableToReg(void * Variable, char * VariableName, int Dest) {
 
 	PUTDST16(RecompPos,0xeb0f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void MmxPandRegToReg(int Dest, int Source) {
@@ -217,7 +219,7 @@ void MmxPandVariableToReg(void * Variable, char * VariableName, int Dest) {
 
 	PUTDST16(RecompPos,0xdb0f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void MmxPandnRegToReg(int Dest, int Source) {
@@ -296,7 +298,7 @@ void MmxShuffleMemoryToReg(int Dest, void * Variable, char * VariableName, BYTE 
 
 	PUTDST16(RecompPos,0x700f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST8(RecompPos, Immed);	
 }
 
@@ -375,7 +377,7 @@ void MmxPmullwVariableToReg(int Dest, void * Variable, char * VariableName) {
 	}
 	PUTDST16(RecompPos,0xd50f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos, Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void MmxPmulhuwRegToReg(int Dest, int Source) {
@@ -453,7 +455,7 @@ void MmxPmulhwRegToVariable(int Dest, void * Variable, char * VariableName) {
 	}
 	PUTDST16(RecompPos,0xe50f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos, Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 
@@ -596,7 +598,7 @@ void MmxPaddswVariableToReg(int Dest, void * Variable, char * VariableName) {
 
 	PUTDST16(RecompPos,0xed0f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos, Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void MmxPsubswVariableToReg(int Dest, void * Variable, char * VariableName) {
@@ -617,7 +619,7 @@ void MmxPsubswVariableToReg(int Dest, void * Variable, char * VariableName) {
 
 	PUTDST16(RecompPos,0xe90f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos, Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void MmxPaddwRegToReg(int Dest, int Source) {

--- a/Source/RSP/Recompiler CPU.c
+++ b/Source/RSP/Recompiler CPU.c
@@ -754,9 +754,10 @@ void CompilerLinkBlocks(void) {
 	x86_SetBranch32b(RecompPos - 4, KnownCode);
 }
 
-void CompilerRSPBlock ( void ) {
-	DWORD Count, Padding, X86BaseAddress = (DWORD)RecompPos;
+void CompilerRSPBlock(void)
+{
 	BYTE * IMEM_SAVE = (BYTE *)malloc(0x1000);
+	const size_t X86BaseAddress = (size_t)RecompPos;
 
 	NextInstruction = NORMAL;
 	CompilePC = *PrgCount;
@@ -766,8 +767,11 @@ void CompilerRSPBlock ( void ) {
 	CurrentBlock.CurrPC = CompilePC;
 
 	/* Align the block to a boundary */	
-	if (X86BaseAddress & 7) {
-		Padding = (8 - (X86BaseAddress & 7)) & 7;
+	if (X86BaseAddress & 7)
+	{
+		register size_t Count;
+		const size_t Padding = (8 - (X86BaseAddress & 7)) & 7;
+
 		for (Count = 0; Count < Padding; Count++) {
 			CPU_Message("%08X: nop", RecompPos);
 			*(RecompPos++) = 0x90;

--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -5444,7 +5444,7 @@ void Compile_Opcode_LRV ( void ) {
 	Jump[0] = RecompPos - 1;
 /*
 	DecX86reg(x86_EAX);
-	LeaSourceAndOffset(x86_EAX, x86_EAX, (DWORD) &RSP_Vect[RSPOpC.rt].B[0]);
+	LeaSourceAndOffset(x86_EAX, x86_EAX, (size_t)&RSP_Vect[RSPOpC.rt].B[0]);
 	DecX86reg(x86_EAX);
 */
 	AddConstToX86Reg(x86_EAX, ((DWORD)&RSP_Vect[RSPOpC.rt].UB[0]) - 2);

--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -5447,7 +5447,7 @@ void Compile_Opcode_LRV ( void ) {
 	LeaSourceAndOffset(x86_EAX, x86_EAX, (size_t)&RSP_Vect[RSPOpC.rt].B[0]);
 	DecX86reg(x86_EAX);
 */
-	AddConstToX86Reg(x86_EAX, ((DWORD)&RSP_Vect[RSPOpC.rt].UB[0]) - 2);
+	AddConstToX86Reg(x86_EAX, ((size_t)&RSP_Vect[RSPOpC.rt].UB[0]) - 2);
 
 	CPU_Message("   Loop:");
 	Loop = RecompPos;

--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -2451,14 +2451,14 @@ void Compile_Vector_VMUDM ( void ) {
 
 	Push(x86_EBP);
 	sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rd);
-	MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
+	MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
 
 	if (bWriteToDest) {
 		sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.sa);
-		MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.sa].HW[0], Reg, x86_ECX);
+		MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.sa].HW[0], Reg, x86_ECX);
 	} else if (!bOptimize) {
 		sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rt);
-		MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rt].HW[0], Reg, x86_ECX);
+		MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rt].HW[0], Reg, x86_ECX);
 	}
 
 	for (count = 0; count < 8; count++) {
@@ -2575,7 +2575,7 @@ void Compile_Vector_VMUDN ( void ) {
 
 	Push(x86_EBP);
 	sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rd);
-	MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
+	MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
 
 	for (count = 0; count < 8; count++) {
 		CPU_Message("     Iteration: %i", count);
@@ -2719,7 +2719,7 @@ void Compile_Vector_VMUDH ( void ) {
 		 */
 		
 		sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rd);
-		MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
+		MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
 
 		MoveSxX86RegPtrDispToX86RegHalf(x86_EBP, 0, x86_EAX);
 		MoveSxX86RegPtrDispToX86RegHalf(x86_EBP, 2, x86_ECX);
@@ -2732,7 +2732,7 @@ void Compile_Vector_VMUDH ( void ) {
 		ImulX86RegToX86Reg(x86_ESI, x86_EBX);
 		XorX86RegToX86Reg(x86_EDX, x86_EDX);
 
-		MoveOffsetToX86reg((DWORD)&RSP_ACCUM[0].W[0], "RSP_ACCUM[0].W[0]", x86_EBP);
+		MoveOffsetToX86reg((size_t)&RSP_ACCUM[0].W[0], "RSP_ACCUM[0].W[0]", x86_EBP);
 
 		MoveX86RegToX86regPointerDisp(x86_EDX, x86_EBP, 0);
 		MoveX86RegToX86regPointerDisp(x86_EAX, x86_EBP, 4);
@@ -2748,7 +2748,7 @@ void Compile_Vector_VMUDH ( void ) {
 		 */
 
 		sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rd);
-		MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
+		MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
 
 		MoveSxX86RegPtrDispToX86RegHalf(x86_EBP,  8, x86_EAX);
 		MoveSxX86RegPtrDispToX86RegHalf(x86_EBP, 10, x86_ECX);
@@ -2761,7 +2761,7 @@ void Compile_Vector_VMUDH ( void ) {
 		ImulX86RegToX86Reg(x86_ESI, x86_EBX);
 		XorX86RegToX86Reg(x86_EDX, x86_EDX);
 
-		MoveOffsetToX86reg((DWORD)&RSP_ACCUM[0].W[0], "RSP_ACCUM[0].W[0]", x86_EBP);
+		MoveOffsetToX86reg((size_t)&RSP_ACCUM[0].W[0], "RSP_ACCUM[0].W[0]", x86_EBP);
 
 		MoveX86RegToX86regPointerDisp(x86_EDX, x86_EBP, 32);
 		MoveX86RegToX86regPointerDisp(x86_EAX, x86_EBP, 36);
@@ -2987,14 +2987,14 @@ void Compile_Vector_VMADM ( void ) {
 
 	Push(x86_EBP);
 	sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rd);
-	MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
+	MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
 
 	if (bWriteToDest) {
 		sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.sa);
-		MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.sa].HW[0], Reg, x86_ECX);
+		MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.sa].HW[0], Reg, x86_ECX);
 	} else if (!bOptimize) {
 		sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rt);
-		MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rt].HW[0], Reg, x86_ECX);
+		MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rt].HW[0], Reg, x86_ECX);
 	}
 
 	for (count = 0; count < 8; count++) {
@@ -3070,7 +3070,7 @@ void Compile_Vector_VMADN ( void ) {
 
 	Push(x86_EBP);
 	sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rd);
-	MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
+	MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
 
 	for (count = 0; count < 8; count++) {
 		CPU_Message("     Iteration: %i", count);
@@ -3146,7 +3146,7 @@ void Compile_Vector_VMADH ( void ) {
 	if (bWriteToDest == FALSE && bOptimize == TRUE) {
 		Push(x86_EBP);
 		sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rd);
-		MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
+		MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
 
 		/* 
 		 * Pipe lined segment 0
@@ -3196,14 +3196,14 @@ void Compile_Vector_VMADH ( void ) {
 	} else {
 		Push(x86_EBP);
 		sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rd);
-		MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
+		MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
 
 		if (bWriteToDest) {
 			sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.sa);
-			MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.sa].HW[0], Reg, x86_ECX);
+			MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.sa].HW[0], Reg, x86_ECX);
 		} else if (!bOptimize) {
 			sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rt);
-			MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rt].HW[0], Reg, x86_ECX);
+			MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rt].HW[0], Reg, x86_ECX);
 		}
 
 		for (count = 0; count < 8; count++) {
@@ -3686,7 +3686,7 @@ void Compile_Vector_VADDC ( void ) {
 
 	Push(x86_EBP);
 	sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rd);
-	MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
+	MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rd].HW[0], Reg, x86_EBP);
 
 	for (count = 0; count < 8; count++) {
 		CPU_Message("     Iteration: %i", count);
@@ -5251,7 +5251,7 @@ void Compile_Opcode_LDV ( void ) {
 	CPU_Message("   Unaligned:");
 	x86_SetBranch32b(Jump[0], RecompPos);
 	sprintf(Reg, "RSP_Vect[%i].UB[%i]", RSPOpC.rt, 15 - RSPOpC.del);
-	MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rt].UB[15 - RSPOpC.del], Reg, x86_EDI);
+	MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rt].UB[15 - RSPOpC.del], Reg, x86_EDI);
 	length = 8;
 	if (RSPOpC.del == 12){
 		length = 4;
@@ -5993,7 +5993,7 @@ void Compile_Opcode_SDV ( void ) {
 	x86_SetBranch32b((DWORD*)Jump[0], (DWORD*)RecompPos);
 
 	sprintf(Reg, "RSP_Vect[%i].UB[%i]", RSPOpC.rt, 15 - RSPOpC.del);
-	MoveOffsetToX86reg((DWORD)&RSP_Vect[RSPOpC.rt].UB[15 - RSPOpC.del], Reg, x86_EDI);
+	MoveOffsetToX86reg((size_t)&RSP_Vect[RSPOpC.rt].UB[15 - RSPOpC.del], Reg, x86_EDI);
 	MoveConstToX86reg(8, x86_ECX);
 
 	CPU_Message("   Loop:");

--- a/Source/RSP/Sse.c
+++ b/Source/RSP/Sse.c
@@ -35,6 +35,8 @@
 #define PUTDST8(dest,value)  (*((BYTE *)(dest))=(BYTE)(value)); dest += 1;
 #define PUTDST16(dest,value) (*((WORD *)(dest))=(WORD)(value)); dest += 2;
 #define PUTDST32(dest,value) (*((DWORD *)(dest))=(DWORD)(value)); dest += 4;
+#define PUTDSTPTR(dest, value) \
+    *(void **)(dest) = (void *)(value); dest += sizeof(void *);
 
 char * sse_Strings[8] = {
 	"xmm0", "xmm1", "xmm2", "xmm3", 
@@ -61,7 +63,7 @@ void SseMoveAlignedVariableToReg(void *Variable, char *VariableName, int sseReg)
 
 	PUTDST16(RecompPos,0x280f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void SseMoveAlignedN64MemToReg(int sseReg, int AddrReg) {
@@ -92,7 +94,7 @@ void SseMoveAlignedN64MemToReg(int sseReg, int AddrReg) {
 
 	PUTDST16(RecompPos,0x280f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void SseMoveAlignedRegToVariable(int sseReg, void *Variable, char *VariableName) {
@@ -113,7 +115,7 @@ void SseMoveAlignedRegToVariable(int sseReg, void *Variable, char *VariableName)
 
 	PUTDST16(RecompPos,0x290f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void SseMoveAlignedRegToN64Mem(int sseReg, int AddrReg) {
@@ -144,7 +146,7 @@ void SseMoveAlignedRegToN64Mem(int sseReg, int AddrReg) {
 
 	PUTDST16(RecompPos,0x290f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void SseMoveUnalignedVariableToReg(void *Variable, char *VariableName, int sseReg) {
@@ -165,7 +167,7 @@ void SseMoveUnalignedVariableToReg(void *Variable, char *VariableName, int sseRe
 
 	PUTDST16(RecompPos,0x100f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void SseMoveUnalignedN64MemToReg(int sseReg, int AddrReg) {
@@ -196,7 +198,7 @@ void SseMoveUnalignedN64MemToReg(int sseReg, int AddrReg) {
 
 	PUTDST16(RecompPos,0x100f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void SseMoveUnalignedRegToVariable(int sseReg, void *Variable, char *VariableName) {
@@ -217,7 +219,7 @@ void SseMoveUnalignedRegToVariable(int sseReg, void *Variable, char *VariableNam
 
 	PUTDST16(RecompPos,0x110f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void SseMoveUnalignedRegToN64Mem(int sseReg, int AddrReg) {
@@ -248,7 +250,7 @@ void SseMoveUnalignedRegToN64Mem(int sseReg, int AddrReg) {
 
 	PUTDST16(RecompPos,0x110f);
 	PUTDST8(RecompPos, x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void SseMoveRegToReg(int Dest, int Source) {

--- a/Source/RSP/X86.c
+++ b/Source/RSP/X86.c
@@ -1101,7 +1101,7 @@ void JsLabel32(char *Label, DWORD Value) {
 ** if we need this rewrite it into 1 function
 **/
 
-void LeaSourceAndOffset(int x86DestReg, int x86SourceReg, int offset) {
+void LeaSourceAndOffset(int x86DestReg, int x86SourceReg, size_t offset) {
 	WORD x86Command = 0;
 
 	CPU_Message("      lea %s, [%s + %0Xh]",x86_Name(x86DestReg),x86_Name(x86SourceReg),offset);
@@ -1130,7 +1130,8 @@ void LeaSourceAndOffset(int x86DestReg, int x86SourceReg, int offset) {
 		DisplayError("LeaSourceAndOffset\nUnknown x86 Register");
 	}
 
-	if ((offset & 0xFFFFFF80) != 0 && (offset & 0xFFFFFF80) != 0xFFFFFF80) {
+// To do:  Check high DWORD of offset for 64-bit x86.
+	if ((offset & 0x00000000FFFFFF80) != 0 && (offset & ~0x7F) != ~0x7F) {
 		PUTDST16(RecompPos,x86Command);
 		PUTDST32(RecompPos,offset);
 	} else {

--- a/Source/RSP/X86.c
+++ b/Source/RSP/X86.c
@@ -1178,7 +1178,7 @@ void MoveConstToX86reg(DWORD Const, int x86reg) {
     PUTDST32(RecompPos,Const);
 }
 
-void MoveOffsetToX86reg(DWORD Const, char * VariableName, int x86reg) {
+void MoveOffsetToX86reg(size_t Const, char * VariableName, int x86reg) {
 	CPU_Message("      mov %s, offset %s",x86_Name(x86reg),VariableName);
 	switch (x86reg) {
 	case x86_EAX: PUTDST16(RecompPos,0xC0C7); break;

--- a/Source/RSP/X86.c
+++ b/Source/RSP/X86.c
@@ -152,9 +152,15 @@ void AddConstToVariable (DWORD Const, void *Variable, char *VariableName) {
 	PUTDST32(RecompPos,Const);
 }
 
-void AddConstToX86Reg (int x86Reg, DWORD Const) {
+void AddConstToX86Reg(int x86Reg, size_t Const)
+{
+    const size_t zero_extension_mask = 0x00000000000000007F;
+    const size_t sign_extension_mask = ~(zero_extension_mask);
+    const size_t extension_from_8bit = Const & sign_extension_mask;
+
+/* To do:  if 64-bit x86, then what if `Const' upper DWORD set? */
 	CPU_Message("      add %s, %Xh",x86_Name(x86Reg),Const);
-	if ((Const & 0xFFFFFF80) != 0 && (Const & 0xFFFFFF80) != 0xFFFFFF80) {
+	if (extension_from_8bit != 0 && extension_from_8bit != sign_extension_mask) {
 		switch (x86Reg) {
 		case x86_EAX: PUTDST16(RecompPos,0xC081); break;
 		case x86_EBX: PUTDST16(RecompPos,0xC381); break;

--- a/Source/RSP/X86.c
+++ b/Source/RSP/X86.c
@@ -37,6 +37,8 @@
 #define PUTDST8(dest,value)  (*((BYTE *)(dest))=(BYTE)(value)); dest += 1;
 #define PUTDST16(dest,value) (*((WORD *)(dest))=(WORD)(value)); dest += 2;
 #define PUTDST32(dest,value) (*((DWORD *)(dest))=(DWORD)(value)); dest += 4;
+#define PUTDSTPTR(dest, value) \
+    *(void **)(dest) = (void *)(value); dest += sizeof(void *);
 
 char * x86_Strings[8] = {
 	"eax", "ebx", "ecx", "edx", 
@@ -99,7 +101,7 @@ void AdcX86regToVariable(int x86reg, void * Variable, char * VariableName) {
 	default:
 		DisplayError("AddVariableToX86reg\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void AdcX86regHalfToVariable(int x86reg, void * Variable, char * VariableName) {
@@ -118,13 +120,13 @@ void AdcX86regHalfToVariable(int x86reg, void * Variable, char * VariableName) {
 	default:
 		DisplayError("AdcX86regHalfToVariable\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void AdcConstToVariable(void *Variable, char *VariableName, BYTE Constant) {
 	CPU_Message("      adc dword ptr [%s], %Xh", VariableName, Constant);
 	PUTDST16(RecompPos,0x1583);
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 	PUTDST8(RecompPos,Constant);
 }
 
@@ -148,7 +150,7 @@ void AdcConstToX86reg( BYTE Constant, int x86reg ) {
 void AddConstToVariable (DWORD Const, void *Variable, char *VariableName) {
 	CPU_Message("      add dword ptr [%s], 0x%X",VariableName, Const);
 	PUTDST16(RecompPos,0x0581);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST32(RecompPos,Const);
 }
 
@@ -194,7 +196,7 @@ void AdcConstHalfToVariable(void *Variable, char *VariableName, BYTE Constant) {
 	PUTDST8(RecompPos,0x83);
 	PUTDST8(RecompPos,0x15);
 
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 
 	PUTDST8(RecompPos,Constant);
 }
@@ -213,7 +215,7 @@ void AddVariableToX86reg(int x86reg, void * Variable, char * VariableName) {
 	default:
 		DisplayError("AddVariableToX86reg\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void AddX86regToVariable(int x86reg, void * Variable, char * VariableName) {
@@ -230,7 +232,7 @@ void AddX86regToVariable(int x86reg, void * Variable, char * VariableName) {
 	default:
 		DisplayError("AddVariableToX86reg\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void AddX86regHalfToVariable(int x86reg, void * Variable, char * VariableName) {
@@ -250,7 +252,7 @@ void AddX86regHalfToVariable(int x86reg, void * Variable, char * VariableName) {
 	default:
 		DisplayError("AddVariableToX86reg\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void AddX86RegToX86Reg(int Destination, int Source) {
@@ -283,7 +285,7 @@ void AddX86RegToX86Reg(int Destination, int Source) {
 void AndConstToVariable (DWORD Const, void *Variable, char *VariableName) {
 	CPU_Message("      and dword ptr [%s], 0x%X",VariableName, Const);
 	PUTDST16(RecompPos,0x2581);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST32(RecompPos,Const);
 }
 
@@ -328,7 +330,7 @@ void AndVariableToX86Reg(void * Variable, char * VariableName, int x86Reg) {
 	case x86_ESP: PUTDST16(RecompPos,0x2523); break;
 	case x86_EBP: PUTDST16(RecompPos,0x2D23); break;
 	}
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void AndVariableToX86regHalf(void * Variable, char * VariableName, int x86Reg) {
@@ -344,7 +346,7 @@ void AndVariableToX86regHalf(void * Variable, char * VariableName, int x86Reg) {
 	case x86_ESP: PUTDST16(RecompPos,0x2523); break;
 	case x86_EBP: PUTDST16(RecompPos,0x2D23); break;
 	}
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void AndX86RegToVariable(void * Variable, char * VariableName, int x86Reg) {
@@ -359,7 +361,7 @@ void AndX86RegToVariable(void * Variable, char * VariableName, int x86Reg) {
 	case x86_ESP: PUTDST16(RecompPos,0x2521); break;
 	case x86_EBP: PUTDST16(RecompPos,0x2D21); break;
 	}
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void AndX86RegToX86Reg(int Destination, int Source) {
@@ -466,13 +468,13 @@ void BsrX86RegToX86Reg(int Destination, int Source) {
 void Call_Direct(void * FunctAddress, char * FunctName) {
 	CPU_Message("      call offset %s",FunctName);
 	PUTDST8(RecompPos,0xE8);
-	PUTDST32(RecompPos,(DWORD)FunctAddress-(DWORD)RecompPos - 4);
+	PUTDSTPTR(RecompPos, (size_t)FunctAddress - (size_t)RecompPos - sizeof(void *));
 }
 
 void Call_Indirect(void * FunctAddress, char * FunctName) {
 	CPU_Message("      call [%s]",FunctName);
 	PUTDST16(RecompPos,0x15FF);
-	PUTDST32(RecompPos,FunctAddress);
+	PUTDSTPTR(RecompPos, FunctAddress);
 }
 
 void CondMoveEqual(int Destination, int Source) {
@@ -730,7 +732,7 @@ void CondMoveLessEqual(int Destination, int Source) {
 void CompConstToVariable(DWORD Const, void * Variable, char * VariableName) {
 	CPU_Message("      cmp dword ptr [%s], 0x%X",VariableName, Const);
 	PUTDST16(RecompPos,0x3D81);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST32(RecompPos,Const);
 }
 
@@ -740,7 +742,7 @@ void CompConstHalfToVariable(WORD Const, void * Variable, char * VariableName) {
 	PUTDST8(RecompPos,0x81);
 	PUTDST8(RecompPos,0x3D);
 
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST16(RecompPos,Const);
 }
 
@@ -789,7 +791,7 @@ void CompX86regToVariable(int x86Reg, void * Variable, char * VariableName) {
 	default:
 		DisplayError("Unknown x86 Register");
 	}
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void CompVariableToX86reg(int x86Reg, void * Variable, char * VariableName) {
@@ -806,7 +808,7 @@ void CompVariableToX86reg(int x86Reg, void * Variable, char * VariableName) {
 	default:
 		DisplayError("Unknown x86 Register");
 	}
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void CompX86RegToX86Reg(int Destination, int Source) {
@@ -1149,7 +1151,7 @@ void LeaSourceAndOffset(int x86DestReg, int x86SourceReg, size_t offset) {
 void MoveConstByteToVariable (BYTE Const,void *Variable, char *VariableName) {
 	CPU_Message("      mov byte ptr [%s], %Xh",VariableName,Const);
 	PUTDST16(RecompPos,0x05C6);
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
     PUTDST8(RecompPos,Const);
 }
 
@@ -1157,14 +1159,14 @@ void MoveConstHalfToVariable (WORD Const,void *Variable, char *VariableName) {
 	CPU_Message("      mov word ptr [%s], %Xh",VariableName,Const);
 	PUTDST8(RecompPos,0x66);
 	PUTDST16(RecompPos,0x05C7);
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
     PUTDST16(RecompPos,Const);
 }
 
 void MoveConstToVariable (DWORD Const,void *Variable, char *VariableName) {
 	CPU_Message("      mov dword ptr [%s], %Xh",VariableName,Const);
 	PUTDST16(RecompPos,0x05C7);
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
     PUTDST32(RecompPos,Const);
 }
 
@@ -1481,7 +1483,7 @@ void MoveN64MemDispToX86reg(int x86reg, int AddrReg, BYTE Disp) {
 	case x86_EBP: x86Command += 0xA800; break;
 	}
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM + Disp);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM + Disp);
 }
 
 void MoveN64MemToX86reg(int x86reg, int AddrReg) {
@@ -1510,7 +1512,7 @@ void MoveN64MemToX86reg(int x86reg, int AddrReg) {
 	case x86_EBP: x86Command += 0xA800; break;
 	}
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void MoveN64MemToX86regByte(int x86reg, int AddrReg) {
@@ -1537,7 +1539,7 @@ void MoveN64MemToX86regByte(int x86reg, int AddrReg) {
 		break;
 	}
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void MoveN64MemToX86regHalf(int x86reg, int AddrReg) {
@@ -1567,7 +1569,7 @@ void MoveN64MemToX86regHalf(int x86reg, int AddrReg) {
 	case x86_EBP: x86Command += 0xA800; break;
 	}
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void MoveX86regByteToN64Mem(int x86reg, int AddrReg) {
@@ -1590,7 +1592,7 @@ void MoveX86regByteToN64Mem(int x86reg, int AddrReg) {
 	case x86_EDX: x86Command += 0x9000; break;
 	}
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void MoveX86regHalfToN64Mem(int x86reg, int AddrReg) {
@@ -1619,7 +1621,7 @@ void MoveX86regHalfToN64Mem(int x86reg, int AddrReg) {
 	case x86_EBP: x86Command += 0xA800; break;
 	}
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void MoveX86regToN64Mem(int x86reg, int AddrReg) {
@@ -1647,7 +1649,7 @@ void MoveX86regToN64Mem(int x86reg, int AddrReg) {
 	case x86_EBP: x86Command += 0xA800; break;
 	}
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void MoveX86regToN64MemDisp(int x86reg, int AddrReg, BYTE Disp) {
@@ -1675,7 +1677,7 @@ void MoveX86regToN64MemDisp(int x86reg, int AddrReg, BYTE Disp) {
 	case x86_EBP: x86Command += 0xA800; break;
 	}
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM+Disp);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM + Disp);
 }
 
 void MoveVariableToX86reg(void *Variable, char *VariableName, int x86reg) {
@@ -1691,7 +1693,7 @@ void MoveVariableToX86reg(void *Variable, char *VariableName, int x86reg) {
 	case x86_EBP: PUTDST16(RecompPos,0x2D8B); break;
 	default: DisplayError("MoveVariableToX86reg\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void MoveVariableToX86regByte(void *Variable, char *VariableName, int x86reg) {
@@ -1703,7 +1705,7 @@ void MoveVariableToX86regByte(void *Variable, char *VariableName, int x86reg) {
 	case x86_EDX: PUTDST16(RecompPos,0x158A); break;
 	default: DisplayError("MoveVariableToX86regByte\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void MoveVariableToX86regHalf(void *Variable, char *VariableName, int x86reg) {
@@ -1720,7 +1722,7 @@ void MoveVariableToX86regHalf(void *Variable, char *VariableName, int x86reg) {
 	case x86_EBP: PUTDST16(RecompPos,0x2D8B); break;
 	default: DisplayError("MoveVariableToX86reg\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void MoveX86regByteToVariable(int x86reg, void * Variable, char * VariableName) {
@@ -1733,7 +1735,7 @@ void MoveX86regByteToVariable(int x86reg, void * Variable, char * VariableName) 
 	default:
 		DisplayError("MoveX86regByteToVariable\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void MoveX86regHalfToVariable(int x86reg, void * Variable, char * VariableName) {
@@ -1751,7 +1753,7 @@ void MoveX86regHalfToVariable(int x86reg, void * Variable, char * VariableName) 
 	default:
 		DisplayError("MoveX86regHalfToVariable\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void MoveX86regToVariable(int x86reg, void * Variable, char * VariableName) {
@@ -1768,7 +1770,7 @@ void MoveX86regToVariable(int x86reg, void * Variable, char * VariableName) {
 	default:
 		DisplayError("MoveX86regToVariable\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void MoveX86RegToX86Reg(int Source, int Destination) {
@@ -1877,7 +1879,7 @@ void MoveSxVariableToX86regByte(void *Variable, char *VariableName, int x86reg) 
 	case x86_EBP: PUTDST8(RecompPos,0x2D); break;
 	default: DisplayError("MoveSxVariableToX86regByte\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void MoveSxVariableToX86regHalf(void *Variable, char *VariableName, int x86reg) {
@@ -1896,7 +1898,7 @@ void MoveSxVariableToX86regHalf(void *Variable, char *VariableName, int x86reg) 
 	case x86_EBP: PUTDST8(RecompPos,0x2D); break;
 	default: DisplayError("MoveSxVariableToX86regHalf\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void MoveSxN64MemToX86regByte(int x86reg, int AddrReg) {
@@ -1924,7 +1926,7 @@ void MoveSxN64MemToX86regByte(int x86reg, int AddrReg) {
 	}
 	PUTDST8(RecompPos,0x0f);
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void MoveSxN64MemToX86regHalf(int x86reg, int AddrReg) {
@@ -1955,7 +1957,7 @@ void MoveSxN64MemToX86regHalf(int x86reg, int AddrReg) {
 
 	PUTDST8(RecompPos, 0x0f);
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void MoveZxX86RegHalfToX86Reg(int Source, int Destination) {
@@ -2035,7 +2037,7 @@ void MoveZxVariableToX86regByte(void *Variable, char *VariableName, int x86reg) 
 	case x86_EBP: PUTDST8(RecompPos,0x2D); break;
 	default: DisplayError("MoveZxVariableToX86regByte\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void MoveZxVariableToX86regHalf(void *Variable, char *VariableName, int x86reg) {
@@ -2054,7 +2056,7 @@ void MoveZxVariableToX86regHalf(void *Variable, char *VariableName, int x86reg) 
 	case x86_EBP: PUTDST8(RecompPos,0x2D); break;
 	default: DisplayError("MoveZxVariableToX86regHalf\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void MoveZxN64MemToX86regByte(int x86reg, int AddrReg) {
@@ -2082,7 +2084,7 @@ void MoveZxN64MemToX86regByte(int x86reg, int AddrReg) {
 	}
 	PUTDST8(RecompPos,0x0f);
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void MoveZxN64MemToX86regHalf(int x86reg, int AddrReg) {
@@ -2113,7 +2115,7 @@ void MoveZxN64MemToX86regHalf(int x86reg, int AddrReg) {
 
 	PUTDST8(RecompPos, 0x0f);
 	PUTDST16(RecompPos,x86Command);
-	PUTDST32(RecompPos,RSPInfo.DMEM);
+	PUTDSTPTR(RecompPos, RSPInfo.DMEM);
 }
 
 void MulX86reg(int x86reg) {
@@ -2167,7 +2169,7 @@ void NotX86reg(int x86reg) {
 void OrConstToVariable(DWORD Const, void * Variable, char * VariableName) {
 	CPU_Message("      or dword ptr [%s], 0x%X",VariableName, Const);
 	PUTDST16(RecompPos,0x0D81);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST32(RecompPos,Const);
 }
 
@@ -2212,7 +2214,7 @@ void OrVariableToX86Reg(void * Variable, char * VariableName, int x86Reg) {
 	case x86_ESP: PUTDST16(RecompPos,0x250B); break;
 	case x86_EBP: PUTDST16(RecompPos,0x2D0B); break;
 	}
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void OrVariableToX86regHalf(void * Variable, char * VariableName, int x86Reg) {
@@ -2228,7 +2230,7 @@ void OrVariableToX86regHalf(void * Variable, char * VariableName, int x86Reg) {
 	case x86_ESP: PUTDST16(RecompPos,0x250B); break;
 	case x86_EBP: PUTDST16(RecompPos,0x2D0B); break;
 	}
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void OrX86RegToVariable(void * Variable, char * VariableName, int x86Reg) {
@@ -2243,7 +2245,7 @@ void OrX86RegToVariable(void * Variable, char * VariableName, int x86Reg) {
 	case x86_ESP: PUTDST16(RecompPos,0x2509); break;
 	case x86_EBP: PUTDST16(RecompPos,0x2D09); break;
 	}
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void OrX86RegToX86Reg(int Destination, int Source) {
@@ -2341,14 +2343,14 @@ void SetlVariable(void * Variable, char * VariableName) {
 	CPU_Message("      setl byte ptr [%s]",VariableName);
 	PUTDST16(RecompPos,0x9C0F);
 	PUTDST8(RecompPos,0x05);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void SetleVariable(void * Variable, char * VariableName) {
 	CPU_Message("      setle byte ptr [%s]",VariableName);
 	PUTDST16(RecompPos,0x9E0F);
 	PUTDST8(RecompPos,0x05);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void Setb(int x86reg) {
@@ -2368,7 +2370,7 @@ void SetbVariable(void * Variable, char * VariableName) {
 	CPU_Message("      setb byte ptr [%s]",VariableName);
 	PUTDST16(RecompPos,0x920F);
 	PUTDST8(RecompPos,0x05);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void Setg(int x86reg) {
@@ -2388,14 +2390,14 @@ void SetgVariable(void * Variable, char * VariableName) {
 	CPU_Message("      setg byte ptr [%s]",VariableName);
 	PUTDST16(RecompPos,0x9F0F);
 	PUTDST8(RecompPos,0x05);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void SetgeVariable(void * Variable, char * VariableName) {
 	CPU_Message("      setge byte ptr [%s]",VariableName);
 	PUTDST16(RecompPos,0x9D0F);
 	PUTDST8(RecompPos,0x05);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void Seta(int x86reg) {
@@ -2415,7 +2417,7 @@ void SetaVariable(void * Variable, char * VariableName) {
 	CPU_Message("      seta byte ptr [%s]",VariableName);
 	PUTDST16(RecompPos,0x970F);
 	PUTDST8(RecompPos,0x05);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void Setae(int x86reg) {
@@ -2448,7 +2450,7 @@ void SetzVariable(void * Variable, char * VariableName) {
 	CPU_Message("      setz byte ptr [%s]",VariableName);
 	PUTDST16(RecompPos,0x940F);
 	PUTDST8(RecompPos,0x05);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void Setnz(int x86reg) {
@@ -2468,7 +2470,7 @@ void SetnzVariable(void * Variable, char * VariableName) {
 	CPU_Message("      setnz byte ptr [%s]",VariableName);
 	PUTDST16(RecompPos,0x950F);
 	PUTDST8(RecompPos,0x05);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 }
 
 void ShiftLeftDoubleImmed(int Destination, int Source, BYTE Immediate) {
@@ -2568,7 +2570,7 @@ void ShiftLeftSignVariableImmed(void *Variable, char *VariableName, BYTE Immedia
 	CPU_Message("      shl dword ptr [%s], %Xh",VariableName, Immediate);
 
 	PUTDST16(RecompPos,0x25C1)
-	PUTDST32(RecompPos, Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST8(RecompPos,Immediate);
 }
 
@@ -2593,7 +2595,7 @@ void ShiftRightSignVariableImmed(void *Variable, char *VariableName, BYTE Immedi
 	CPU_Message("      sar dword ptr [%s], %Xh",VariableName, Immediate);
 
 	PUTDST16(RecompPos,0x3DC1)
-	PUTDST32(RecompPos, Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST8(RecompPos,Immediate);
 }
 
@@ -2630,14 +2632,14 @@ void ShiftRightUnsignVariableImmed(void *Variable, char *VariableName, BYTE Imme
 	CPU_Message("      shr dword ptr [%s], %Xh",VariableName, Immediate);
 
 	PUTDST16(RecompPos,0x2DC1)
-	PUTDST32(RecompPos, Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST8(RecompPos,Immediate);
 }
 
 void SubConstFromVariable (DWORD Const, void *Variable, char *VariableName) {
 	CPU_Message("      sub dword ptr [%s], 0x%X",VariableName, Const);\
 	PUTDST16(RecompPos,0x2D81);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST32(RecompPos,Const);
 }
 
@@ -2684,7 +2686,7 @@ void SubVariableFromX86reg(int x86reg, void * Variable, char * VariableName) {
 	default:
 		DisplayError("SubVariableFromX86reg\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void SubX86regFromVariable(int x86reg, void * Variable, char * VariableName) {
@@ -2701,7 +2703,7 @@ void SubX86regFromVariable(int x86reg, void * Variable, char * VariableName) {
 	default:
 		DisplayError("SubX86regFromVariable\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void SubX86RegToX86Reg(int Destination, int Source) {
@@ -2759,7 +2761,7 @@ void SbbX86RegToX86Reg(int Destination, int Source) {
 void TestConstToVariable(DWORD Const, void * Variable, char * VariableName) {
 	CPU_Message("      test dword ptr [%s], 0x%X",VariableName, Const);
 	PUTDST16(RecompPos,0x05F7);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST32(RecompPos,Const);
 }
 
@@ -2840,7 +2842,7 @@ void XorConstToVariable(void *Variable, char *VariableName, DWORD Const) {
 	CPU_Message("      xor dword ptr [%s], 0x%X",VariableName, Const);
 
 	PUTDST16(RecompPos, 0x3581);
-	PUTDST32(RecompPos,Variable);
+	PUTDSTPTR(RecompPos, Variable);
 	PUTDST32(RecompPos, Const);
 }
 
@@ -2885,7 +2887,7 @@ void XorVariableToX86reg(void *Variable, char *VariableName, int x86reg) {
 	case x86_EBP: PUTDST16(RecompPos,0x2D33); break;
 	default: DisplayError("XorVariableToX86reg\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }
 
 void XorX86RegToVariable(void *Variable, char *VariableName, int x86reg) {
@@ -2901,5 +2903,5 @@ void XorX86RegToVariable(void *Variable, char *VariableName, int x86reg) {
 	case x86_EBP: PUTDST16(RecompPos,0x2D31); break;
 	default: DisplayError("XorX86RegToVariable\nUnknown x86 Register");
 	}
-    PUTDST32(RecompPos,Variable);
+    PUTDSTPTR(RecompPos, Variable);
 }

--- a/Source/RSP/X86.c
+++ b/Source/RSP/X86.c
@@ -427,7 +427,11 @@ void BreakPointNotification (const char * const FileName, const int LineNumber) 
 void X86BreakPoint (LPCSTR FileName, int LineNumber) {
 	Pushad();
 	PushImm32("LineNumber",LineNumber);
+#if defined(_M_IX86)
 	PushImm32("FileName",(DWORD)FileName);
+#else
+	DisplayError("PushImm64\nUnimplemented.");
+#endif
 	Call_Direct(BreakPointNotification,"BreakPointNotification");
 	AddConstToX86Reg(x86_ESP, 8);
 	Popad();

--- a/Source/RSP/X86.h
+++ b/Source/RSP/X86.h
@@ -114,7 +114,7 @@ void MoveConstToN64Mem				( DWORD Const, int AddrReg );
 void MoveConstToN64MemDisp			( DWORD Const, int AddrReg, BYTE Disp );
 void MoveConstToVariable			( DWORD Const, void *Variable, char *VariableName );
 void MoveConstToX86reg				( DWORD Const, int x86reg );
-void MoveOffsetToX86reg				( DWORD Const, char * VariableName, int x86reg );
+void MoveOffsetToX86reg				( size_t Const, char * VariableName, int x86reg );
 void MoveX86regByteToX86regPointer	( int Source, int AddrReg );
 void MoveX86regHalfToX86regPointer	( int Source, int AddrReg );
 void MoveX86regHalfToX86regPointerDisp ( int Source, int AddrReg, BYTE Disp);

--- a/Source/RSP/X86.h
+++ b/Source/RSP/X86.h
@@ -46,7 +46,7 @@ void AdcConstToX86reg				( BYTE Constant, int x86reg );
 void AdcConstToVariable				( void *Variable, char *VariableName, BYTE Constant );
 void AdcConstHalfToVariable			( void *Variable, char *VariableName, BYTE Constant );
 void AddConstToVariable				( DWORD Const, void *Variable, char *VariableName );
-void AddConstToX86Reg				( int x86Reg, DWORD Const );
+void AddConstToX86Reg				( int x86Reg, size_t Const );
 void AddVariableToX86reg			( int x86reg, void * Variable, char * VariableName );
 void AddX86regToVariable			( int x86reg, void * Variable, char * VariableName );
 void AddX86regHalfToVariable		( int x86reg, void * Variable, char * VariableName );

--- a/Source/RSP/X86.h
+++ b/Source/RSP/X86.h
@@ -105,7 +105,7 @@ void JneLabel32						( char * Label, DWORD Value );
 void JnsLabel8						( char * Label, BYTE Value );
 void JnsLabel32						( char * Label, DWORD Value );
 void JsLabel32						( char * Label, DWORD Value );
-void LeaSourceAndOffset				( int x86DestReg, int x86SourceReg, int offset );
+void LeaSourceAndOffset				( int x86DestReg, int x86SourceReg, size_t offset );
 void MoveConstByteToN64Mem			( BYTE Const, int AddrReg );
 void MoveConstHalfToN64Mem			( WORD Const, int AddrReg );
 void MoveConstByteToVariable		( BYTE Const,void *Variable, char *VariableName );

--- a/Source/RSP/dma.c
+++ b/Source/RSP/dma.c
@@ -71,7 +71,7 @@ void SP_DMA_READ (void)
 	{
 		for (i = 0 ; i < Length; i++)
 		{
-			*(BYTE *)(((DWORD)Dest + j * Length + i) ^ 3) = *(BYTE *)(((DWORD)Source + j * Skip + i) ^ 3);
+			*(uint8_t *)(((size_t)Dest + j * Length + i) ^ 3) = *(uint8_t *)(((size_t)Source + j * Skip + i) ^ 3);
 		}
 	}
 #else
@@ -90,7 +90,7 @@ void SP_DMA_READ (void)
 		{
 			for (i = 0 ; i < Length; i++)
 			{
-				*(BYTE *)(((DWORD)Dest + i) ^ 3) = *(BYTE *)(((DWORD)Source + i) ^ 3);
+				*(uint8_t *)(((size_t)Dest + i) ^ 3) = *(uint8_t *)(((size_t)Source + i) ^ 3);
 			}
 			Source += Skip;
 			Dest += Length;
@@ -138,7 +138,7 @@ void SP_DMA_WRITE (void)
 	{
 		for (i = 0 ; i < Length; i++)
 		{
-			*(BYTE *)(((DWORD)Dest + j * Skip + i) ^ 3) = *(BYTE *)(((DWORD)Source + j * Length + i) ^ 3);
+			*(uint8_t *)(((size_t)Dest + j * Skip + i) ^ 3) = *(uint8_t *)(((size_t)Source + j * Length + i) ^ 3);
 		}
 	}
 #else
@@ -157,7 +157,7 @@ void SP_DMA_WRITE (void)
 		{
 			for (i = 0 ; i < Length; i++)
 			{
-				*(BYTE *)(((DWORD)Dest + i) ^ 3) = *(BYTE *)(((DWORD)Source + i) ^ 3);
+				*(uint8_t *)(((size_t)Dest + i) ^ 3) = *(uint8_t *)(((size_t)Source + i) ^ 3);
 			}
 			Source += Length;
 			Dest += Skip;


### PR DESCRIPTION
Definitely one of my dumber pull requests, as sadly it helps get the re-compiler working in 64-bit. :(

Although, on the bright side, it does at least fix all those annoying warning messages in the MinGW console when you go to compile. :P It also fixes broken SP DMA pointer truncation in the interpreter.

Have not checked if all 64-bit MSVC warnings were fixed by these changes as well.