### PR TITLE
ported MinGW build script for project64::Common to Unix shell

### DIFF
--- a/Source/Script/Unix/common.sh
+++ b/Source/Script/Unix/common.sh
@@ -1,0 +1,57 @@
+src=./../../Common
+obj=./Common
+
+mkdir -p $obj
+
+FLAGS_x86="\
+ -S \
+ -masm=intel \
+ -march=native \
+ -Os"
+
+C_FLAGS=$FLAGS_x86
+
+CC=g++
+AS=as
+
+echo Compiling common library sources for Project64...
+$CC -o $obj/CriticalSection.asm         $src/CriticalSection.cpp $C_FLAGS
+$CC -o $obj/FileClass.asm              "$src/File Class.cpp" $C_FLAGS
+$CC -o $obj/IniFileClass.asm           "$src/Ini File Class.cpp" $C_FLAGS
+$CC -o $obj/LogClass.asm               "$src/Log Class.cpp" $C_FLAGS
+$CC -o $obj/md5.asm                     $src/md5.cpp $C_FLAGS
+$CC -o $obj/MemTest.asm                 $src/MemTest.cpp $C_FLAGS
+$CC -o $obj/path.asm                    $src/path.cpp $C_FLAGS
+$CC -o $obj/stdstring.asm              "$src/std string.cpp" $C_FLAGS
+$CC -o $obj/SyncEvent.asm               $src/SyncEvent.cpp $C_FLAGS
+$CC -o $obj/Trace.asm                   $src/Trace.cpp $C_FLAGS
+$CC -o $obj/Util.asm                    $src/Util.cpp $C_FLAGS
+
+echo Assembling common library sources...
+$AS -o $obj/CriticalSection.o           $obj/CriticalSection.asm
+$AS -o $obj/FileClass.o                 $obj/FileClass.asm
+$AS -o $obj/IniFileClass.o              $obj/IniFileClass.asm
+$AS -o $obj/LogClass.o                  $obj/LogClass.asm
+$AS -o $obj/md5.o                       $obj/md5.asm
+$AS -o $obj/MemTest.o                   $obj/MemTest.asm
+$AS -o $obj/path.o                      $obj/path.asm
+$AS -o $obj/stdstring.o                 $obj/stdstring.asm
+$AS -o $obj/SyncEvent.o                 $obj/SyncEvent.asm
+$AS -o $obj/Trace.o                     $obj/Trace.asm
+$AS -o $obj/Util.o                      $obj/Util.asm
+
+set OBJ_LIST="\
+ $obj/Util.o \
+ $obj/Trace.o \
+ $obj/SyncEvent.o \
+ $obj/stdstring.o \
+ $obj/path.o \
+ $obj/MemTest.o \
+ $obj/md5.o \
+ $obj/LogClass.o \
+ $obj/IniFileClass.o \
+ $obj/FileClass.o \
+ $obj/CriticalSection.o"
+
+echo Linking static library objects for Common...
+ar rcs $obj/libcommon.a $OBJ_LIST


### PR DESCRIPTION
Project64/Common now attempts to compile under Unix-based operating systems.

We do have a few compiler errors, but I can tackle them after we decide whether this extra directory for native GCC build scripts away from the MinGW Windows batch files is acceptable.

This new file is identical mostly to the one for MinGW Windows building it, with slight syntax differences to account for the fact that not all GNU distributions emulate the Windows command shell syntax.

Currently the build output from executing `./make.sh` is:
```
no@no-laptop:~/project64/Source/Script/Unix$ ./common.sh
Compiling common library sources for Project64...
In file included from ./../../Common/CriticalSection.cpp:1:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
In file included from ./../../Common/File Class.cpp:1:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
In file included from ./../../Common/Ini File Class.cpp:1:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
In file included from ./../../Common/Log Class.cpp:1:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
In file included from ./../../Common/md5.cpp:43:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
In file included from ./../../Common/MemTest.cpp:7:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
In file included from ./../../Common/path.cpp:4:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
In file included from ./../../Common/std string.cpp:1:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
In file included from ./../../Common/SyncEvent.cpp:1:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
In file included from ./../../Common/Trace.cpp:1:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
In file included from ./../../Common/Util.cpp:1:0:
./../../Common/stdafx.h:4:21: fatal error: windows.h: No such file or directory
 #include <windows.h>
                     ^
compilation terminated.
```
I think this windows.h business can be fixed subsequently.