### PR TITLE
[ROM Browser] fixed issue #763

### DIFF
--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -707,7 +707,12 @@ void CRomBrowser::FillRomList(strlist & FileList, const CPath & BaseDirectory, c
 
 					for (int x = 0; x < 0x40; x += 4)
 					{
-						*((DWORD *)&RomData[x]) = std::strtoul(&szHeader[x * 2], 0, 16);
+                        const size_t delimit_offset = sizeof("FFFFFFFF") - 1;
+                        const char backup_character = szHeader[2*x + delimit_offset];
+
+                        szHeader[2*x + delimit_offset] = '\0';
+                        *(uint32_t *)&RomData[x] = std::strtoul(&szHeader[2*x], NULL, 16);
+                        szHeader[2*x + delimit_offset] = backup_character;
 					}
 
 					WriteTrace(TraceDebug, __FUNCTION__ ": 14");


### PR DESCRIPTION
The problem was because `AsciiToHex` was replaced with `std::strtoul(..., NULL, 16)`.
They are not entirely equivalent.

One cannot use the standard library functions strtol() and strtoul() to read a gigantic ASCII string without risking overflow.  As the `szHeader[]` C++ string was typically over 50 characters long, so, unless you are compiling for a system where sizeof(long) is something ridiculously huge, the return value is ULONG_MAX, and the standard library sets an internal error code of `ERANGE`.

Conversely, the custom `AsciiToHex` function did not comply to the standard library rules and simply performed wraparound from the upper, foremost characters of the string--ignoring subsequent characters if the string was too long.

Example, on 32-bit Windows you would get:
```c
unsigned long a, b;
static const char very_long_str[] = "112233445566778899AABBCCDDEEFF";

a = AsciiToHex(&very_long_str[0]); /* result:  0x11223344 */
b = strtoul(&very_long_str[0], NULL, 16); /* result:  ULONG_MAX = 0xFFFFFFFFul */
```

So this was causing corrupt ROM browser entries with 7z zipped files.