### PR TITLE
[Glide64] fixed wrong include paths for case-sensitivity

### DIFF
--- a/Source/Glide64/Gfx_1.3.h
+++ b/Source/Glide64/Gfx_1.3.h
@@ -69,7 +69,7 @@ the plugin
 #include <stddef.h>		// offsetof
 #include <glide.h>
 #include <Common/MemTest.h>
-#include <settings/Settings.h>
+#include <Settings/Settings.h>
 #include "GlideExtensions.h"
 #include "rdp.h"
 #include "Keys.h"

--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -37,7 +37,7 @@
 //
 //****************************************************************
 
-#include <common/StdString.h>
+#include <Common/StdString.h>
 #include "Gfx_1.3.h"
 #include "Version.h"
 #include <Settings/Settings.h>


### PR DESCRIPTION
Glide64 begins to compile on Linux now, but the only present `<wx/setup.h>` integrated with the repository itself is under the MSVC folder and throws #error's when using GCC without the MinGW port

In the meantime it's easy enough to fix the case-sensitive Unix-style include paths so the include errors go away, then maybe later I can finish the script to make sure it's correct.