### PR TITLE
Express initial CIC DMA poke in terms of the SW operation.

### DIFF
--- a/Source/Project64/N64 System/Mips/Dma.cpp
+++ b/Source/Project64/N64 System/Mips/Dma.cpp
@@ -18,20 +18,26 @@ m_Sram(Sram)
 
 void CDMA::OnFirstDMA()
 {
-    const uint32_t RDRAM_size = g_MMU->RdramSize();
+    int16_t offset;
     const uint32_t base = 0x00000000;
+    const uint32_t rt = g_MMU->RdramSize();
 
     switch (g_Rom->CicChipID())
     {
-    case CIC_NUS_6101:  g_MMU->SW_PAddr(0x000318 + base, RDRAM_size); break;
-    case CIC_NUS_5167:  g_MMU->SW_PAddr(0x000318 + base, RDRAM_size); break;
+    case CIC_NUS_6101:  offset = +0x0318; break;
+    case CIC_NUS_5167:  offset = +0x0318; break;
     case CIC_UNKNOWN:
-    case CIC_NUS_6102:  g_MMU->SW_PAddr(0x000318 + base, RDRAM_size); break;
-    case CIC_NUS_6103:  g_MMU->SW_PAddr(0x000318 + base, RDRAM_size); break;
-    case CIC_NUS_6105:  g_MMU->SW_PAddr(0x0003F0 + base, RDRAM_size); break;
-    case CIC_NUS_6106:  g_MMU->SW_PAddr(0x000318 + base, RDRAM_size); break;
-    default: g_Notify->DisplayError(stdstr_f("Unhandled CicChip(%d) in first DMA", g_Rom->CicChipID()).ToUTF16().c_str());
+    case CIC_NUS_6102:  offset = +0x0318; break;
+    case CIC_NUS_6103:  offset = +0x0318; break;
+    case CIC_NUS_6105:  offset = +0x03F0; break;
+    case CIC_NUS_6106:  offset = +0x0318; break;
+    default:
+        g_Notify->DisplayError(
+            stdstr_f("Unhandled CicChip(%d) in first DMA", g_Rom->CicChipID()).ToUTF16().c_str()
+        );
+        return;
     }
+    g_MMU->SW_PAddr(base + offset, rt);
 }
 
 void CDMA::PI_DMA_READ()

--- a/Source/Project64/N64 System/Mips/Dma.cpp
+++ b/Source/Project64/N64 System/Mips/Dma.cpp
@@ -18,15 +18,18 @@ m_Sram(Sram)
 
 void CDMA::OnFirstDMA()
 {
+    const uint32_t RDRAM_size = g_MMU->RdramSize();
+    const uint32_t base = 0x00000000;
+
     switch (g_Rom->CicChipID())
     {
-    case CIC_NUS_6101: *(uint32_t *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
-    case CIC_NUS_5167: *(uint32_t *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
+    case CIC_NUS_6101:  g_MMU->SW_PAddr(0x000318 + base, RDRAM_size); break;
+    case CIC_NUS_5167:  g_MMU->SW_PAddr(0x000318 + base, RDRAM_size); break;
     case CIC_UNKNOWN:
-    case CIC_NUS_6102: *(uint32_t *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
-    case CIC_NUS_6103: *(uint32_t *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
-    case CIC_NUS_6105: *(uint32_t *)&((g_MMU->Rdram())[0x3F0]) = g_MMU->RdramSize(); break;
-    case CIC_NUS_6106: *(uint32_t *)&((g_MMU->Rdram())[0x318]) = g_MMU->RdramSize(); break;
+    case CIC_NUS_6102:  g_MMU->SW_PAddr(0x000318 + base, RDRAM_size); break;
+    case CIC_NUS_6103:  g_MMU->SW_PAddr(0x000318 + base, RDRAM_size); break;
+    case CIC_NUS_6105:  g_MMU->SW_PAddr(0x0003F0 + base, RDRAM_size); break;
+    case CIC_NUS_6106:  g_MMU->SW_PAddr(0x000318 + base, RDRAM_size); break;
     default: g_Notify->DisplayError(stdstr_f("Unhandled CicChip(%d) in first DMA", g_Rom->CicChipID()).ToUTF16().c_str());
     }
 }


### PR DESCRIPTION
Created for the reasons discussed [here](https://github.com/project64/project64/commit/64e0dae30fa8273a0d2ef658be6040a5dd6b6fb2#commitcomment-14402401).

The first commit is the main reason, which replaces `*(uint32_t *)addr = (uint32_t)source` because:

1.  Byte order cannot be maintained--the `SW` function exposed through the core API is most reliable for handling the preferred client/server CPU endianness in the memory model.
2.  Cannot safely guarantee that the u8* returned by `g_MMU->Rdram()` is 32-bit aligned.
3.  Promoting a u8* to a u32* temporarily to alias a 32-bit write is undefined behavior.  In addition to the two rules above, doing this involves assumptions of transparency between memory "layers" (somewhat analogous to the way unions are frequently used in the source), so this is not portable.

I hope that in the future we will be able to avoid casting pointers in this fashion.  Converting char* to uint32_t* is better than doing it to DWORD* or unsigned long* but is still inflexible and can break the build on other platforms.