### PR TITLE
"Project 64" -> "Project64"

### DIFF
--- a/Source/Installer/Installer.iss
+++ b/Source/Installer/Installer.iss
@@ -5,7 +5,7 @@
 
 [Setup]
 AppId={{BEB5FB69-4080-466F-96C4-F15DF271718B}
-AppName=Project 64
+AppName=Project64
 AppVersion={#AppVersion}
 DefaultDirName={pf}\Project64 2.2
 VersionInfoVersion={#AppVersion}
@@ -21,7 +21,7 @@ UninstallDisplayIcon={uninstallexe}
 SetupIconFile={#BaseDir}\Source\Project64\User Interface\Icons\pj64.ico
 
 [Run]
-Filename: "{app}\Project64.exe"; Description: "{cm:LaunchProgram,{#StringChange('Project 64', '&', '&&')}}"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\Project64.exe"; Description: "{cm:LaunchProgram,{#StringChange('Project64', '&', '&&')}}"; Flags: nowait postinstall skipifsilent
 
 [Files]
 Source: "{#BaseDir}\Bin\{#Configuration}\Project64.exe"; DestDir: "{app}"; Flags: ignoreversion
@@ -44,9 +44,9 @@ Name: "{app}\Screenshots"; Permissions: users-modify
 Name: "{app}\Textures"; Permissions: users-modify
 
 [Icons]
-Name: "{commonprograms}\Project 64 2.2\Project 64"; Filename: "{app}\Project64.exe"
-Name: "{commonprograms}\Project 64 2.2\Uninstall Project64 2.2"; Filename: "{uninstallexe}"; Parameters: "/LOG"
-Name: "{commonprograms}\Project 64 2.2\Support"; Filename: "http://forum.pj64-emu.com"
+Name: "{commonprograms}\Project64 2.2\Project64"; Filename: "{app}\Project64.exe"
+Name: "{commonprograms}\Project64 2.2\Uninstall Project64 2.2"; Filename: "{uninstallexe}"; Parameters: "/LOG"
+Name: "{commonprograms}\Project64 2.2\Support"; Filename: "http://forum.pj64-emu.com"
 
 [Code]
 function HaveCommandlineParam (inParam: String): Boolean;

--- a/Source/Project64/Logging.cpp
+++ b/Source/Project64/Logging.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Logging.h
+++ b/Source/Project64/Logging.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Multilanguage.h
+++ b/Source/Project64/Multilanguage.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Multilanguage/Language Class.cpp
+++ b/Source/Project64/Multilanguage/Language Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Multilanguage/Language Class.h
+++ b/Source/Project64/Multilanguage/Language Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Multilanguage/LanguageSelector.cpp
+++ b/Source/Project64/Multilanguage/LanguageSelector.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Multilanguage/LanguageSelector.h
+++ b/Source/Project64/Multilanguage/LanguageSelector.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System.h
+++ b/Source/Project64/N64 System.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/C Core/r4300i Commands.cpp
+++ b/Source/Project64/N64 System/C Core/r4300i Commands.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/C Core/r4300i Commands.h
+++ b/Source/Project64/N64 System/C Core/r4300i Commands.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Cheat Class.cpp
+++ b/Source/Project64/N64 System/Cheat Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Cheat Class.h
+++ b/Source/Project64/N64 System/Cheat Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.h
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Dump.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Search.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Search.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Debugger/Debugger - Memory Search.h
+++ b/Source/Project64/N64 System/Debugger/Debugger - Memory Search.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Debugger/Debugger - TLB.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - TLB.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Debugger/Debugger - TLB.h
+++ b/Source/Project64/N64 System/Debugger/Debugger - TLB.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Debugger/Debugger - View Memory.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger - View Memory.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Debugger/Debugger - View Memory.h
+++ b/Source/Project64/N64 System/Debugger/Debugger - View Memory.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Debugger/Debugger.cpp
+++ b/Source/Project64/N64 System/Debugger/Debugger.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Debugger/debugger.h
+++ b/Source/Project64/N64 System/Debugger/debugger.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Interpreter/Interpreter CPU.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter CPU.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Interpreter/Interpreter CPU.h
+++ b/Source/Project64/N64 System/Interpreter/Interpreter CPU.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops 32.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops 32.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops 32.h
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops 32.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Interpreter/Interpreter Ops.h
+++ b/Source/Project64/N64 System/Interpreter/Interpreter Ops.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Audio.cpp
+++ b/Source/Project64/N64 System/Mips/Audio.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Audio.h
+++ b/Source/Project64/N64 System/Mips/Audio.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Dma.cpp
+++ b/Source/Project64/N64 System/Mips/Dma.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Dma.h
+++ b/Source/Project64/N64 System/Mips/Dma.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Eeprom.cpp
+++ b/Source/Project64/N64 System/Mips/Eeprom.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Eeprom.h
+++ b/Source/Project64/N64 System/Mips/Eeprom.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/FlashRam.cpp
+++ b/Source/Project64/N64 System/Mips/FlashRam.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/FlashRam.h
+++ b/Source/Project64/N64 System/Mips/FlashRam.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Memory Class.h
+++ b/Source/Project64/N64 System/Mips/Memory Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Memory Labels Class.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Labels Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Memory Labels Class.h
+++ b/Source/Project64/N64 System/Mips/Memory Labels Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
+++ b/Source/Project64/N64 System/Mips/Memory Virtual Mem.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Mempak.H
+++ b/Source/Project64/N64 System/Mips/Mempak.H
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Mempak.cpp
+++ b/Source/Project64/N64 System/Mips/Mempak.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/OpCode.h
+++ b/Source/Project64/N64 System/Mips/OpCode.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Pif Ram.cpp
+++ b/Source/Project64/N64 System/Mips/Pif Ram.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Pif Ram.h
+++ b/Source/Project64/N64 System/Mips/Pif Ram.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Register Class.cpp
+++ b/Source/Project64/N64 System/Mips/Register Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Register Class.h
+++ b/Source/Project64/N64 System/Mips/Register Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Rumblepak.cpp
+++ b/Source/Project64/N64 System/Mips/Rumblepak.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Rumblepak.h
+++ b/Source/Project64/N64 System/Mips/Rumblepak.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Sram.cpp
+++ b/Source/Project64/N64 System/Mips/Sram.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/Sram.h
+++ b/Source/Project64/N64 System/Mips/Sram.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/System Events.cpp
+++ b/Source/Project64/N64 System/Mips/System Events.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/System Events.h
+++ b/Source/Project64/N64 System/Mips/System Events.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/System Timing.cpp
+++ b/Source/Project64/N64 System/Mips/System Timing.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/System Timing.h
+++ b/Source/Project64/N64 System/Mips/System Timing.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/TLB Class.h
+++ b/Source/Project64/N64 System/Mips/TLB Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/TLB class.cpp
+++ b/Source/Project64/N64 System/Mips/TLB class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Mips/TranslateVaddr.h
+++ b/Source/Project64/N64 System/Mips/TranslateVaddr.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/N64 Class.h
+++ b/Source/Project64/N64 System/N64 Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/N64 Rom Class.cpp
+++ b/Source/Project64/N64 System/N64 Rom Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/N64 Rom Class.h
+++ b/Source/Project64/N64 System/N64 Rom Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/N64 Types.h
+++ b/Source/Project64/N64 System/N64 Types.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Profiling Class.cpp
+++ b/Source/Project64/N64 System/Profiling Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Profiling Class.h
+++ b/Source/Project64/N64 System/Profiling Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Code Block.cpp
+++ b/Source/Project64/N64 System/Recompiler/Code Block.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Code Block.h
+++ b/Source/Project64/N64 System/Recompiler/Code Block.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Code Section.cpp
+++ b/Source/Project64/N64 System/Recompiler/Code Section.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Code Section.h
+++ b/Source/Project64/N64 System/Recompiler/Code Section.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Exit Info.h
+++ b/Source/Project64/N64 System/Recompiler/Exit Info.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Function Info.cpp
+++ b/Source/Project64/N64 System/Recompiler/Function Info.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Function Info.h
+++ b/Source/Project64/N64 System/Recompiler/Function Info.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Function Map Class.cpp
+++ b/Source/Project64/N64 System/Recompiler/Function Map Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Function Map Class.h
+++ b/Source/Project64/N64 System/Recompiler/Function Map Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Jump Info.h
+++ b/Source/Project64/N64 System/Recompiler/Jump Info.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Loop Analysis.cpp
+++ b/Source/Project64/N64 System/Recompiler/Loop Analysis.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Loop Analysis.h
+++ b/Source/Project64/N64 System/Recompiler/Loop Analysis.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Recompiler Class.cpp
+++ b/Source/Project64/N64 System/Recompiler/Recompiler Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Recompiler Class.h
+++ b/Source/Project64/N64 System/Recompiler/Recompiler Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Recompiler Memory.cpp
+++ b/Source/Project64/N64 System/Recompiler/Recompiler Memory.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Recompiler Memory.h
+++ b/Source/Project64/N64 System/Recompiler/Recompiler Memory.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Recompiler Ops.cpp
+++ b/Source/Project64/N64 System/Recompiler/Recompiler Ops.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Recompiler Ops.h
+++ b/Source/Project64/N64 System/Recompiler/Recompiler Ops.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Reg Info.cpp
+++ b/Source/Project64/N64 System/Recompiler/Reg Info.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Reg Info.h
+++ b/Source/Project64/N64 System/Recompiler/Reg Info.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Section Info.cpp
+++ b/Source/Project64/N64 System/Recompiler/Section Info.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/Section Info.h
+++ b/Source/Project64/N64 System/Recompiler/Section Info.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/X86ops.cpp
+++ b/Source/Project64/N64 System/Recompiler/X86ops.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/X86ops.h
+++ b/Source/Project64/N64 System/Recompiler/X86ops.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/x86CodeLog.cpp
+++ b/Source/Project64/N64 System/Recompiler/x86CodeLog.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Recompiler/x86CodeLog.h
+++ b/Source/Project64/N64 System/Recompiler/x86CodeLog.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Rom Information Class.cpp
+++ b/Source/Project64/N64 System/Rom Information Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Rom Information Class.h
+++ b/Source/Project64/N64 System/Rom Information Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Speed Limitor Class.cpp
+++ b/Source/Project64/N64 System/Speed Limitor Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/Speed Limitor Class.h
+++ b/Source/Project64/N64 System/Speed Limitor Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/System Globals.cpp
+++ b/Source/Project64/N64 System/System Globals.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/N64 System/System Globals.h
+++ b/Source/Project64/N64 System/System Globals.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugin.h
+++ b/Source/Project64/Plugin.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/Audio Plugin.cpp
+++ b/Source/Project64/Plugins/Audio Plugin.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/Audio Plugin.h
+++ b/Source/Project64/Plugins/Audio Plugin.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/Controller Plugin.cpp
+++ b/Source/Project64/Plugins/Controller Plugin.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/Controller Plugin.h
+++ b/Source/Project64/Plugins/Controller Plugin.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/GFX plugin.cpp
+++ b/Source/Project64/Plugins/GFX plugin.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/GFX plugin.h
+++ b/Source/Project64/Plugins/GFX plugin.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/Plugin Base.cpp
+++ b/Source/Project64/Plugins/Plugin Base.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/Plugin Base.h
+++ b/Source/Project64/Plugins/Plugin Base.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/Plugin Class.cpp
+++ b/Source/Project64/Plugins/Plugin Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/Plugin Class.h
+++ b/Source/Project64/Plugins/Plugin Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/Plugin List.cpp
+++ b/Source/Project64/Plugins/Plugin List.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/RSP Plugin.cpp
+++ b/Source/Project64/Plugins/RSP Plugin.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Plugins/RSP Plugin.h
+++ b/Source/Project64/Plugins/RSP Plugin.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings.h
+++ b/Source/Project64/Settings.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Debug Settings.cpp
+++ b/Source/Project64/Settings/Debug Settings.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Debug Settings.h
+++ b/Source/Project64/Settings/Debug Settings.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Game Settings.cpp
+++ b/Source/Project64/Settings/Game Settings.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Game Settings.h
+++ b/Source/Project64/Settings/Game Settings.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Gui Settings.cpp
+++ b/Source/Project64/Settings/Gui Settings.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Gui Settings.h
+++ b/Source/Project64/Settings/Gui Settings.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/N64System Settings.cpp
+++ b/Source/Project64/Settings/N64System Settings.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/N64System Settings.h
+++ b/Source/Project64/Settings/N64System Settings.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Notification Settings.cpp
+++ b/Source/Project64/Settings/Notification Settings.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Notification Settings.h
+++ b/Source/Project64/Settings/Notification Settings.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Recompiler Settings.cpp
+++ b/Source/Project64/Settings/Recompiler Settings.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Recompiler Settings.h
+++ b/Source/Project64/Settings/Recompiler Settings.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-Application.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-Application.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-Application.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-Application.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-ApplicationIndex.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-ApplicationIndex.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-ApplicationIndex.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-ApplicationIndex.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-ApplicationPath.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-ApplicationPath.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-ApplicationPath.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-ApplicationPath.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-Base.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-Base.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-Cheats.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-Cheats.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-Cheats.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-Cheats.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-GameSetting.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-GameSetting.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-GameSetting.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-GameSetting.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-GameSettingIndex.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-GameSettingIndex.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-GameSettingIndex.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-GameSettingIndex.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RDBCpuType.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-RDBCpuType.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RDBCpuType.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-RDBCpuType.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RDBOnOff.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-RDBOnOff.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RDBOnOff.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-RDBOnOff.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RDBRamSize.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-RDBRamSize.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RDBRamSize.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-RDBRamSize.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RDBSaveChip.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-RDBSaveChip.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RDBSaveChip.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-RDBSaveChip.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RDBYesNo.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-RDBYesNo.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RDBYesNo.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-RDBYesNo.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RelativePath.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-RelativePath.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RelativePath.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-RelativePath.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RomDatabase.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-RomDatabase.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RomDatabase.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-RomDatabase.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RomDatabaseIndex.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-RomDatabaseIndex.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RomDatabaseIndex.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-RomDatabaseIndex.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RomDatabaseSetting.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-RomDatabaseSetting.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-RomDatabaseSetting.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-RomDatabaseSetting.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-SelectedDirectory.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-SelectedDirectory.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-SelectedDirectory.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-SelectedDirectory.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-TempBool.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-TempBool.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-TempBool.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-TempBool.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-TempNumber.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-TempNumber.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-TempNumber.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-TempNumber.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-TempString.cpp
+++ b/Source/Project64/Settings/SettingType/SettingsType-TempString.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/SettingType/SettingsType-TempString.h
+++ b/Source/Project64/Settings/SettingType/SettingsType-TempString.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Settings Class.cpp
+++ b/Source/Project64/Settings/Settings Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Settings/Settings Class.h
+++ b/Source/Project64/Settings/Settings Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface.h
+++ b/Source/Project64/User Interface.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Cheat Class UI.cpp
+++ b/Source/Project64/User Interface/Cheat Class UI.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Cheat Class UI.h
+++ b/Source/Project64/User Interface/Cheat Class UI.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Frame Per Second Class.cpp
+++ b/Source/Project64/User Interface/Frame Per Second Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Frame Per Second Class.h
+++ b/Source/Project64/User Interface/Frame Per Second Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Gui Class.cpp
+++ b/Source/Project64/User Interface/Gui Class.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Gui Class.h
+++ b/Source/Project64/User Interface/Gui Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Menu Class.h
+++ b/Source/Project64/User Interface/Menu Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/MenuShortCuts.h
+++ b/Source/Project64/User Interface/MenuShortCuts.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Notification Class.h
+++ b/Source/Project64/User Interface/Notification Class.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Rom Browser.h
+++ b/Source/Project64/User Interface/Rom Browser.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Advanced Options.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Advanced Options.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Advanced Options.h
+++ b/Source/Project64/User Interface/Settings/Settings Page - Advanced Options.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Directories.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Directories.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Directories.h
+++ b/Source/Project64/User Interface/Settings/Settings Page - Directories.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - General.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - General.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - General.h
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - General.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - Plugin.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - Plugin.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - Plugin.h
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - Plugin.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - Recompiler.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - Recompiler.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - Recompiler.h
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - Recompiler.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - Status.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - Status.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Game - Status.h
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game - Status.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Game Browser.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game Browser.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Game Browser.h
+++ b/Source/Project64/User Interface/Settings/Settings Page - Game Browser.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Keyboard Shortcuts.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Keyboard Shortcuts.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Keyboard Shortcuts.h
+++ b/Source/Project64/User Interface/Settings/Settings Page - Keyboard Shortcuts.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Options.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Options.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Options.h
+++ b/Source/Project64/User Interface/Settings/Settings Page - Options.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Plugin.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page - Plugin.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page - Plugin.h
+++ b/Source/Project64/User Interface/Settings/Settings Page - Plugin.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page.cpp
+++ b/Source/Project64/User Interface/Settings/Settings Page.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/Settings/Settings Page.h
+++ b/Source/Project64/User Interface/Settings/Settings Page.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/UI Resources.rc
+++ b/Source/Project64/User Interface/UI Resources.rc
@@ -387,7 +387,7 @@ IDD_About DIALOGEX 0, 0, 233, 265
 STYLE DS_SETFONT | DS_MODALFRAME | DS_FIXEDSYS | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
 FONT 8, "MS Shell Dlg", 0, 0, 0x1
 BEGIN
-    LTEXT           "Core Project 64 Team:",IDC_TEAM,15,87,168,17
+    LTEXT           "Core Project64 Team:",IDC_TEAM,15,87,168,17
     LTEXT           "Zilmar",IDC_ZILMAR,15,108,49,11
     LTEXT           "founder. Core and application programmer. Web site.",IDC_ZILMAR_DETAILS,69,107,151,24
     LTEXT           "Jabo",IDC_JABO,15,133,49,11

--- a/Source/Project64/User Interface/WTL Controls/ModifiedCheckBox.h
+++ b/Source/Project64/User Interface/WTL Controls/ModifiedCheckBox.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/WTL Controls/ModifiedComboBox.h
+++ b/Source/Project64/User Interface/WTL Controls/ModifiedComboBox.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/WTL Controls/ModifiedEditBox.cpp
+++ b/Source/Project64/User Interface/WTL Controls/ModifiedEditBox.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/WTL Controls/ModifiedEditBox.h
+++ b/Source/Project64/User Interface/WTL Controls/ModifiedEditBox.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/WTL Controls/PartialGroupBox.cpp
+++ b/Source/Project64/User Interface/WTL Controls/PartialGroupBox.cpp
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/WTL Controls/PartialGroupBox.h
+++ b/Source/Project64/User Interface/WTL Controls/PartialGroupBox.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/User Interface/WTL Controls/numberctrl.h
+++ b/Source/Project64/User Interface/WTL Controls/numberctrl.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/Version.h
+++ b/Source/Project64/Version.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *
@@ -16,7 +16,7 @@
 #define VERSION_REVISION            0
 #define VERSION_BUILD               9999
 
-#define VER_FILE_DESCRIPTION_STR    "Project 64"
+#define VER_FILE_DESCRIPTION_STR    "Project64"
 #define VER_FILE_VERSION            VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION, VERSION_BUILD
 #define VER_FILE_VERSION_STR        STRINGIZE(VERSION_MAJOR)        \
                                     "." STRINGIZE(VERSION_MINOR)    \

--- a/Source/Project64/WTL App.h
+++ b/Source/Project64/WTL App.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/Project64/stdafx.h
+++ b/Source/Project64/stdafx.h
@@ -1,6 +1,6 @@
 /****************************************************************************
 *                                                                           *
-* Project 64 - A Nintendo 64 emulator.                                      *
+* Project64 - A Nintendo 64 emulator.                                      *
 * http://www.pj64-emu.com/                                                  *
 * Copyright (C) 2012 Project64. All rights reserved.                        *
 *                                                                           *

--- a/Source/RSP/Cpu.c
+++ b/Source/RSP/Cpu.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Cpu.h
+++ b/Source/RSP/Cpu.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Interpreter CPU.c
+++ b/Source/RSP/Interpreter CPU.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Interpreter CPU.h
+++ b/Source/RSP/Interpreter CPU.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Interpreter Ops.h
+++ b/Source/RSP/Interpreter Ops.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Mmx.c
+++ b/Source/RSP/Mmx.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/OpCode.h
+++ b/Source/RSP/OpCode.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Profiling.cpp
+++ b/Source/RSP/Profiling.cpp
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Profiling.h
+++ b/Source/RSP/Profiling.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/RSP Command.h
+++ b/Source/RSP/RSP Command.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/RSP Register.c
+++ b/Source/RSP/RSP Register.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/RSP Registers.h
+++ b/Source/RSP/RSP Registers.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Recompiler Analysis.c
+++ b/Source/RSP/Recompiler Analysis.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Recompiler CPU.c
+++ b/Source/RSP/Recompiler CPU.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Recompiler CPU.h
+++ b/Source/RSP/Recompiler CPU.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Recompiler Ops.h
+++ b/Source/RSP/Recompiler Ops.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Recompiler Sections.c
+++ b/Source/RSP/Recompiler Sections.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Rsp.h
+++ b/Source/RSP/Rsp.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Sse.c
+++ b/Source/RSP/Sse.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Types.h
+++ b/Source/RSP/Types.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/Version.h
+++ b/Source/RSP/Version.h
@@ -1,5 +1,5 @@
 /*
-* RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+* RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
 *
 * (c) Copyright 2001 jabo (jabo@emulation64.com) and
 * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/X86.c
+++ b/Source/RSP/X86.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/X86.h
+++ b/Source/RSP/X86.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/breakpoint.c
+++ b/Source/RSP/breakpoint.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/breakpoint.h
+++ b/Source/RSP/breakpoint.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/dma.c
+++ b/Source/RSP/dma.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/dma.h
+++ b/Source/RSP/dma.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/log.cpp
+++ b/Source/RSP/log.cpp
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/log.h
+++ b/Source/RSP/log.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/memory.c
+++ b/Source/RSP/memory.c
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)

--- a/Source/RSP/memory.h
+++ b/Source/RSP/memory.h
@@ -1,5 +1,5 @@
 /*
- * RSP Compiler plug in for Project 64 (A Nintendo 64 emulator).
+ * RSP Compiler plug in for Project64 (A Nintendo 64 emulator).
  *
  * (c) Copyright 2001 jabo (jabo@emulation64.com) and
  * zilmar (zilmar@emulation64.com)


### PR DESCRIPTION
Only use "Project64", rather than mix & match "Project 64" and "Project64"