### PR TITLE
[Common] #include <malloc.h> to fix undeclared `alloca`

### DIFF
--- a/Source/Common/std string.cpp
+++ b/Source/Common/std string.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include <malloc.h>
 #include <algorithm>
 
 stdstr::stdstr()


### PR DESCRIPTION
Fixes the following compile errors with MinGW:
```
$project64\Source\Script\MinGW\..\..\Common\std string.cpp:
In member function 'void stdstr::ArgFormat(const char*, char*&)':
$project64\Source\Script\MinGW\..\..\Common\std string.cpp:59:52:
error: 'alloca' was not declared in this scope
  char * buffer = (char *)alloca(nlen * sizeof(char));
                                                    ^
$project64\Source\Script\MinGW\..\..\Common\std string.cpp: In member
 function 'stdstr& stdstr::FromUTF16(const wchar_t*, bool*)':
$project64\Source\Script\MinGW\..\..\Common\std string.cpp:195:43:
error: 'alloca' was not declared in this scope
    char * buf = (char *)alloca(nNeeded + 1);
                                           ^
$project64\Source\Script\MinGW\..\..\Common\std string.cpp:
In member function 'std::wstring stdstr::ToUTF16(bool*)':
$project64\Source\Script\MinGW\..\..\Common\std string.cpp:224:68:
error: 'alloca' was not declared in this scope
   wchar_t * buf = (wchar_t *)alloca((nNeeded + 1) * sizeof(wchar_t));
                                                                    ^
```