### PR TITLE
Simplify ROM browser shell file extensions comparisons.

### DIFF
--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -567,6 +567,7 @@ void CRomBrowser::AddFileNameToList(strlist & FileList, const stdstr & Directory
             stdstr FileName = Directory + Name + Extension;
             FileName.ToLower();
             FileList.push_back(FileName);
+            break;
         }
     }
 }
@@ -586,8 +587,8 @@ void CRomBrowser::FillRomList(strlist & FileList, const CPath & BaseDirectory, c
 	do
 	{
         uint8_t ext_ID;
+        int8_t new_list_entry = 0;
         const uint8_t exts = sizeof(ROM_extensions) / sizeof(ROM_extensions[0]);
-rom_entry_begin:
 
 		//TODO: Fix exception on Windows XP (Visual Studio 2010+)
 		//WriteTraceF(TraceDebug,__FUNCTION__ ": 2 %s m_StopRefresh = %d",(LPCSTR)SearchPath,m_StopRefresh);
@@ -612,10 +613,16 @@ rom_entry_begin:
         {
             if (Extension == ROM_extensions[ext_ID] && Extension != "7z")
             {
-                AddRomToList(SearchPath, lpLastRom);
-                goto rom_entry_begin;
+                new_list_entry = 1;
+                break;
             }
         }
+        if (new_list_entry)
+        {
+            AddRomToList(SearchPath, lpLastRom);
+            continue;
+        }
+
 		if (Extension == "7z")
 		{
 			try

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -652,11 +652,7 @@ rom_entry_begin:
 					_splitpath(FileName.c_str(), drive2, dir2, FileName2, ext2);
 
 					WriteTraceF(TraceDebug, __FUNCTION__ ": 6 %s", ext2);
-					if (_stricmp(ext2, ".v64") != 0 && _stricmp(ext2, ".z64") != 0 &&
-						_stricmp(ext2, ".n64") != 0 && _stricmp(ext2, ".rom") != 0 &&
-						_stricmp(ext2, ".jap") != 0 && _stricmp(ext2, ".pal") != 0 &&
-						_stricmp(ext2, ".usa") != 0 && _stricmp(ext2, ".eur") != 0 &&
-						_stricmp(ext2, ".bin") == 0)
+					if (_stricmp(ext2, ".bin") == 0)
 					{
 						continue;
 					}


### PR DESCRIPTION
Just something I happened upon by accident while stumbling through the `g_Plugins` business.
We can loop through a string table instead of iterating multiple `if` a && b && c && d && ... .

The second commit is probably the more important of the two, because it fixes what I think to be a redundancy in the extension analysis.  Or why was the original code this?
```c
if (_stricmp(ext2, ".v64") != 0 && _stricmp(ext2, ".z64") != 0 &&
	_stricmp(ext2, ".n64") != 0 && _stricmp(ext2, ".rom") != 0 &&
	_stricmp(ext2, ".jap") != 0 && _stricmp(ext2, ".pal") != 0 &&
	_stricmp(ext2, ".usa") != 0 && _stricmp(ext2, ".eur") != 0 &&
	_stricmp(ext2, ".bin") == 0)
{
```
MSDN's personal [documentation of _stricmp](https://msdn.microsoft.com/en-us/library/k59z8dwe.aspx) agrees that a return value of 0 indicates equality between the string operands, while a nonzero return value indicates inequality.

So instead of str != a && str != b && str != c ... && str == z, why not say only `str == z`?