### PR TITLE
Fix compilation for non-XP platform toolsets.

### DIFF
--- a/Source/3rd Party/wx/src/msw/window.cpp
+++ b/Source/3rd Party/wx/src/msw/window.cpp
@@ -106,7 +106,7 @@
     #include <windowsx.h>
 #endif
 
-#if !defined __WXWINCE__ && !defined NEED_PBT_H
+#if !defined __WXWINCE__ && !defined NEED_PBT_H && 0 // Project64 does not support Windows CE
     #include <pbt.h>
 #endif
 


### PR DESCRIPTION
wxWidgets core (msw/window.cpp) includes `pbt.h` header, which sets some constants not needed at all by Glide64. This require fails if using non-xp platform toolsets (or nont-Microsoft toolsets).

Note: newer versions of wxWidgets like 3.0.2 don't use that header at all.
I built wit both xp-compatible and non-xp-compatible toolsets, and the source builds and runs correctly.