### PR TITLE
fixed incorrect file name for case-sensitivity

### DIFF
--- a/Source/Project64-core/Project64-core.vcxproj
+++ b/Source/Project64-core/Project64-core.vcxproj
@@ -71,7 +71,7 @@
     <ClCompile Include="N64System\Recompiler\RecompilerOps.cpp" />
     <ClCompile Include="N64System\Recompiler\RegInfo.cpp" />
     <ClCompile Include="N64System\Recompiler\SectionInfo.cpp" />
-    <ClCompile Include="N64System\Recompiler\X86CodeLog.cpp" />
+    <ClCompile Include="N64System\Recompiler\x86CodeLog.cpp" />
     <ClCompile Include="N64System\Recompiler\X86ops.cpp" />
     <ClCompile Include="N64System\SpeedLimitorClass.cpp" />
     <ClCompile Include="N64System\SystemGlobals.cpp" />


### PR DESCRIPTION
Fix a regression from a recent pull request that incorrectly capitalized `x86` to `X86`.

The correct file name in the repository has a lowercase 'x', and the grammatically correct name needs it lowercase.  Automatic capitalization is unwarranted for normal phrases, ideas, concepts or anything short of an actual sentence.