### PR TITLE
[Plugin Specs] Change uint32_t to int32_t (formerly BOOL).

### DIFF
--- a/Source/Project64/Plugins/Controller Plugin.h
+++ b/Source/Project64/Plugins/Controller Plugin.h
@@ -45,9 +45,9 @@ typedef union
 
 typedef struct
 {
-    uint32_t Present;
-    uint32_t RawData;
-    int32_t   Plugin;
+    int32_t Present;
+    int32_t RawData;
+    int32_t Plugin;
 } CONTROL;
 
 enum PluginType


### PR DESCRIPTION
I still say these should be `int`, not `int32_t`.

But looking aside away from that issue, I would think `uint32_t` makes even less sense than `int32_t` does.  If I recall correctly, much of the reasoning for converting from C standard types to C99 exact-width types was for ABI predictability and being able to read what the size is right away.

So if these were `BOOL` (which is a signed int), why change them to `uint32_t` (which is unsigned int)?

Sure it may not break anything since you still write either 0 or 1 to it (FALSE or TRUE macros), but I thought the intended purpose of changing int to int32_t was to make the strict type clearer to the reader.