### PR TITLE
Set target machine for Static Library projects.

### DIFF
--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -195,6 +195,9 @@
   
   <!-- Win32 -->
   <ItemDefinitionGroup Condition="'$(Platform)'=='Win32'">
+    <Lib>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Lib>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
     </Link>
@@ -212,6 +215,9 @@
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition="'$(Platform)'=='x64'">
+    <Lib>
+      <TargetMachine>MachineX64</TargetMachine>
+    </Lib>
     <Link>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>


### PR DESCRIPTION
Currently, only DLL projects (such as plugins) and executables set the /MACHINE argument explicitly.
.LIB targets (such as wx and Common) projects make the compiler guess the hardware platform throwing the following type of warning:
```
LINK : warning LNK4068: /MACHINE not specified; defaulting to X86 [Source\3rd Party\sdl\sdl2.vcxproj]
```

This change sets the target machine for static libraries on both Win32 and Win64 platforms.