### PR TITLE
[Common] Use size-neutral types.

### DIFF
--- a/Source/Common/SyncEvent.cpp
+++ b/Source/Common/SyncEvent.cpp
@@ -15,9 +15,9 @@ void SyncEvent::Trigger()
     SetEvent(m_Event);
 }
 
-bool SyncEvent::IsTriggered(int32_t iWaitTime)
+bool SyncEvent::IsTriggered(size_t iWaitTime)
 {
-    return (WAIT_OBJECT_0 == WaitForSingleObject(m_Event,iWaitTime));
+    return (WAIT_OBJECT_0 == WaitForSingleObject(m_Event, iWaitTime));
 }
 
 void SyncEvent::Reset()

--- a/Source/Common/SyncEvent.h
+++ b/Source/Common/SyncEvent.h
@@ -9,7 +9,7 @@ public:
     ~SyncEvent(void);
 
     void Trigger (void);
-    bool IsTriggered (int32_t iWaitTime = 0);
+    bool IsTriggered(size_t iWaitTime = 0);
     void Reset();
     void * GetHandle();
 

--- a/Source/Common/Util.cpp
+++ b/Source/Common/Util.cpp
@@ -2,7 +2,7 @@
 #include "Util.h"
 #include <Tlhelp32.h>
 
-void pjutil::Sleep(uint32_t timeout)
+void pjutil::Sleep(unsigned long timeout)
 {
     ::Sleep(timeout);
 }

--- a/Source/Common/Util.cpp
+++ b/Source/Common/Util.cpp
@@ -2,7 +2,7 @@
 #include "Util.h"
 #include <Tlhelp32.h>
 
-void pjutil::Sleep(unsigned long timeout)
+void pjutil::Sleep(size_t timeout)
 {
     ::Sleep(timeout);
 }

--- a/Source/Common/Util.h
+++ b/Source/Common/Util.h
@@ -4,7 +4,7 @@
 class pjutil
 {
 public:
-    static void Sleep(uint32_t timeout);
+    static void Sleep(unsigned long timeout);
     static bool TerminatedExistingExe();
 
 private:

--- a/Source/Common/Util.h
+++ b/Source/Common/Util.h
@@ -4,7 +4,7 @@
 class pjutil
 {
 public:
-    static void Sleep(unsigned long timeout);
+    static void Sleep(size_t timeout);
     static bool TerminatedExistingExe();
 
 private:


### PR DESCRIPTION
Somewhat (but not really) related to https://github.com/project64/project64/pull/728 .

Here, again, `int32_t` is a completely random and arbitrary preference of parameter type, as the relevant functions have no pertinence to the necessity of having 32-bit precision (let alone exactly that).

What happens if you're compiling for a system whose `Sleep()` function equivalent, for example, only accepts a 64-bit (or a 21-bit, or 16-bit) unsigned integer for the timeout counter in milliseconds?  This choice of `uint32_t` is still partly biased to the Windows `Sleep()` function and is not really portable.

A better choice would be the neutral type `unsigned long`, but `size_t` would be understandable.