### PR TITLE
Fixed VCXPROJ for Project64-core.

### DIFF
--- a/Project64.sln
+++ b/Project64.sln
@@ -214,10 +214,12 @@ Global
 		{81CE8DAF-EBB2-4761-8E45-B71ABCCA8C68}.Release|x64.Build.0 = Release|x64
 		{00C7B43A-DED7-4DF0-B072-9A5783EF866D}.Debug|Win32.ActiveCfg = Debug|Win32
 		{00C7B43A-DED7-4DF0-B072-9A5783EF866D}.Debug|Win32.Build.0 = Debug|Win32
-		{00C7B43A-DED7-4DF0-B072-9A5783EF866D}.Debug|x64.ActiveCfg = Debug|Win32
+		{00C7B43A-DED7-4DF0-B072-9A5783EF866D}.Debug|x64.ActiveCfg = Debug|x64
+		{00C7B43A-DED7-4DF0-B072-9A5783EF866D}.Debug|x64.Build.0 = Debug|x64
 		{00C7B43A-DED7-4DF0-B072-9A5783EF866D}.Release|Win32.ActiveCfg = Release|Win32
 		{00C7B43A-DED7-4DF0-B072-9A5783EF866D}.Release|Win32.Build.0 = Release|Win32
-		{00C7B43A-DED7-4DF0-B072-9A5783EF866D}.Release|x64.ActiveCfg = Release|Win32
+		{00C7B43A-DED7-4DF0-B072-9A5783EF866D}.Release|x64.ActiveCfg = Release|x64
+		{00C7B43A-DED7-4DF0-B072-9A5783EF866D}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Project64-core/Project64-core.vcxproj
+++ b/Source/Project64-core/Project64-core.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
@@ -103,12 +111,12 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\3rd Party\zlib\contrib\minizip\unzip.h" />
-    <ClInclude Include="..\3rd Party\zlib\contrib\minizip\zip.h" />
-    <ClInclude Include="..\3rd Party\zlib\zconf.h" />
-    <ClInclude Include="..\3rd Party\zlib\zlib.h" />
-    <ClInclude Include="3rd Party\7zip.h" />
-    <ClInclude Include="3rd Party\zip.h" />
+    <ClInclude Include="..\3rdParty\zlib\contrib\minizip\unzip.h" />
+    <ClInclude Include="..\3rdParty\zlib\contrib\minizip\zip.h" />
+    <ClInclude Include="..\3rdParty\zlib\zconf.h" />
+    <ClInclude Include="..\3rdParty\zlib\zlib.h" />
+    <ClInclude Include="3rdParty\7zip.h" />
+    <ClInclude Include="3rdParty\zip.h" />
     <ClInclude Include="AppInit.h" />
     <ClInclude Include="Logging.h" />
     <ClInclude Include="Multilanguage.h" />
@@ -195,7 +203,7 @@
     <ClInclude Include="Version.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\3rd Party\zlib\zlib.vcxproj">
+    <ProjectReference Include="..\3rdParty\zlib\zlib.vcxproj">
       <Project>{731bd205-2826-4631-b7af-117658e88dbc}</Project>
     </ProjectReference>
     <ProjectReference Include="..\3rdParty\7zip\7zip.vcxproj">


### PR DESCRIPTION
Project64-core.vcxproj has incorrect configuration that makes x64 builds fail (not being able to find Project64-core.lib).

Testing done:
* Built all permutations of (Debug, Release)|(Win32, x64) successfully.