### PR TITLE
Increase g_Plugins (and friends) security against null pointers.

### DIFF
--- a/Source/Project64/N64 System/Mips/Pif Ram.cpp
+++ b/Source/Project64/N64 System/Mips/Pif Ram.cpp
@@ -89,12 +89,26 @@ void CPifRam::n64_cic_nus_6105(char challenge[], char respone[], int length)
 
 void CPifRam::PifRamRead()
 {
+    CControl_Plugin * control_plugin;
+    CONTROL * Controllers;
+
 	if (m_PifRam[0x3F] == 0x2) 
 	{
 		return;
 	}
 
-	CONTROL * Controllers = g_Plugins->Control()->PluginControllers();
+    if (g_Plugins == NULL)
+    {
+        g_Notify->DisplayError(L"PifRamRead\ng_Plugins NULL exception");
+        return;
+    }
+    control_plugin = g_Plugins->Control();
+    if (control_plugin == NULL)
+    {
+        g_Notify->DisplayError(L"PifRamRead\nPlugin NULL exception");
+        return;
+    }
+    Controllers = control_plugin->PluginControllers();
 
 	int Channel = 0;
 	for (int CurPos = 0; CurPos < 0x40; CurPos ++)
@@ -118,10 +132,10 @@ void CPifRam::PifRamRead()
 				{
 					if (Controllers[Channel].Present && Controllers[Channel].RawData)
 					{
-						if (g_Plugins->Control()->ReadController)
-						{
-							g_Plugins->Control()->ReadController(Channel,&m_PifRam[CurPos]);
-						}
+                        if (control_plugin->ReadController)
+                        {
+                            control_plugin->ReadController(Channel, &m_PifRam[CurPos]);
+                        }
 					}
 					else
 					{						
@@ -142,16 +156,30 @@ void CPifRam::PifRamRead()
 			break;
 		}
 	} 
-	if (g_Plugins->Control()->ReadController)
-	{
-		g_Plugins->Control()->ReadController(-1,NULL);
-	}
+    if (control_plugin->ReadController)
+    {
+        control_plugin->ReadController(-1, NULL);
+    }
 }
 
 void CPifRam::PifRamWrite()
 {
-	CONTROL * Controllers = g_Plugins->Control()->PluginControllers();
+    CControl_Plugin * control_plugin;
+    CONTROL * Controllers;
 	int Channel = 0, CurPos;
+
+    if (g_Plugins == NULL)
+    {
+        g_Notify->DisplayError(L"PifRamWrite\ng_Plugins NULL exception");
+        return;
+    }
+    control_plugin = g_Plugins->Control();
+    if (control_plugin == NULL)
+    {
+        g_Notify->DisplayError(L"PifRamWrite\nPlugin NULL exception");
+        return;
+    }
+    Controllers = control_plugin->PluginControllers();
 
 	if ( m_PifRam[0x3F] > 0x1)
 	{ 
@@ -227,10 +255,10 @@ void CPifRam::PifRamWrite()
 				{
 					if (Controllers[Channel].Present && Controllers[Channel].RawData)
 					{
-						if (g_Plugins->Control()->ControllerCommand)
-						{
-							g_Plugins->Control()->ControllerCommand(Channel,&m_PifRam[CurPos]);
-						}
+                        if (control_plugin->ControllerCommand)
+                        {
+                            control_plugin->ControllerCommand(Channel, &m_PifRam[CurPos]);
+                        }
 					}
 					else
 					{
@@ -263,10 +291,10 @@ void CPifRam::PifRamWrite()
 		}
 	}
 	m_PifRam[0x3F] = 0;
-	if (g_Plugins->Control()->ControllerCommand)
-	{
-		g_Plugins->Control()->ControllerCommand(-1,NULL);
-	}
+    if (control_plugin->ControllerCommand)
+    {
+        control_plugin->ControllerCommand(-1, NULL);
+    }
 }
 
 void CPifRam::SI_DMA_READ() 
@@ -445,9 +473,23 @@ void CPifRam::SI_DMA_WRITE()
     }
 }
 
