### PR TITLE
Lowercase-ize some letters

### DIFF
--- a/Lang/French.pj.Lang
+++ b/Lang/French.pj.Lang
@@ -88,7 +88,7 @@
 #198#  "Emplacement 8"
 #199#  "Emplacement 9"
 #200#  "Emplacement 10"
-#201#  "Sélection de l'Emplacement de Sauvegarde (%ws)"
+#201#  "Sélection de l’emplacement de sauvegarde (%ws)"
 
 //Pop up Menu
 #210#  "Lancer le jeu"
@@ -342,8 +342,8 @@
 #688#  "Aucun jeu lancé"
 #689#  "Un jeu est lancé"
 #690#  "Un jeu est lancé (Fenêtré)"
-#691#  "Un jeu est lancé (Plein Ecran)"
-#692#  "Détecter la Touche"
+#691#  "Un jeu est lancé (Plein écran)"
+#692#  "Détecter la touche"
 
 // Frame Rate Option
 #700#  "Interruptions verticales par seconde"


### PR DESCRIPTION
So this is the modification I spoke about in #799. Rules for capitalizing titles in French are basically:

* First word is capitalized, others follow normal rules (e.g. still capitalize proper nouns)
* If the first word is an article (*le*, *la*, *un*, etc.), capitalize the second word
* If the second word is an adjective *preceding* a name, also capitalize the name
* The preceding rule doesn’t apply for adjectives *following* a name

It’s up to us to determine what is a title and what isn’t. For instance, I left a capital in a parenthesis because that parenthesis’ content can be considered as a title.

This is one of my resources for french typography: http://jacques-andre.fr/faqtypo/lessons.pdf