### PR TITLE
Synchronize MinGW build scripts to new space-free file paths.

### DIFF
--- a/Source/Script/MinGW/common.cmd
+++ b/Source/Script/MinGW/common.cmd
@@ -25,13 +25,13 @@ set AS=%MinGW%\bin\as.exe
 
 ECHO Compiling common library sources for Project64...
 %CC% -o %obj%\CriticalSection.asm       %src%\CriticalSection.cpp %C_FLAGS%
-%CC% -o %obj%\FileClass.asm            "%src%\File Class.cpp" %C_FLAGS%
-%CC% -o %obj%\IniFileClass.asm         "%src%\Ini File Class.cpp" %C_FLAGS%
-%CC% -o %obj%\LogClass.asm             "%src%\Log Class.cpp" %C_FLAGS%
+%CC% -o %obj%\FileClass.asm             %src%\FileClass.cpp %C_FLAGS%
+%CC% -o %obj%\IniFileClass.asm          %src%\IniFileClass.cpp %C_FLAGS%
+%CC% -o %obj%\LogClass.asm              %src%\LogClass.cpp %C_FLAGS%
 %CC% -o %obj%\md5.asm                   %src%\md5.cpp %C_FLAGS%
 %CC% -o %obj%\MemTest.asm               %src%\MemTest.cpp %C_FLAGS%
 %CC% -o %obj%\path.asm                  %src%\path.cpp %C_FLAGS%
-%CC% -o %obj%\stdstring.asm            "%src%\std string.cpp" %C_FLAGS%
+%CC% -o %obj%\stdstring.asm             %src%\StdString.cpp %C_FLAGS%
 %CC% -o %obj%\SyncEvent.asm             %src%\SyncEvent.cpp %C_FLAGS%
 %CC% -o %obj%\Trace.asm                 %src%\Trace.cpp %C_FLAGS%
 %CC% -o %obj%\Util.asm                  %src%\Util.cpp %C_FLAGS%

--- a/Source/Script/MinGW/glide64.cmd
+++ b/Source/Script/MinGW/glide64.cmd
@@ -12,10 +12,10 @@ mkdir %obj%
 REM set MinGW=C:\msys64\mingw64\x86_64-w64-mingw32\..
 
 set FLAGS_x86=^
- -I"%src%\.."^
- -I"%src%\..\3rd Party\wx\include"^
- -I"%src%\..\3rd Party\wx\lib\vc_lib\msw"^
- -I"%src%\..\Glitch64\inc"^
+ -I%src%\..^
+ -I%src%\..\3rdParty\wx\include^
+ -I%src%\..\3rdParty\wx\lib\vc_lib\msw^
+ -I%src%\..\Glitch64\inc^
  -S^
  -masm=intel^
  -march=native^

--- a/Source/Script/MinGW/nrage.cmd
+++ b/Source/Script/MinGW/nrage.cmd
@@ -12,7 +12,7 @@ mkdir %obj%
 REM set MinGW=C:\msys64\mingw64\x86_64-w64-mingw32\..
 
 set FLAGS_x86=^
- -I"%src%\..\3rd Party\directx\include"^
+ -I%src%\..\3rdParty\directx\include^
  -Wno-write-strings^
  -S^
  -masm=intel^

--- a/Source/Script/MinGW/rsp.cmd
+++ b/Source/Script/MinGW/rsp.cmd
@@ -13,7 +13,7 @@ REM set MinGW=C:\msys64\mingw64\x86_64-w64-mingw32\..
 
 set FLAGS_x86=^
  -Wno-write-strings^
- -I"%src%\.."^
+ -I%src%\..^
  -S^
  -masm=intel^
  -march=native^
@@ -32,15 +32,15 @@ ECHO Compiling RSP plugin sources...
 %CC% -o %obj%\dma.asm                   %src%\dma.c %C_FLAGS%
 %CC% -o %obj%\breakpoint.asm            %src%\breakpoint.c %C_FLAGS%
 %CC% -o %obj%\log.asm                   %src%\log.cpp %C_FLAGS%
-%CC% -o %obj%\InterpreterCPU.asm       "%src%\Interpreter CPU.c" %C_FLAGS%
-%CC% -o %obj%\RecompilerCPU.asm        "%src%\Recompiler CPU.c" %C_FLAGS%
-%CC% -o %obj%\InterpreterOps.asm       "%src%\Interpreter Ops.c" %C_FLAGS%
-%CC% -o %obj%\RecompilerOps.asm        "%src%\Recompiler Ops.c" %C_FLAGS%
+%CC% -o %obj%\InterpreterCPU.asm        %src%\InterpreterCPU.c %C_FLAGS%
+%CC% -o %obj%\RecompilerCPU.asm         %src%\RecompilerCPU.c %C_FLAGS%
+%CC% -o %obj%\InterpreterOps.asm        %src%\InterpreterOps.c %C_FLAGS%
+%CC% -o %obj%\RecompilerOps.asm         %src%\RecompilerOps.c %C_FLAGS%
 %CC% -o %obj%\Profiling.asm             %src%\Profiling.cpp %C_FLAGS%
-%CC% -o %obj%\RSPCommand.asm           "%src%\RSP Command.c" %C_FLAGS%
-%CC% -o %obj%\RSPRegister.asm          "%src%\RSP Register.c" %C_FLAGS%
-%CC% -o %obj%\RecompilerSections.asm   "%src%\Recompiler Sections.c" %C_FLAGS%
-%CC% -o %obj%\RecompilerAnalysis.asm   "%src%\Recompiler Analysis.c" %C_FLAGS%
+%CC% -o %obj%\RSPCommand.asm            %src%\RSPCommand.c %C_FLAGS%
+%CC% -o %obj%\RSPRegister.asm           %src%\RSPRegister.c %C_FLAGS%
+%CC% -o %obj%\RecompilerSections.asm    %src%\RecompilerSections.c %C_FLAGS%
+%CC% -o %obj%\RecompilerAnalysis.asm    %src%\RecompilerAnalysis.c %C_FLAGS%
 %CC% -o %obj%\X86.asm                   %src%\X86.c %C_FLAGS%
 %CC% -o %obj%\Mmx.asm                   %src%\Mmx.c %C_FLAGS%
 %CC% -o %obj%\Sse.asm                   %src%\Sse.c %C_FLAGS%


### PR DESCRIPTION
Just a little update to the build scripts now that I am back on my Windows dev machine again.

This is to reflect the file path simplifications to not have spaces as of recent in any PJ source file names.