### PR TITLE
CN64 time critical thread priority setting

### DIFF
--- a/Source/Project64/N64 System/N64 Class.cpp
+++ b/Source/Project64/N64 System/N64 Class.cpp
@@ -375,6 +375,11 @@ void  CN64System::StartEmulation(bool NewThread)
 
 void CN64System::StartEmulationThread(ThreadInfo * Info)
 {
+	if (g_Settings->LoadBool(Setting_CN64TimeCritical))
+	{
+ 		SetThreadPriority(GetCurrentThread(),THREAD_PRIORITY_TIME_CRITICAL);
+	}
+
     CoInitialize(NULL);
 
     EmulationStarting(*Info->ThreadHandle, Info->ThreadID);

--- a/Source/Project64/Plugins/Audio Plugin.cpp
+++ b/Source/Project64/Plugins/Audio Plugin.cpp
@@ -182,7 +182,11 @@ void CAudioPlugin::DacrateChanged(SYSTEM_TYPE Type)
 
 void CAudioPlugin::AudioThread(CAudioPlugin * _this) {
     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
-    for (;;)
+	if (g_Settings->LoadBool(Setting_CN64TimeCritical))
+	{
+ 		SetThreadPriority(GetCurrentThread(),THREAD_PRIORITY_HIGHEST);
+	}
+	for (;;)
     {
         _this->AiUpdate(true);
     }

--- a/Source/Project64/Settings/Settings Class.cpp
+++ b/Source/Project64/Settings/Settings Class.cpp
@@ -109,6 +109,7 @@ void CSettings::AddHowToHandleSetting()
     AddHandler(Setting_ApplicationName, new CSettingTypeTempString(""));
     AddHandler(Setting_UseFromRegistry, new CSettingTypeApplication("Settings", "Use Registry", (uint32_t)false));
     AddHandler(Setting_RdbEditor, new CSettingTypeApplication("", "Rdb Editor", false));
+    AddHandler(Setting_CN64TimeCritical,new CSettingTypeApplication("","CN64TimeCritical",false));
     AddHandler(Setting_PluginPageFirst, new CSettingTypeApplication("", "Plugin Page First", false));
     AddHandler(Setting_DisableScrSaver, new CSettingTypeApplication("", "Disable Screen Saver", (uint32_t)true));
     AddHandler(Setting_AutoSleep, new CSettingTypeApplication("", "Auto Sleep", (uint32_t)true));

--- a/Source/Project64/Settings/Settings.h
+++ b/Source/Project64/Settings/Settings.h
@@ -48,6 +48,7 @@ enum SettingID
     Setting_ApplicationName,
     Setting_UseFromRegistry,
     Setting_RdbEditor,
+    Setting_CN64TimeCritical,
     Setting_PluginPageFirst,
     Setting_DisableScrSaver,
     Setting_AutoSleep,


### PR DESCRIPTION
Fixes slowdowns on Windows 8.1 caused by DWM/Aero/Desktop Compositing.

To turn on, add CN64TimeCritical=1, under the [default] section in Project64.cfg.