### PR TITLE
Fix default toolset when using VS 2010

### DIFF
--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>$(DefaultPlatformToolset)_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!=''">$(DefaultPlatformToolset)_xp</PlatformToolset>
   </PropertyGroup>
 
   <ImportGroup Label="PropertySheets">


### PR DESCRIPTION
Within the VCXPROJ Visual Studio versions, only 2010 does not have an `_xp` flavor (it is XP-compatible by default).
It also des not set the `$(DefaultPlatformToolset)` variable.
This causes build failures when compiling from within VS2010 and requiring to set the toolset manually.

This change skips setting the `<PlatformToolset>` if the `$(DefaultPlatformToolset)` variable does not exist. Visual Studio 2010 falls back to its own toolset (`v100`), which is the expected behavior.