### PR TITLE
logging class:  fixed likely regression with create/open conditions

### DIFF
--- a/Source/Common/File Class.cpp
+++ b/Source/Common/File Class.cpp
@@ -79,14 +79,12 @@ bool CFile::Open(const char * lpszFileName, uint32_t nOpenFlags)
     sa.bInheritHandle = (nOpenFlags & modeNoInherit) == 0;
 
     // map creation flags
-    ULONG dwCreateFlag = 0;
+    ULONG dwCreateFlag = OPEN_EXISTING;
     if (nOpenFlags & modeCreate)
     {
-        dwCreateFlag = (nOpenFlags & modeNoTruncate) != 0 ? OPEN_ALWAYS : CREATE_ALWAYS;
-    }
-    else
-    {
-        dwCreateFlag = OPEN_EXISTING;
+        dwCreateFlag =
+            ((nOpenFlags & modeNoTruncate) != 0)
+          ? OPEN_ALWAYS : CREATE_ALWAYS;
     }
 
     // attempt file creation

--- a/Source/Common/File Class.cpp
+++ b/Source/Common/File Class.cpp
@@ -82,7 +82,7 @@ bool CFile::Open(const char * lpszFileName, uint32_t nOpenFlags)
     ULONG dwCreateFlag = 0;
     if (nOpenFlags & modeCreate)
     {
-        dwCreateFlag = nOpenFlags & modeNoTruncate != 0 ? OPEN_ALWAYS : CREATE_ALWAYS;
+        dwCreateFlag = (nOpenFlags & modeNoTruncate) != 0 ? OPEN_ALWAYS : CREATE_ALWAYS;
     }
     else
     {

--- a/Source/Common/File Class.cpp
+++ b/Source/Common/File Class.cpp
@@ -82,7 +82,7 @@ bool CFile::Open(const char * lpszFileName, uint32_t nOpenFlags)
     ULONG dwCreateFlag = 0;
     if (nOpenFlags & modeCreate)
     {
-        dwCreateFlag = nOpenFlags & modeNoTruncate == 0 ? OPEN_ALWAYS : CREATE_ALWAYS;
+        dwCreateFlag = nOpenFlags & modeNoTruncate != 0 ? OPEN_ALWAYS : CREATE_ALWAYS;
     }
     else
     {

--- a/Source/Common/File Class.cpp
+++ b/Source/Common/File Class.cpp
@@ -82,9 +82,7 @@ bool CFile::Open(const char * lpszFileName, uint32_t nOpenFlags)
     ULONG dwCreateFlag = OPEN_EXISTING;
     if (nOpenFlags & modeCreate)
     {
-        dwCreateFlag =
-            ((nOpenFlags & modeNoTruncate) != 0)
-          ? OPEN_ALWAYS : CREATE_ALWAYS;
+        dwCreateFlag = ((nOpenFlags & modeNoTruncate) != 0) ? OPEN_ALWAYS : CREATE_ALWAYS;
     }
 
     // attempt file creation


### PR DESCRIPTION
This just looks like a bug because before the code said this:
```c
if (nOpenFlags & modeNoTruncate)
    dwCreateFlag = OPEN_ALWAYS;
else
    dwCreateFlag = CREATE_ALWAYS;
```

It was just recently changed this morning to this:
```
dwCreateFlag = nOpenFlags & modeNoTruncate == 0 ? OPEN_ALWAYS : CREATE_ALWAYS;
```
which I am almost positive is not an accurate translation of the original.

For two reasons:

1.  Operator precedence.  `a & b == 0` by default means `(a) & (b == 0)`.
2.  It should be != not ==, otherwise switch OPEN : CREATE to CREATE : OPEN.