### PR TITLE
LW_VAddr:  Fold two VAddr comparisons into one branch.

### DIFF
--- a/Source/Project64/N64System/Mips/MemoryVirtualMem.cpp
+++ b/Source/Project64/N64System/Mips/MemoryVirtualMem.cpp
@@ -303,7 +303,7 @@ bool CMipsMemoryVM::LW_VAddr(uint32_t VAddr, uint32_t& Value)
 {
     if (VAddr >= 0xA3F00000 && VAddr < 0xC0000000)
     {
-        if (VAddr < 0xA4000000 || VAddr >= 0xA4002000)
+        if ((VAddr & 0xFFFFE000ul) != 0xA4000000ul) // !(A4000000 <= addr < A4002000)
         {
             VAddr &= 0x1FFFFFFF;
             LW_NonMemory(VAddr, &Value);


### PR DESCRIPTION
Before making this change:
![pjinterpret-old](https://cloud.githubusercontent.com/assets/1396303/11605811/41389a24-9ad7-11e5-9394-3ca41d1b1813.png)

After making this change:
![pjinterpret-new](https://cloud.githubusercontent.com/assets/1396303/11605813/62be053a-9ad7-11e5-845b-f7982a6dcf69.png)

As I dislike relying simple-mindedly on the rich man's profiler application, I did check the VI/s when running Mario at a still spot, to make sure the profiler's generalizations didn't vary inversely against the actual speed of the game.  (Sometimes profilers tell you a function got faster, when actually it's slower.)

Now, as the code has become harder to read, I'll explain my optimization.

I went from
```c
if (VAddr < 0xA4000000 || VAddr >= 0xA4002000)
```
to
```c
if (!(VAddr >= 0xA4000000 && VAddr < 0xA4002000))
```
to
```c
if ((VAddr & 0xFFFFE000ul) != 0xA4000000ul)
```

The third step is essentially the same as check upper 16 bits, (VAddr[31..16] & 0xFFFF) == 0xA400, combined with a simple bit-wise logic trick to compare the rest of the lower bits' range between `(0x0000 <= x <= 0x2000)`.