### PR TITLE
Fix Blurry Fonts on High-DPI Windows 10

### DIFF
--- a/Source/Project64/Project64.vcxproj
+++ b/Source/Project64/Project64.vcxproj
@@ -39,6 +39,9 @@
       <StackReserveSize>1</StackReserveSize>
       <DataExecutionPrevention>false</DataExecutionPrevention>
     </Link>
+    <Manifest> 
+      <EnableDPIAwareness>true</EnableDPIAwareness>
+    </Manifest> 
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="Logging.cpp" />


### PR DESCRIPTION
May appear blurred on Windows 10 high-DPI displays, that fixed.

<img width="481" alt="win10" src="https://cloud.githubusercontent.com/assets/7089513/11081160/c7bfab3c-885d-11e5-82d0-fdc0f3a5cbeb.png">

<img width="453" alt="win10fixdpi" src="https://cloud.githubusercontent.com/assets/7089513/11081102/5f895f18-885d-11e5-8f1a-4cc1c9cddefb.png">
