### PR TITLE
CTLB:  Replace `int' with `size_t'.

### DIFF
--- a/Source/Project64/N64 System/Mips/TLB class.cpp
+++ b/Source/Project64/N64 System/Mips/TLB class.cpp
@@ -303,7 +303,8 @@ void CTLB::RecordDifference( CLog &LogFile, const CTLB& rTLB)
 
 bool CTLB::operator == (const CTLB& rTLB) const
 {
-    for (size_t i = 0, n = sizeof(m_tlb)/sizeof(m_tlb[0]); i < n; i++)
+    const size_t n = sizeof(m_tlb) / sizeof(TLB_ENTRY);
+    for (size_t i = 0; i < n; i++)
     {
         if (m_tlb[i].EntryDefined != rTLB.m_tlb[i].EntryDefined)
         {

--- a/Source/Project64/N64 System/Mips/TLB class.cpp
+++ b/Source/Project64/N64 System/Mips/TLB class.cpp
@@ -303,7 +303,7 @@ void CTLB::RecordDifference( CLog &LogFile, const CTLB& rTLB)
 
 bool CTLB::operator == (const CTLB& rTLB) const
 {
-    const size_t n = sizeof(m_tlb) / sizeof(TLB_ENTRY);
+    const size_t n = sizeof(m_tlb) / sizeof(m_tlb[0]);
     for (size_t i = 0; i < n; i++)
     {
         if (m_tlb[i].EntryDefined != rTLB.m_tlb[i].EntryDefined)

--- a/Source/Project64/N64 System/Mips/TLB class.cpp
+++ b/Source/Project64/N64 System/Mips/TLB class.cpp
@@ -303,7 +303,7 @@ void CTLB::RecordDifference( CLog &LogFile, const CTLB& rTLB)
 
 bool CTLB::operator == (const CTLB& rTLB) const
 {
-    for (int i = 0, n = sizeof(m_tlb)/sizeof(m_tlb[0]); i < n; i++)
+    for (size_t i = 0, n = sizeof(m_tlb)/sizeof(m_tlb[0]); i < n; i++)
     {
         if (m_tlb[i].EntryDefined != rTLB.m_tlb[i].EntryDefined)
         {


### PR DESCRIPTION
To be awfully pedantic, `int` is not the best choice of type here.

1.  `sizeof()` operator yields the native source type `size_t`, which is not signed and larger than `int`.
2.  CPU memory limits such as the *n*th index into an array[] for `array[n]` are indicated by the standard type `size_t`, which defines the maximum index into such an array.

tl;dr:  `size_t` is better than `int` is better than `int32_t`, in order of least likely to break code. :)