### PR TITLE
Ignore High-DPI setting when using VS 2008 toolset.

### DIFF
--- a/Source/Project64/Project64.vcxproj
+++ b/Source/Project64/Project64.vcxproj
@@ -39,7 +39,7 @@
       <StackReserveSize>1</StackReserveSize>
       <DataExecutionPrevention>false</DataExecutionPrevention>
     </Link>
-    <Manifest>
+    <Manifest Condition="'$(PlatformToolset)'!='v90'">
       <EnableDPIAwareness>true</EnableDPIAwareness>
     </Manifest>
   </ItemDefinitionGroup>


### PR DESCRIPTION
The VS2008 compilers don't know about the <EnableDPIAwareness> setting.
This triggers an error when building with MSBuild (VCXPROJ versions of Visual Studio) and setting the platform toolset to 'v90' (VS2008).

This changes ignores the setting altogether when using versons older than 2010.