### PR TITLE
DllConfig(hParent) should be a pointer, not a uint32_t.

### DIFF
--- a/Source/Project64/Plugins/Plugin Base.cpp
+++ b/Source/Project64/Plugins/Plugin Base.cpp
@@ -71,7 +71,7 @@ bool CPlugin::Load (const char * FileName)
     RomOpen        = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "RomOpen" );
     RomClosed      = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "RomClosed" );
     PluginOpened   = (void (__cdecl *)(void)) GetProcAddress( (HMODULE)m_hDll, "PluginLoaded" );
-    DllConfig      = (void (__cdecl *)(uint32_t)) GetProcAddress( (HMODULE)m_hDll, "DllConfig" );
+    DllConfig      = (void (__cdecl *)(void *)) GetProcAddress( (HMODULE)m_hDll, "DllConfig" );
     DllAbout       = (void (__cdecl *)(void *)) GetProcAddress( (HMODULE)m_hDll, "DllAbout" );
 
     SetSettingInfo3 = (void (__cdecl *)(PLUGIN_SETTINGS3 *))GetProcAddress( (HMODULE)m_hDll, "SetSettingInfo3" );

--- a/Source/Project64/Plugins/Plugin Base.h
+++ b/Source/Project64/Plugins/Plugin Base.h
@@ -30,7 +30,7 @@ public:
     void Close();
 
     void(__cdecl *DllAbout)  (void * hWnd);
-    void(__cdecl *DllConfig) (uint32_t hParent);
+    void(__cdecl *DllConfig) (void * hParent);
 
     static bool ValidPluginVersion ( PLUGIN_INFO & PluginInfo );
 

--- a/Source/Project64/Plugins/Plugin Class.cpp
+++ b/Source/Project64/Plugins/Plugin Class.cpp
@@ -318,7 +318,7 @@ bool CPlugins::Reset(CN64System * System)
 	return true;
 }
 
-void CPlugins::ConfigPlugin(uint32_t hParent, PLUGIN_TYPE Type)
+void CPlugins::ConfigPlugin(void* hParent, PLUGIN_TYPE Type)
 {
 	switch (Type)
 	{

--- a/Source/Project64/Plugins/Plugin Class.h
+++ b/Source/Project64/Plugins/Plugin Class.h
@@ -104,7 +104,7 @@ public:
     void RomOpened(void);
     void RomClosed(void);
     void SetRenderWindows(RenderWindow * MainWindow, RenderWindow * SyncWindow);
-    void ConfigPlugin(uint32_t hParent, PLUGIN_TYPE Type);
+    void ConfigPlugin(void* hParent, PLUGIN_TYPE Type);
     bool CopyPlugins(const stdstr & DstDir) const;
     void CreatePlugins(void);
     bool Reset(CN64System * System);

--- a/Source/Project64/User Interface/Main Menu Class.cpp
+++ b/Source/Project64/User Interface/Main Menu Class.cpp
@@ -323,10 +323,22 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
             m_Gui->MakeWindowOnTop(g_Settings->LoadBool(GameRunning_CPU_Running));
         }
         break;
-    case ID_OPTIONS_CONFIG_RSP:  WriteTrace(TraceDebug, __FUNCTION__ ": ID_OPTIONS_CONFIG_RSP"); g_Plugins->ConfigPlugin((DWORD)hWnd, PLUGIN_TYPE_RSP); break;
-    case ID_OPTIONS_CONFIG_GFX:  WriteTrace(TraceDebug, __FUNCTION__ ": ID_OPTIONS_CONFIG_GFX"); g_Plugins->ConfigPlugin((DWORD)hWnd, PLUGIN_TYPE_GFX); break;
-    case ID_OPTIONS_CONFIG_AUDIO:WriteTrace(TraceDebug, __FUNCTION__ ": ID_OPTIONS_CONFIG_AUDIO"); g_Plugins->ConfigPlugin((DWORD)hWnd, PLUGIN_TYPE_AUDIO); break;
-    case ID_OPTIONS_CONFIG_CONT: WriteTrace(TraceDebug, __FUNCTION__ ": ID_OPTIONS_CONFIG_CONT"); g_Plugins->ConfigPlugin((DWORD)hWnd, PLUGIN_TYPE_CONTROLLER); break;
+    case ID_OPTIONS_CONFIG_RSP:
+        WriteTrace(TraceDebug, __FUNCTION__ ": ID_OPTIONS_CONFIG_RSP");
+        g_Plugins->ConfigPlugin(hWnd, PLUGIN_TYPE_RSP);
+        break;
+    case ID_OPTIONS_CONFIG_GFX:
+        WriteTrace(TraceDebug, __FUNCTION__ ": ID_OPTIONS_CONFIG_GFX");
+        g_Plugins->ConfigPlugin(hWnd, PLUGIN_TYPE_GFX);
+        break;
+    case ID_OPTIONS_CONFIG_AUDIO:
+        WriteTrace(TraceDebug, __FUNCTION__ ": ID_OPTIONS_CONFIG_AUDIO");
+        g_Plugins->ConfigPlugin(hWnd, PLUGIN_TYPE_AUDIO);
+        break;
+    case ID_OPTIONS_CONFIG_CONT:
+        WriteTrace(TraceDebug, __FUNCTION__ ": ID_OPTIONS_CONFIG_CONT");
+        g_Plugins->ConfigPlugin(hWnd, PLUGIN_TYPE_CONTROLLER);
+        break;
     case ID_OPTIONS_CPU_USAGE:
         WriteTrace(TraceDebug, __FUNCTION__ ": ID_OPTIONS_CPU_USAGE");
         if (g_Settings->LoadBool(UserInterface_ShowCPUPer))


### PR DESCRIPTION
Based on my training in the art of Compile-Fu (and testing the compiled binary for crashes), these are the only instances of `uint32_t hWnd/hParent` that I noticed and needed fixing.

They've been around since the beginning of time as far as I can see...before 2008 at least.