### PR TITLE
[Common] MaxFileSize:  Use size_t for memory sizes.

### DIFF
--- a/Source/Common/Log Class.h
+++ b/Source/Common/Log Class.h
@@ -15,8 +15,8 @@ class CLog
 	bool   m_FlushOnWrite;
 	stdstr m_FileName;
 	bool   m_TruncateFileLog;
-	uint32_t  m_MaxFileSize;
-	uint32_t  m_FileChangeSize;
+	size_t m_MaxFileSize;
+	size_t m_FileChangeSize;
 
 public:
 	 CLog ( void );
@@ -29,10 +29,10 @@ public:
 	bool Empty    ( void );
 	void Close    ( void );
 	
-	inline void SetMaxFileSize ( uint32_t Size )    
-	{ 
-		m_MaxFileSize = Size; 
-		m_FileChangeSize = (uint32_t)(Size * 0.1);
+	inline void SetMaxFileSize(size_t Size)
+	{
+		m_MaxFileSize = Size;
+		m_FileChangeSize = (size_t)(Size * 0.1);
 	}
 	inline void SetTruncateFile( bool Truncate ) { m_TruncateFileLog = Truncate; }
 	inline void SetFlush       ( bool Always )   { m_FlushOnWrite = Always; }

--- a/Source/Common/Trace.cpp
+++ b/Source/Common/Trace.cpp
@@ -191,7 +191,7 @@ m_FlushFile(FlushFile)
 	m_hLogFile.Open(FileName, Log_Append);
 }
 
-CTraceFileLog::CTraceFileLog(LPCTSTR FileName, bool FlushFile, LOG_OPEN_MODE eMode, uint32_t dwMaxFileSize) :
+CTraceFileLog::CTraceFileLog(LPCTSTR FileName, bool FlushFile, LOG_OPEN_MODE eMode, size_t dwMaxFileSize) :
 m_FlushFile(FlushFile)
 {
 	enum { MB = 1024 * 1024 };
@@ -199,14 +199,11 @@ m_FlushFile(FlushFile)
 	m_hLogFile.SetFlush(false);
 	m_hLogFile.SetTruncateFile(true);
 
-	if (dwMaxFileSize < 2048 && dwMaxFileSize > 2)
-	{
-		m_hLogFile.SetMaxFileSize(dwMaxFileSize * MB);
+	if (dwMaxFileSize < 3 || dwMaxFileSize > 2047)
+	{ /* Clamp file size to 5 MB if it exceeds 2047 or falls short of 3. */
+		dwMaxFileSize = 5;
 	}
-	else
-	{
-		m_hLogFile.SetMaxFileSize(5 * MB);
-	}
+	m_hLogFile.SetMaxFileSize(dwMaxFileSize * MB);
 
 	m_hLogFile.Open(FileName, eMode);
 }

--- a/Source/Common/Trace.h
+++ b/Source/Common/Trace.h
@@ -26,7 +26,7 @@ class CTraceFileLog : public CTraceModule
 
 public:
     CTraceFileLog (const char * FileName, bool FlushFile = true);
-    CTraceFileLog (const char * FileName, bool FlushFile, LOG_OPEN_MODE eMode, uint32_t dwMaxFileSize = 5);
+    CTraceFileLog(const char * FileName, bool FlushFile, LOG_OPEN_MODE eMode, size_t dwMaxFileSize = 5);
     virtual ~CTraceFileLog ();
 
     void Write ( const char * Message, bool EndOfLine );


### PR DESCRIPTION
What does `uint32_t` have to do with anything?

It's just a file size--either less or more than 32 bits in storage.  A better and more portable type for `MaxFileSize()` would be `unsigned long` or, better yet, `size_t`.  The latter is slightly preferable in that the C standard has this type pertinent to memory limits (such as the index into an array of elements).  It also is slightly preferable to `long` because only `size_t` can be a 64-bit type on Windows, due to Microsoft's stupid ABI.