### PR TITLE
some more fixes to #include directives breaking non-Win32 builds

### DIFF
--- a/Source/Project64-core/AppInit.cpp
+++ b/Source/Project64-core/AppInit.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
-#include <common/path.h>
-#include <common/trace.h>
+#include <Common/path.h>
+#include <Common/trace.h>
 #include <Common/Util.h>
 #include <Project64-core/N64System/Mips/MemoryVirtualMem.h>
 #include <Project64-core/N64System/SystemGlobals.h>

--- a/Source/Project64-core/stdafx.h
+++ b/Source/Project64-core/stdafx.h
@@ -1,6 +1,6 @@
-#include <Common\stdtypes.h>
+#include <Common/stdtypes.h>
 #include <Common/StdString.h>
-#include <Common\TraceDefs.h>
+#include <Common/TraceDefs.h>
 
 #include "Multilanguage.h"
 #include "Notification.h"


### PR DESCRIPTION
Just a couple more current fixes in advance for getting Unix compile script to work.

In order for C as a language to be portable, `#include` paths need to have some kind of universally accepted standard.  Due to C inherently being from the Unix operating system, that accepted standard is `path/filename` and not `path\filename` with the Windows-style backslash.