### PR TITLE
Improve RSP MinGW linker configuration.

### DIFF
--- a/Source/Script/MinGW/rsp.cmd
+++ b/Source/Script/MinGW/rsp.cmd
@@ -68,6 +68,8 @@ ECHO.
 
 set OBJ_LIST=^
  -mwindows^
+ -L%obj%\..\Common^
+ -lcommon^
  -lgdi32^
  %obj%\Sse.o^
  %obj%\Mmx.o^

--- a/Source/Script/MinGW/rsp.cmd
+++ b/Source/Script/MinGW/rsp.cmd
@@ -67,6 +67,8 @@ ECHO Assembling RSP sources...
 ECHO.
 
 set OBJ_LIST=^
+ -mwindows^
+ -lgdi32^
  %obj%\Sse.o^
  %obj%\Mmx.o^
  %obj%\X86.o^
@@ -87,5 +89,5 @@ set OBJ_LIST=^
  %obj%\Main.o
 
 ECHO Linking RSP objects...
-%MinGW%\bin\g++.exe -o %obj%\RSP_1.7.dll %OBJ_LIST% -lgdi32 -s
+%MinGW%\bin\g++.exe -o %obj%\RSP_1.7.dll %OBJ_LIST% -s
 PAUSE

--- a/Source/Script/MinGW/rsp.cmd
+++ b/Source/Script/MinGW/rsp.cmd
@@ -71,6 +71,7 @@ set OBJ_LIST=^
  -L%obj%\..\Common^
  -lcommon^
  -lgdi32^
+ %obj%\RSP.res^
  %obj%\Sse.o^
  %obj%\Mmx.o^
  %obj%\X86.o^
@@ -91,5 +92,6 @@ set OBJ_LIST=^
  %obj%\Main.o
 
 ECHO Linking RSP objects...
+%MinGW%\bin\windres.exe -o %obj%\RSP.res -i %src%\RSP.rc -O coff
 %MinGW%\bin\g++.exe -o %obj%\RSP_1.7.dll %OBJ_LIST% -s
 PAUSE


### PR DESCRIPTION
...but still does not yet link.

I can't understand what's wrong yet, but `stdstr::stdstr` is being compiled as:

* `_ZN6stdstrC1Ev` in `std string.cpp` and `Profiling.cpp` (if 64-bit)
* `__ZN6stdstrC1Ev` in `std string.cpp` and `Profiling.cpp` (if 32-bit)

Some sort of C++ subtlety in the compiler symbols generation is causing another unknown mismatch between the class names so PJ64 Common gets a different name while RSP stdstr in MinGW does not...I will have to figure out what's the matter with fixing that in a future pull request after this one.

Similar issue with CLog class:
```
project64\Source\Script\MinGW\RSP\Profiling.o:Profiling.cpp:
(.text$_ZN10CProfiling11GenerateLogEv[_ZN10CProfiling11GenerateLogEv]+0x34):
undefined reference to `stdstr::stdstr()'

project64\Source\Script\MinGW\RSP\Profiling.o:Profiling.cpp:
(.text$_ZN10CProfiling11GenerateLogEv[_ZN10CProfiling11GenerateLogEv]+0x3c):
undefined reference to `CLog::CLog()'
```