### PR TITLE
[Common] Use standard C memory limit `size_t` type.

### DIFF
--- a/Source/Common/File Class.cpp
+++ b/Source/Common/File Class.cpp
@@ -165,19 +165,23 @@ bool CFile::Write(const void* lpBuf, size_t nCount)
     return true;
 }
 
-uint32_t CFile::Read(void* lpBuf, uint32_t nCount)
+size_t CFile::Read(void* lpBuf, size_t nCount)
 {
     if (nCount == 0)
     {
         return 0;   // avoid Win32 "null-read"
     }
+    if (nCount > ULONG_MAX)
+    {
+        nCount = ULONG_MAX; /* Or should we loop ReadFile() every 2 GB? */
+    }
 
     DWORD dwRead = 0;
-    if (!::ReadFile(m_hFile, lpBuf, nCount, &dwRead, NULL))
+    if (!::ReadFile(m_hFile, lpBuf, (DWORD)nCount, &dwRead, NULL))
     {
         return 0;
     }
-    return (uint32_t)dwRead;
+    return (dwRead);
 }
 
 long CFile::Seek(long lOff, SeekPosition nFrom)

--- a/Source/Common/File Class.cpp
+++ b/Source/Common/File Class.cpp
@@ -140,15 +140,19 @@ bool CFile::Flush()
     return ::FlushFileBuffers(m_hFile) != 0;
 }
 
-bool CFile::Write(const void* lpBuf, uint32_t nCount)
+bool CFile::Write(const void* lpBuf, size_t nCount)
 {
     if (nCount == 0)
     {
         return true;     // avoid Win32 "null-write" option
     }
+    if (nCount > ULONG_MAX)
+    {
+        nCount = ULONG_MAX; /* Or should we loop WriteFile() every 2 GB? */
+    }
 
-    ULONG nWritten = 0;
-    if (!::WriteFile(m_hFile, lpBuf, nCount, &nWritten, NULL))
+    DWORD nWritten = 0;
+    if (!::WriteFile(m_hFile, lpBuf, (DWORD)nCount, &nWritten, NULL))
     {
         return false;
     }

--- a/Source/Common/File Class.h
+++ b/Source/Common/File Class.h
@@ -41,7 +41,7 @@ public:
     virtual uint32_t GetLength() const = 0;
 
     virtual uint32_t Read(void* lpBuf, uint32_t nCount) = 0;
-    virtual bool Write(const void* lpBuf, uint32_t nCount) = 0;
+    virtual bool Write(const void* lpBuf, size_t nCount) = 0;
 
     virtual bool Flush() = 0;
     virtual bool Close() = 0;
@@ -79,7 +79,7 @@ public:
     virtual uint32_t GetLength() const;
 
     virtual uint32_t Read(void* lpBuf, uint32_t nCount);
-    virtual bool Write(const void* lpBuf, uint32_t nCount);
+    virtual bool Write(const void* lpBuf, size_t nCount);
 
     virtual bool Flush();
     virtual bool Close();

--- a/Source/Common/File Class.h
+++ b/Source/Common/File Class.h
@@ -40,7 +40,7 @@ public:
     virtual bool SetLength(uint32_t dwNewLen) = 0;
     virtual uint32_t GetLength() const = 0;
 
-    virtual uint32_t Read(void* lpBuf, uint32_t nCount) = 0;
+    virtual size_t Read(void* lpBuf, size_t nCount) = 0;
     virtual bool Write(const void* lpBuf, size_t nCount) = 0;
 
     virtual bool Flush() = 0;
@@ -78,7 +78,7 @@ public:
     virtual bool SetLength(uint32_t dwNewLen);
     virtual uint32_t GetLength() const;
 
-    virtual uint32_t Read(void* lpBuf, uint32_t nCount);
+    virtual size_t Read(void* lpBuf, size_t nCount);
     virtual bool Write(const void* lpBuf, size_t nCount);
 
     virtual bool Flush();

--- a/Source/Common/Log Class.cpp
+++ b/Source/Common/Log Class.cpp
@@ -120,7 +120,7 @@ void CLog::LogArgs(const char * Message, va_list & args )
 void CLog::Log( const char * Message )
 {
 	if (!m_hLogFile.IsOpen()) { return; }
-	m_hLogFile.Write(Message,(uint32_t)strlen(Message)*sizeof(TCHAR));
+	m_hLogFile.Write(Message, strlen(Message)*sizeof(TCHAR));
 	if (m_FlushOnWrite)
 	{
 		m_hLogFile.Flush();

--- a/Source/Common/Log Class.cpp
+++ b/Source/Common/Log Class.cpp
@@ -145,13 +145,13 @@ void CLog::Log( const char * Message )
 			m_hLogFile.Seek((end - m_MaxFileSize) + m_FileChangeSize,CFile::begin);
 
 			// Find next end of line
-			uint32_t NextEnter = 0, dwRead = 0;
+			size_t NextEnter = 0, dwRead = 0;
 			do 
 			{
 				BYTE Data[300];
-				uint32_t dwRead;
+				size_t dwRead;
 
-				dwRead = m_hLogFile.Read(Data,sizeof(Data));
+				dwRead = m_hLogFile.Read(Data, sizeof(Data));
 				if (dwRead == 0)
 				{ 
 					break;
@@ -170,8 +170,9 @@ void CLog::Log( const char * Message )
 			} while(dwRead != 0);
 
 			// copy content of log to the new file
-			uint32_t ReadPos = (end - m_MaxFileSize) + m_FileChangeSize + NextEnter;
-			uint32_t SizeToRead, WritePos = 0;
+			size_t ReadPos = (end - m_MaxFileSize) + m_FileChangeSize + NextEnter;
+			uint32_t WritePos = 0;
+			size_t SizeToRead;
 			do 
 			{
 				enum { fIS_MvSize  = 0x5000 };
@@ -182,8 +183,8 @@ void CLog::Log( const char * Message )
 
 				m_hLogFile.Seek(ReadPos,CFile::begin);
 
-				uint32_t dwRead;
-				dwRead = m_hLogFile.Read(Data,SizeToRead);
+				size_t dwRead;
+				dwRead = m_hLogFile.Read(Data, SizeToRead);
 
 				m_hLogFile.Seek(WritePos,CFile::begin);
 


### PR DESCRIPTION
Related to pull request https://github.com/project64/project64/pull/727 .

Here, again, `uint32_t` is a completely arbitrary and random choice of type, because 32-bit precision has nothing to do with any of these functions in a platform-agnostic sense.