### PR TITLE
Filter compiled sources and build files from Git view.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,14 @@
 *.sdf
 *.suo
 *.user
+
+# compiler-generated sources (MSVC, GCC)
+*.asm
+*.s
+
+# assembled linker objects (GCC)
+*.o
+
 Thumbs.db
 /Bin/Debug
 /Bin/Debug64


### PR DESCRIPTION
As we have build scripts in the repository for MinGW, people may notice when using those to compile that a lot of *.s (asm sources, actually I made it .asm in this case for x86 syntax) and *.o (for the linker) files.

This update is just an option so that they don't show in Git commands/views for staging files for commit.