### PR TITLE
Fix compilation error

### DIFF
--- a/Project64.sln
+++ b/Project64.sln
@@ -9,7 +9,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Glide", "Glide", "{9FE699A5-41C3-4441-92AB-639B3D77DE26}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Common", "Source\Common\Common.vcxproj", "{B4A4B994-9111-42B1-93C2-6F1CA8BC4421}"
-EndProjectt
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Project64", "Source\Project64\Project64.vcxproj", "{7E534C8E-1ACE-4A88-8807-39A11ED4DA18}"
 	ProjectSection(ProjectDependencies) = postProject
 		{FD617E80-9E40-4138-85DA-B94633972E6A} = {FD617E80-9E40-4138-85DA-B94633972E6A}

--- a/Source/Project64/Plugins/Controller Plugin.h
+++ b/Source/Project64/Plugins/Controller Plugin.h
@@ -71,8 +71,8 @@ public:
 private:
     friend CControl_Plugin; //controller plugin class has full access
 
-    uint32_t & m_Present;
-    uint32_t & m_RawData;
+    int32_t & m_Present;
+    int32_t & m_RawData;
     int32_t      & m_PlugType;
     BUTTONS    m_Buttons;
 


### PR DESCRIPTION
@project64, https://github.com/project64/project64/commit/623411ce99cebd6f1a1be96002e6a8c51a595b4c did not fix the compilation error. It's still there.

It might be mask by the typo in Project64.sln, which skips building Project64.exe.

This PR fixes it.
Please approve.