### PR TITLE
Get N-Rage linking with MinGW 64-bit.

### DIFF
--- a/Source/Script/MinGW/nrage.cmd
+++ b/Source/Script/MinGW/nrage.cmd
@@ -54,7 +54,15 @@ set OBJ_LIST=^
  %obj%\PakIO.o^
  %obj%\FileAccess.o^
  %obj%\Interface.o^
- %obj%\NRagePluginV2.o
+ %obj%\NRagePluginV2.o^
+ -ldinput8^
+ -loleaut32^
+ -lole32^
+ -luuid^
+ -lcomctl32^
+ -mwindows^
+ -lcomdlg32^
+ -lgdi32
 
 ECHO Linking N-Rage objects...
 %MinGW%\bin\g++.exe -o %obj%\PJ64_NRage.dll %OBJ_LIST% -shared -shared-libgcc

--- a/Source/Script/MinGW/nrage.cmd
+++ b/Source/Script/MinGW/nrage.cmd
@@ -62,8 +62,10 @@ set OBJ_LIST=^
  -lcomctl32^
  -mwindows^
  -lcomdlg32^
- -lgdi32
+ -lgdi32^
+ %obj%\NRagePluginV2.res
 
 ECHO Linking N-Rage objects...
+%MinGW%\bin\windres.exe -o %obj%\NRagePluginV2.res -i %src%\NRagePluginV2.rc -O coff
 %MinGW%\bin\g++.exe -o %obj%\PJ64_NRage.dll %OBJ_LIST% -shared -shared-libgcc
 PAUSE

--- a/Source/nragev20/Debug.h
+++ b/Source/nragev20/Debug.h
@@ -24,7 +24,7 @@
 #ifndef _DEBUG_H_
 #define _DEBUG_H_
 
-#include <wtypes.h>
+#include <windows.h>
 
 #ifdef _DEBUG
 

--- a/Source/nragev20/XInputController.cpp
+++ b/Source/nragev20/XInputController.cpp
@@ -19,6 +19,10 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+//code from http://msdn.microsoft.com/en-us/library/ee417014(VS.85).aspx
+#include <windows.h>
+#include <wbemidl.h>
+
 #include "XInputController.h"
 #include "FileAccess.h"
 #include <wchar.h>

--- a/Source/nragev20/XInputController.h
+++ b/Source/nragev20/XInputController.h
@@ -28,9 +28,6 @@
 #ifndef _XINPUTCONTROLLER_H
 #define _XINPUTCONTROLLER_H
 
-//code from http://msdn.microsoft.com/en-us/library/ee417014(VS.85).aspx
-#include <wbemidl.h>
-#include <oleauto.h>
 //#include <wmsstd.h> <-- only needed for SAFE_RELEASE(x)
 
 /* fixes undefined FILE, etc. type errors in MSVC 2010 build -- cxd4 */

--- a/Source/nragev20/commonIncludes.h
+++ b/Source/nragev20/commonIncludes.h
@@ -42,7 +42,8 @@
 
 #ifdef ARRAYSIZE
 #undef ARRAYSIZE
-#define ARRAYSIZE( array ) (sizeof(array) / sizeof(array[0]))
-#endif	//ARRAYSIZE
+#endif //ARRAYSIZE
+
+#define ARRAYSIZE(array)        (sizeof(array) / sizeof((array)[0]))
 
 #endif // #ifndef _COMMONINCLUDES_H_

--- a/Source/nragev20/commonIncludes.h
+++ b/Source/nragev20/commonIncludes.h
@@ -29,7 +29,6 @@
 
 #include "settings.h"
 #include <tchar.h>
-#include <wtypes.h>
 #include "resource.h"
 #include "Debug.h"
 


### PR DESCRIPTION
In prior pull requests, I have added a working compile script.  Linking fails however.

The linker errors were easily fixed by adding some more libraries (mostly -ldinput, -lole32 and `-mwindows`) and a call to compile the .RC resource script file to a `.res` and add that in to the linker.  (Otherwise trying to config the DLL in PJ64 just does nothing and shows no UI.)

Sorry--original, plain 32-bit MinGW package still does not compile N-Rage.  Get MSYS2 or 64-bit GCC.
Have not gotten the 32-bit DLL to build because the official packages have no `<wbemidl.h>`.

I have also changed parts of the code such as moving the missing/unsupported MSVC-specific headers (which are not officially available with MinGW) outside the .h file, into .cpp file, cleanups to divide the number of duplicated error messages, etc. ... anything to help anyone else take a crack at it.