-void CPifRam::ProcessControllerCommand ( int Control, BYTE * Command) 
+void CPifRam::ProcessControllerCommand(int Control, BYTE * Command)
 {
-	CONTROL * Controllers = g_Plugins->Control()->PluginControllers();
+    CControl_Plugin * control_plugin;
+    CONTROL * Controllers;
+
+    if (g_Plugins == NULL)
+    {
+        g_Notify->DisplayError(L"ProcessControllerCommand\ng_Plugins NULL exception");
+        return;
+    }
+    control_plugin = g_Plugins->Control();
+    if (control_plugin == NULL)
+    {
+        g_Notify->DisplayError(L"ProcessControllerCommand\nPlugin NULL exception");
+        return;
+    }
+    Controllers = control_plugin->PluginControllers();
 
 	switch (Command[2])
 	{
@@ -527,7 +569,7 @@ void CPifRam::ProcessControllerCommand ( int Control, BYTE * Command)
 			case PLUGIN_RUMBLE_PAK: Rumblepak::ReadFrom(Command); break;
 			case PLUGIN_MEMPAK: Mempak::ReadFrom(Control, Command); break;
 			case PLUGIN_TANSFER_PAK: /* TODO */; break;
-			case PLUGIN_RAW: if (g_Plugins->Control()->ControllerCommand) { g_Plugins->Control()->ControllerCommand(Control, Command); } break;
+			case PLUGIN_RAW: if (control_plugin->ControllerCommand) { control_plugin->ControllerCommand(Control, Command); } break;
 			default:
 				memset(&Command[5], 0, 0x20);
 			}
@@ -569,7 +611,7 @@ void CPifRam::ProcessControllerCommand ( int Control, BYTE * Command)
 			case PLUGIN_MEMPAK: Mempak::WriteTo(Control, Command); break;
 			case PLUGIN_RUMBLE_PAK: Rumblepak::WriteTo(Control, Command); break;
 			case PLUGIN_TANSFER_PAK: /* TODO */; break;
-			case PLUGIN_RAW: if (g_Plugins->Control()->ControllerCommand) { g_Plugins->Control()->ControllerCommand(Control, Command); } break;
+			case PLUGIN_RAW: if (control_plugin->ControllerCommand) { control_plugin->ControllerCommand(Control, Command); } break;
 			}
 
 			if (Controllers[Control].Plugin != PLUGIN_RAW)
@@ -594,8 +636,23 @@ void CPifRam::ProcessControllerCommand ( int Control, BYTE * Command)
 	}
 }
 
