### PR TITLE
non-implicit string.h inclusion to fix non-Win32 compiles

### DIFF
--- a/Source/Common/stdafx.h
+++ b/Source/Common/stdafx.h
@@ -4,6 +4,7 @@
 #include <windows.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <string.h>
 
 #include "MemTest.h"
 #include "StdString.h"


### PR DESCRIPTION
If I remember, `<string.h>` gets included implicitly on Win32 if you include...was it either stdio.h or stdlib.h, I think.  To make sure actually that strcmp and memcpy and other symbols get resolved while compiling outside of Windows, having this header get explicitly included helps.