### PR TITLE
Fix linker errors for NRage (x64)

### DIFF
--- a/Source/3rdParty/sdl/sdl2.vcxproj
+++ b/Source/3rdParty/sdl/sdl2.vcxproj
@@ -35,7 +35,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PrecompiledHeader />
-      <AdditionalIncludeDirectories>include;$(Root)Source/3rd Party/directx/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;$(Root)Source/3rdParty/directx/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>HAVE_LIBC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>

--- a/Source/nragev20/NRage_Input_V2.vcxproj
+++ b/Source/nragev20/NRage_Input_V2.vcxproj
@@ -40,14 +40,14 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(Root)Source\3rd Party\directx\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(Root)Source\3rdParty\directx\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
       <AdditionalDependencies>xinput.lib;dinput8.lib;dxguid.lib;Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(Root)Source\3rdParty\directx\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64'">$(Root)Source\3rd Party\directx\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)'=='x64'">$(Root)Source\3rdParty\directx\lib64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Recent directory renaming (Source\3rd Party => Source\3rdParty) was not applied in SDL and NRage VCXPROJ file.
Here is the error when building for x64:
```
"D:\Extra\pj64\buildme\Project64.sln" (default target) (1) ->
"D:\Extra\pj64\buildme\Source\nragev20\NRage_Input_V2.vcxproj" (default target) (17)
->
(Link target) ->
  DirectInput.obj : error LNK2001: unresolved external symbol c_dfDIMouse2 [D:\Extra\
pj64\buildme\Source\nragev20\NRage_Input_V2.vcxproj]
  DirectInput.obj : error LNK2001: unresolved external symbol c_dfDIKeyboard [D:\Extr
a\pj64\buildme\Source\nragev20\NRage_Input_V2.vcxproj]
  DirectInput.obj : error LNK2001: unresolved external symbol c_dfDIJoystick [D:\Extr
a\pj64\buildme\Source\nragev20\NRage_Input_V2.vcxproj]
  D:\Extra\pj64\buildme\Plugin64\Input\PJ64_NRage.dll : fatal error LNK1120: 3 unreso
lved externals [D:\Extra\pj64\buildme\Source\nragev20\NRage_Input_V2.vcxproj]
```

This change corrects this minor typo.