### PR TITLE
Fixed "Saved current state" and "Loaded State"

### DIFF
--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -1391,7 +1391,7 @@ bool CN64System::SaveState()
 
     CPath SavedFileName(FileName);
 
-    g_Notify->DisplayMessage(5, stdstr_f("%ws %s", SaveMessage.c_str(), SavedFileName.GetNameExtension().c_str()).ToUTF16().c_str());
+    g_Notify->DisplayMessage(5, stdwstr_f(L"%ws %ws", SaveMessage.c_str(), stdstr(SavedFileName.GetNameExtension()).ToUTF16().c_str()).c_str());
     //Notify().RefreshMenu();
     WriteTrace(TraceDebug, __FUNCTION__ ": Done");
     return true;
@@ -1687,7 +1687,7 @@ bool CN64System::LoadState(const char * FileName)
     }
     WriteTrace(TraceDebug, __FUNCTION__ ": 13");
     std::wstring LoadMsg = g_Lang->GetString(MSG_LOADED_STATE);
-    g_Notify->DisplayMessage(5, stdstr_f("%ws %s", LoadMsg.c_str(), CPath(FileNameStr).GetNameExtension().c_str()).ToUTF16().c_str());
+    g_Notify->DisplayMessage(5, stdwstr_f(L"%ws %ws", LoadMsg.c_str(), stdstr(CPath(FileNameStr).GetNameExtension()).ToUTF16().c_str()).c_str());
     WriteTrace(TraceDebug, __FUNCTION__ ": Done");
     return true;
 }


### PR DESCRIPTION
These two strings won't display properly for every language.

If the language doesn't use the Latin alphabet at all, the program will crash.
If it uses mostly Latin characters, some characters won't display properly.

The top string is "Saved current state" and the bottom one is "Loaded State".

Before
![before](https://cloud.githubusercontent.com/assets/5633676/11608933/b6fcd554-9b45-11e5-87f9-b51146a85d5a.png)


After
![after](https://cloud.githubusercontent.com/assets/5633676/11608932/b1b203ee-9b45-11e5-95dd-8ad6212ece7b.png)