-void CPifRam::ReadControllerCommand (int Control, BYTE * Command) {
-	CONTROL * Controllers = g_Plugins->Control()->PluginControllers();
+void CPifRam::ReadControllerCommand(int Control, BYTE * Command)
+{
+    CControl_Plugin * control_plugin;
+    CONTROL * Controllers;
+
+    if (g_Plugins == NULL)
+    {
+        g_Notify->DisplayError(L"ReadControllerCommand\ng_Plugins NULL exception");
+        return;
+    }
+    control_plugin = g_Plugins->Control();
+    if (control_plugin == NULL)
+    {
+        g_Notify->DisplayError(L"ReadControllerCommand\nPlugin NULL exception");
+        return;
+    }
+    Controllers = control_plugin->PluginControllers();
 
 	switch (Command[2])
 	{
@@ -617,7 +674,12 @@ void CPifRam::ReadControllerCommand (int Control, BYTE * Command) {
 		{
 			switch (Controllers[Control].Plugin)
 			{
-			case PLUGIN_RAW: if (g_Plugins->Control()->ReadController) { g_Plugins->Control()->ReadController(Control, Command); } break;
+            case PLUGIN_RAW:
+                if (control_plugin->ReadController)
+                {
+                    control_plugin->ReadController(Control, Command);
+                }
+                break;
 			}
 		} 
 		break;
@@ -626,7 +688,12 @@ void CPifRam::ReadControllerCommand (int Control, BYTE * Command) {
 		{
 			switch (Controllers[Control].Plugin)
 			{
-			case PLUGIN_RAW: if (g_Plugins->Control()->ReadController) { g_Plugins->Control()->ReadController(Control, Command); } break;
+            case PLUGIN_RAW:
+                if (control_plugin->ReadController)
+                {
+                    control_plugin->ReadController(Control, Command);
+                }
+                break;
 			}
 		}
 		break;

--- a/Source/Project64/N64 System/Mips/Rumblepak.cpp
+++ b/Source/Project64/N64 System/Mips/Rumblepak.cpp
@@ -26,13 +26,27 @@ void Rumblepak::ReadFrom(BYTE * command)
 
 void Rumblepak::WriteTo(int Control, BYTE * command)
 {
-	DWORD address = (command[3] << 8) | (command[4] & 0xE0);
+    const uint32_t address =
+        (0x00 << 24)
+      | (0x00 << 16)
+      | (command[3] << 8)
+      | (command[4] << 0)
+    ;
 
-	if ((address) == 0xC000)
-	{
-		if (g_Plugins->Control()->RumbleCommand != NULL)
-		{
-			g_Plugins->Control()->RumbleCommand(Control, *(BOOL *)(&command[5]));
-		}
-	}
+    if (g_Plugins == NULL)
+    {
+        return;
+    }
+    if (g_Plugins->Control() == NULL)
+    {
+        return;
+    }
+    if (g_Plugins->Control()->RumbleCommand == NULL)
+    {
+        return;
+    }
+    if ((address & ~0x1F) == 0x0000C000)
+    {
+        g_Plugins->Control()->RumbleCommand(Control, *(int32_t *)(&command[5]));
+    }
 }

--- a/Source/Project64/User Interface/Main Menu Class.cpp
+++ b/Source/Project64/User Interface/Main Menu Class.cpp
@@ -893,12 +893,27 @@ void CMainMenu::FillOutMenu(HMENU hMenu)
     SystemMenu.push_back(MENU_ITEM(ID_SYSTEM_CHEAT, MENU_CHEAT, m_ShortCuts.ShortCutString(ID_SYSTEM_CHEAT, AccessLevel)));
     SystemMenu.push_back(MENU_ITEM(ID_SYSTEM_GSBUTTON, MENU_GS_BUTTON, m_ShortCuts.ShortCutString(ID_SYSTEM_GSBUTTON, AccessLevel)));
 
+    if (g_Plugins == NULL)
+    {
+        g_Notify->DisplayError(L"FillOutMenu\ng_Plugins null exception");
+        return;
+    }
+    CRSP_Plugin* RSP_plugin         = g_Plugins -> RSP();
+    CGfxPlugin* graphics_plugin     = g_Plugins -> Gfx();
+    CAudioPlugin* audio_plugin      = g_Plugins -> Audio();
+    CControl_Plugin* control_plugin = g_Plugins -> Control();
+    if (!(RSP_plugin && graphics_plugin && audio_plugin && control_plugin))
+    {
+        g_Notify->DisplayError(L"FillOutMenu\nnull plugins exception");
+        return;
+    }
+
     /* Option Menu
     ****************/
     MenuItemList OptionMenu;
     Item.Reset(ID_OPTIONS_FULLSCREEN, MENU_FULL_SCREEN, m_ShortCuts.ShortCutString(ID_OPTIONS_FULLSCREEN, AccessLevel));
     Item.SetItemEnabled(CPURunning);
-    if (g_Plugins && g_Plugins->Gfx() && g_Plugins->Gfx()->ChangeWindow == NULL)
+    if (graphics_plugin->ChangeWindow == NULL)
     {
         Item.SetItemEnabled(false);
     }
@@ -913,13 +928,13 @@ void CMainMenu::FillOutMenu(HMENU hMenu)
     OptionMenu.push_back(MENU_ITEM(SPLITER));
 
     Item.Reset(ID_OPTIONS_CONFIG_GFX, MENU_CONFG_GFX, m_ShortCuts.ShortCutString(ID_OPTIONS_CONFIG_GFX, AccessLevel));
-    if (g_Plugins && g_Plugins->Gfx() == NULL || g_Plugins->Gfx()->DllConfig == NULL)
+    if (graphics_plugin->DllConfig == NULL)
     {
         Item.SetItemEnabled(false);
     }
     OptionMenu.push_back(Item);
     Item.Reset(ID_OPTIONS_CONFIG_AUDIO, MENU_CONFG_AUDIO, m_ShortCuts.ShortCutString(ID_OPTIONS_CONFIG_AUDIO, AccessLevel));
-    if (g_Plugins->Audio() == NULL || g_Plugins->Audio()->DllConfig == NULL)
+    if (audio_plugin->DllConfig == NULL)
     {
         Item.SetItemEnabled(false);
     }
@@ -927,14 +942,14 @@ void CMainMenu::FillOutMenu(HMENU hMenu)
     if (!inBasicMode)
     {
         Item.Reset(ID_OPTIONS_CONFIG_RSP, MENU_CONFG_RSP, m_ShortCuts.ShortCutString(ID_OPTIONS_CONFIG_RSP, AccessLevel));
-        if (g_Plugins->RSP() == NULL || g_Plugins->RSP()->DllConfig == NULL)
+        if (RSP_plugin->DllConfig == NULL)
         {
             Item.SetItemEnabled(false);
         }
         OptionMenu.push_back(Item);
     }
     Item.Reset(ID_OPTIONS_CONFIG_CONT, MENU_CONFG_CTRL, m_ShortCuts.ShortCutString(ID_OPTIONS_CONFIG_CONT, AccessLevel));
-    if (g_Plugins && g_Plugins->Control() == NULL || g_Plugins->Control()->DllConfig == NULL)
+    if (control_plugin->DllConfig == NULL)
     {
         Item.SetItemEnabled(false);
     }
@@ -1087,17 +1102,17 @@ void CMainMenu::FillOutMenu(HMENU hMenu)
 
         /* Debug - RSP
         *******************/
-        if (g_Plugins && g_Plugins->RSP() != NULL && IsMenu((HMENU)g_Plugins->RSP()->GetDebugMenu()))
+        if (IsMenu((HMENU)RSP_plugin->GetDebugMenu()))
         {
-            Item.Reset(ID_PLUGIN_MENU, EMPTY_STRING, EMPTY_STDSTR, g_Plugins->RSP()->GetDebugMenu(), L"&RSP");
+            Item.Reset(ID_PLUGIN_MENU, EMPTY_STRING, EMPTY_STDSTR, RSP_plugin->GetDebugMenu(), L"&RSP");
             DebugMenu.push_back(Item);
         }
 
         /* Debug - RDP
         *******************/
-        if (g_Plugins && g_Plugins->Gfx() != NULL && IsMenu((HMENU)g_Plugins->Gfx()->GetDebugMenu()))
+        if (IsMenu((HMENU)graphics_plugin->GetDebugMenu()))
         {
-            Item.Reset(ID_PLUGIN_MENU, EMPTY_STRING, EMPTY_STDSTR, g_Plugins->Gfx()->GetDebugMenu(), L"&RDP");
+            Item.Reset(ID_PLUGIN_MENU, EMPTY_STRING, EMPTY_STDSTR, graphics_plugin->GetDebugMenu(), L"&RDP");
             DebugMenu.push_back(Item);
         }
 

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -1479,23 +1479,35 @@ void CRomBrowser::RomList_PopupMenu(DWORD /*pnmh*/)
 	{
 		bool inBasicMode = g_Settings->LoadDword(UserInterface_BasicMode) != 0;
 		bool CheatsRemembered = g_Settings->LoadDword(Setting_RememberCheats) != 0;
+
 		if (!CheatsRemembered) { DeleteMenu(hPopupMenu, 9, MF_BYPOSITION); }
 		if (inBasicMode) { DeleteMenu(hPopupMenu, 8, MF_BYPOSITION); }
 		if (inBasicMode && !CheatsRemembered) { DeleteMenu(hPopupMenu, 7, MF_BYPOSITION); }
 		DeleteMenu(hPopupMenu, 6, MF_BYPOSITION);
-		if (!inBasicMode && g_Plugins && g_Plugins->Gfx() && g_Plugins->Gfx()->GetRomBrowserMenu != NULL)
-		{
-			HMENU GfxMenu = (HMENU)g_Plugins->Gfx()->GetRomBrowserMenu();
-			if (GfxMenu)
-			{
-				MENUITEMINFO lpmii;
-				InsertMenuW(hPopupMenu, 6, MF_POPUP | MF_BYPOSITION, (DWORD)GfxMenu, GS(POPUP_GFX_PLUGIN));
-				lpmii.cbSize = sizeof(MENUITEMINFO);
-				lpmii.fMask = MIIM_STATE;
-				lpmii.fState = 0;
-				SetMenuItemInfo(hPopupMenu, (DWORD)GfxMenu, MF_BYCOMMAND, &lpmii);
-			}
-		}
+
+        if (!inBasicMode)
+        {
+            HMENU GfxMenu;
+            MENUITEMINFO lpmii;
+            void* browser_menu = NULL;
+
+            if (g_Plugins != NULL)
+            {
+                if (g_Plugins->Gfx() != NULL)
+                {
+                    browser_menu = g_Plugins->Gfx()->GetRomBrowserMenu;
+                }
+            }
+            if (browser_menu != NULL)
+            {
+                GfxMenu = (HMENU)browser_menu;
+                InsertMenuW(hPopupMenu, 6, MF_POPUP | MF_BYPOSITION, (size_t)GfxMenu, GS(POPUP_GFX_PLUGIN));
+                lpmii.cbSize = sizeof(MENUITEMINFO);
+                lpmii.fMask = MIIM_STATE;
+                lpmii.fState = 0;
+                SetMenuItemInfo(hPopupMenu, (DWORD)GfxMenu, MF_BYCOMMAND, &lpmii);
+            }
+        }
 	}
 
 	//Get the current Mouse location


### PR DESCRIPTION
It's gotten complicated enough to the point where I think I just stop here.  I imagine there will be enough things as it is already to criticize for suggestions on how to update the PR.

Only reason I did this was to strengthen the guard from referencing plugin functions under a pointer under a pointer under a pointer under a ... anywhere along the line there may have been one or more null pointers.  While this can usually be dismissed as an unlikely possibility not worth cluttering the code for I felt like giving it a quick try--who knows maybe it could come in handy against subtle bugs in the future when someone tries to change something.

It may also have performance gains as well I guess since `g_Plugins` is a global which can be sensitive to constant change in a multi-threaded scenario.  Here I have sometimes declared local variables to store the pointer tree into a single pointer to shorten much of the code checks down to reading one single pointer.