### PR TITLE
[Common] Have fallback to including nonstandard <crtdbg.h>.

### DIFF
--- a/Source/Common/File Class.cpp
+++ b/Source/Common/File Class.cpp
@@ -2,6 +2,12 @@
 
 #include <TChar.H>
 
+#if defined(_MSC_VER)
+#include <crtdbg.h>
+#else
+#define _ASSERTE(expr)          ((void)0)
+#endif
+
 CFile::CFile() :
     m_hFile(INVALID_HANDLE_VALUE),
     m_bCloseOnDelete(false)

--- a/Source/Common/MemTest.cpp
+++ b/Source/Common/MemTest.cpp
@@ -1,4 +1,9 @@
+#if defined(_MSC_VER)
 #include <crtdbg.h>
+#else
+#define _ASSERTE(expr)          ((void)0)
+#endif
+
 #include "stdafx.h"
 #ifdef _DEBUG
 


### PR DESCRIPTION
I forgot to push this branch last night.

`<crtdbg.h>` is MSVC-exclusive from what I gather and is not normally available with GCC.
It appears the only thing that's needed in these units is just a #define for `_ASSERTE()`.