### PR TITLE
fixed impossible arithmetic condition

### DIFF
--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -433,7 +433,6 @@ void CRomBrowser::FillRomExtensionInfo(ROM_INFO * pRomInfo)
 	}
 	else
 	{
-		selcol = (std::strtoul(String, 0, 16) & 0xFFFFFF);
 		selcol = (selcol & 0x00FF00) | ((selcol >> 0x10) & 0xFF) | ((selcol & 0xFF) << 0x10);
 		pRomInfo->SelColor = selcol;
 	}

--- a/Source/Project64/User Interface/Rom Browser Class.cpp
+++ b/Source/Project64/User Interface/Rom Browser Class.cpp
@@ -426,8 +426,8 @@ void CRomBrowser::FillRomExtensionInfo(ROM_INFO * pRomInfo)
 	//Get the selected color
 	sprintf(String, "%s.Sel", pRomInfo->Status);
 	m_RomIniFile->GetString("Rom Status", String, "FFFFFFFF", String, 9);
-	int selcol = std::strtoul(String, 0, 16);
-	if (selcol < 0)
+    uint32_t selcol = std::strtoul(String, NULL, 16);
+    if (selcol & 0x80000000)
 	{
 		pRomInfo->SelColor = -1;
 	}


### PR DESCRIPTION
While I'm at it from my other ROM browser PR, please avoid:
`(int) = (unsigned long)...`

The native return type of strtoul() is `unsigned long`, so the destination should be at least some sort of unsigned type--most preferably an `unsigned long` as well.  In some cases (such as this one), `uint32_t` can also work without breaking other platforms.

But don't say int (or int32_t) x = strtoul(...), because strtoul() only returns non-negative integers.

The only way strtol() will interpret the string as a negative number is if the string itself represents a negative number with the unary '-' prefix; false Intel x86-specific assumptions such as "0xFFFFFFFF" meaning `-1` will only result in a range error and overflow in the standard library functions.