### PR TITLE
[Common] recursored Unix file paths to new file names

### DIFF
--- a/Source/Script/Unix/common.sh
+++ b/Source/Script/Unix/common.sh
@@ -16,13 +16,13 @@ AS=as
 
 echo Compiling common library sources for Project64...
 $CC -o $obj/CriticalSection.asm         $src/CriticalSection.cpp $C_FLAGS
-$CC -o $obj/FileClass.asm              "$src/File Class.cpp" $C_FLAGS
-$CC -o $obj/IniFileClass.asm           "$src/Ini File Class.cpp" $C_FLAGS
-$CC -o $obj/LogClass.asm               "$src/Log Class.cpp" $C_FLAGS
+$CC -o $obj/FileClass.asm               $src/FileClass.cpp $C_FLAGS
+$CC -o $obj/IniFileClass.asm            $src/IniFileClass.cpp $C_FLAGS
+$CC -o $obj/LogClass.asm                $src/LogClass.cpp $C_FLAGS
 $CC -o $obj/md5.asm                     $src/md5.cpp $C_FLAGS
 $CC -o $obj/MemTest.asm                 $src/MemTest.cpp $C_FLAGS
 $CC -o $obj/path.asm                    $src/path.cpp $C_FLAGS
-$CC -o $obj/stdstring.asm              "$src/std string.cpp" $C_FLAGS
+$CC -o $obj/stdstring.asm               $src/StdString.cpp $C_FLAGS
 $CC -o $obj/SyncEvent.asm               $src/SyncEvent.cpp $C_FLAGS
 $CC -o $obj/Trace.asm                   $src/Trace.cpp $C_FLAGS
 $CC -o $obj/Util.asm                    $src/Util.cpp $C_FLAGS


### PR DESCRIPTION
Just a minor update for now to conform my recent `common.sh` script to this commit:
https://github.com/project64/project64/commit/e3b32c572db1ebe7f5c8cf60e4db148eebd7f83f

Still does not compile; like project64 said many big changes may be needed before `Common` builds.
I may have to concentrate on other factors in the meantime.

As we are beginning to get source file names without spaces in them (e.g. `StdString.cpp` instead of `"std string.cpp"`, with the space), the scripts will become generally easier to create and maintain for future needs.

When I get back to my Windows dev. machine, I'll update the MinGW scripts with similar changes.  Cannot test them out here on Linux though without setting up some kind of emulation.