### PR TITLE
Remove some leftover code from the old About box

### DIFF
--- a/Source/Project64/User Interface/Gui Class.cpp
+++ b/Source/Project64/User Interface/Gui Class.cpp
@@ -1017,31 +1017,6 @@ DWORD CALLBACK AboutBoxProc(HWND hWnd, DWORD uMsg, DWORD wParam, DWORD lParam)
 		SetWindowText(GetDlgItem(hWnd, IDC_VERSION), VersionDisplay.c_str());
 	}
 	break;
-	case WM_NCHITTEST:
-	{
-		int xPos = LOWORD(lParam);
-		int yPos = HIWORD(lParam);
-		RECT client, a;
-		GetClientRect(hWnd, &a);
-		GetClientRect(hWnd, &client);
-		ClientToScreen(hWnd, (LPPOINT)&client);
-		client.right += client.left;
-		client.bottom += client.top;
-
-		int nCaption = GetSystemMetrics(SM_CYCAPTION) * 4;
-
-		LRESULT lResult = HTCLIENT;
-
-		//check caption
-		if (xPos <= client.right && xPos >= client.left &&
-			(yPos >= client.top + 0) && (yPos <= client.top + 0 + nCaption))
-		{
-			lResult = HTCAPTION;
-		}
-		SetWindowLong(hWnd, DWLP_MSGRESULT, lResult);
-		return TRUE;
-	}
-	break;
 	case WM_CTLCOLORSTATIC:
 	{
 		HDC hdcStatic = (HDC)wParam;


### PR DESCRIPTION
This allowed you click the top region of the About box to move the
window.