### PR TITLE
Get rid of WS_EX_CLIENTEDGE

### DIFF
--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -333,7 +333,7 @@ void CRomBrowser::AllocateBrushs(void)
 
 void CRomBrowser::CreateRomListControl(void)
 {
-	m_hRomList = (HWND)CreateWindowEx(WS_EX_CLIENTEDGE, WC_LISTVIEW, NULL,
+	m_hRomList = (HWND)CreateWindow(WC_LISTVIEW, NULL,
 		WS_TABSTOP | WS_VISIBLE | WS_CHILD | LVS_OWNERDRAWFIXED |
 		LVS_SINGLESEL | LVS_REPORT,
 		0, 0, 0, 0, m_MainWindow, (HMENU)IDC_ROMLIST, GetModuleHandle(NULL), NULL);


### PR DESCRIPTION
Switch to CreateWindow, as CreateWindowEx is no longer need

Makes a notable difference on Win 10.

Before
![untitled2](https://cloud.githubusercontent.com/assets/11582193/11059630/0acab6a8-8758-11e5-8e87-d9dcdbe10a38.png)
After
![untitled](https://cloud.githubusercontent.com/assets/11582193/11059629/0ac83950-8758-11e5-84d6-c8b9bd3cb809.png)


