### PR TITLE
fixed random crashing if End then Start emulation

### DIFF
--- a/Source/Project64/N64 System/Emulation Thread.cpp
+++ b/Source/Project64/N64 System/Emulation Thread.cpp
@@ -36,7 +36,7 @@ void CN64System::StartEmulationThread(ThreadInfo * Info)
 
     CoInitialize(NULL);
 
-    EmulationStarting(Info->ThreadHandle, Info->ThreadID);
+    EmulationStarting(*Info->ThreadHandle, Info->ThreadID);
     delete ((HANDLE  *)Info->ThreadHandle);
     delete Info;
 

--- a/Source/Project64/N64 System/N64 Class.h
+++ b/Source/Project64/N64 System/N64 Class.h
@@ -90,7 +90,7 @@ private:
     //Used for loading and potentially executing the CPU in its own thread.
     struct ThreadInfo
     {
-        void * ThreadHandle;
+        void** ThreadHandle;
         uint32_t ThreadID;
     };
 


### PR DESCRIPTION
Fixes #776.

Hard to discuss the change...it's mostly self-explanatory but whether it was an accidental "mistake" on zilmar's part or if it was done on purpose and/or wrong is kind of open to interpretation.  Nonetheless it does fix the issue so I am proposing it.

Before this commit, the crashes all came from NTDLL.DLL so I fear that this "fix" may just solve hiding an underlying bug even beneath this one.  But it gets PJ64 back to the way it was originally before the commit so I think it's stable in that sense.