### PR TITLE
Fix savestate filename

### DIFF
--- a/Source/Common/StdString.cpp
+++ b/Source/Common/StdString.cpp
@@ -181,7 +181,7 @@ stdstr & stdstr::Trim(const char * chars2remove)
     return *this;
 }
 
-stdstr & stdstr::FromUTF16(const wchar_t * UTF16Source, bool * bSuccess)
+stdstr & stdstr::FromUTF16(const wchar_t * UTF16Source, UINT CodePage, bool * bSuccess)
 {
     bool bConverted = false;
 
@@ -192,7 +192,7 @@ stdstr & stdstr::FromUTF16(const wchar_t * UTF16Source, bool * bSuccess)
     }
     else if (wcslen(UTF16Source) > 0)
     {
-        DWORD nNeeded = WideCharToMultiByte(CP_UTF8, 0, UTF16Source, -1, NULL, 0, NULL, NULL);
+        DWORD nNeeded = WideCharToMultiByte(CodePage, 0, UTF16Source, -1, NULL, 0, NULL, NULL);
         if (nNeeded > 0)
         {
             char * buf = (char *)alloca(nNeeded + 1);
@@ -200,7 +200,7 @@ stdstr & stdstr::FromUTF16(const wchar_t * UTF16Source, bool * bSuccess)
             {
                 memset(buf, 0, nNeeded + 1);
 
-                nNeeded = WideCharToMultiByte(CP_UTF8, 0, UTF16Source, -1, buf, nNeeded, NULL, NULL);
+                nNeeded = WideCharToMultiByte(CodePage, 0, UTF16Source, -1, buf, nNeeded, NULL, NULL);
                 if (nNeeded)
                 {
                     *this = buf;

--- a/Source/Common/StdString.h
+++ b/Source/Common/StdString.h
@@ -38,7 +38,7 @@ public:
     stdstr   & TrimLeft(const char * chars2remove = "\t ");
     stdstr   & TrimRight(const char * chars2remove = "\t ");
 
-    stdstr   & FromUTF16(const wchar_t * UTF16Source, bool * bSuccess = NULL);
+    stdstr   & FromUTF16(const wchar_t * UTF16Source, unsigned int CodePage = CODEPAGE_UTF8, bool * bSuccess = NULL);
     std::wstring ToUTF16(unsigned int CodePage = CODEPAGE_UTF8, bool * bSuccess = NULL);
 
     void ArgFormat(const char * strFormat, va_list & args);

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -1394,9 +1394,7 @@ bool CN64System::SaveState()
     g_Settings->SaveString(GameRunning_InstantSaveFile, "");
     std::wstring SaveMessage = g_Lang->GetString(MSG_SAVED_STATE);
 
-    CPath SavedFileName(FileName);
-
-    g_Notify->DisplayMessage(5, stdwstr_f(L"%ws %ws", SaveMessage.c_str(), stdstr(SavedFileName.GetNameExtension()).ToUTF16().c_str()).c_str());
+    g_Notify->DisplayMessage(5, stdwstr_f(L"%ws %ws", SaveMessage.c_str(), stdstr(CPath(FileName).GetNameExtension()).ToUTF16(CP_ACP).c_str()).c_str());
     //Notify().RefreshMenu();
     WriteTrace(TraceDebug, __FUNCTION__ ": Done");
     return true;
@@ -1697,7 +1695,7 @@ bool CN64System::LoadState(const char * FileName)
     }
     WriteTrace(TraceDebug, __FUNCTION__ ": 13");
     std::wstring LoadMsg = g_Lang->GetString(MSG_LOADED_STATE);
-    g_Notify->DisplayMessage(5, stdwstr_f(L"%ws %ws", LoadMsg.c_str(), stdstr(CPath(FileNameStr).GetNameExtension()).ToUTF16().c_str()).c_str());
+    g_Notify->DisplayMessage(5, stdwstr_f(L"%ws %ws", LoadMsg.c_str(), stdstr(CPath(FileNameStr).GetNameExtension()).ToUTF16(CP_ACP).c_str()).c_str());
     WriteTrace(TraceDebug, __FUNCTION__ ": Done");
     return true;
 }

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -1247,14 +1247,19 @@ bool CN64System::SaveState()
     stdstr FileName, ExtraInfoFileName, CurrentSaveName = g_Settings->LoadStringVal(GameRunning_InstantSaveFile);
     if (CurrentSaveName.empty())
     {
+		stdstr tmp;
+
+		//UTF8 -> UTF16(Unicode) -> ANSI(SJIS)
+		tmp.FromUTF16(g_Settings->LoadStringVal(Game_GoodName).ToUTF16().c_str(), CP_ACP);
+		
         int Slot = g_Settings->LoadDword(Game_CurrentSaveState);
         if (Slot != 0)
         {
-            CurrentSaveName.Format("%s.pj%d", g_Settings->LoadStringVal(Game_GoodName).c_str(), Slot);
+            CurrentSaveName.Format("%s.pj%d", tmp.c_str(), Slot);
         }
         else
         {
-            CurrentSaveName.Format("%s.pj", g_Settings->LoadStringVal(Game_GoodName).c_str());
+            CurrentSaveName.Format("%s.pj", tmp.c_str());
         }
         FileName.Format("%s%s", g_Settings->LoadStringVal(Directory_InstantSave).c_str(), CurrentSaveName.c_str());
         stdstr_f ZipFileName("%s.zip", FileName.c_str());
@@ -1408,14 +1413,19 @@ bool CN64System::LoadState()
     }
 
     CPath FileName;
+	stdstr tmp;
+
+	//UTF8 -> UTF16(Unicode) -> ANSI(SJIS)
+	tmp.FromUTF16(g_Settings->LoadStringVal(Game_GoodName).ToUTF16().c_str(), CP_ACP);
+	
     FileName.SetDriveDirectory(g_Settings->LoadStringVal(Directory_InstantSave).c_str());
     if (g_Settings->LoadDword(Game_CurrentSaveState) != 0)
     {
-        FileName.SetNameExtension(stdstr_f("%s.pj%d", g_Settings->LoadStringVal(Game_GoodName).c_str(), g_Settings->LoadDword(Game_CurrentSaveState)).c_str());
+        FileName.SetNameExtension(stdstr_f("%s.pj%d", tmp.c_str(), g_Settings->LoadDword(Game_CurrentSaveState)).c_str());
     }
     else
     {
-        FileName.SetNameExtension(stdstr_f("%s.pj", g_Settings->LoadStringVal(Game_GoodName).c_str()).c_str());
+        FileName.SetNameExtension(stdstr_f("%s.pj", tmp.c_str()).c_str());
     }
 
     CPath ZipFileName;

--- a/Source/Project64/N64System/RomInformationClass.cpp
+++ b/Source/Project64/N64System/RomInformationClass.cpp
@@ -71,7 +71,7 @@ DWORD CALLBACK RomInfoProc (HWND hDlg, DWORD uMsg, DWORD wParam, DWORD lParam) {
 			SetDlgItemTextW(hDlg, IDC_CIC_CHIP, GS(INFO_CIC_CHIP_TEXT));
 			SetDlgItemTextW(hDlg, IDC_CLOSE_BUTTON, GS(BOTTOM_CLOSE));
 
-			SetDlgItemText(hDlg,IDC_INFO_ROMNAME,_this->m_pRomInfo->GetRomName().c_str());
+			SetDlgItemTextW(hDlg, IDC_INFO_ROMNAME, _this->m_pRomInfo->GetRomName().ToUTF16(stdstr::CODEPAGE_932).c_str());
 			
 			char path[_MAX_PATH], drive[_MAX_DRIVE],dir[_MAX_DIR], fname[_MAX_FNAME],ext[_MAX_EXT];
 			_splitpath(_this->m_pRomInfo->GetFileName().c_str(), drive, dir, fname, ext);

--- a/Source/Project64/UserInterface/MainMenuClass.cpp
+++ b/Source/Project64/UserInterface/MainMenuClass.cpp
@@ -635,9 +635,13 @@ std::wstring CMainMenu::GetSaveSlotString(int Slot)
     if (!g_Settings->LoadBool(GameRunning_CPU_Running)) { return SlotName; }
 
     stdstr LastSaveTime;
+	stdstr tmp;
 
+	//UTF8 -> UTF16(Unicode) -> ANSI(SJIS)
+	tmp.FromUTF16(g_Settings->LoadStringVal(Game_GoodName).ToUTF16().c_str(), CP_ACP);
+	
     //check first save name
-    stdstr _GoodName = g_Settings->LoadStringVal(Game_GoodName);
+    stdstr _GoodName = tmp.c_str();
     stdstr _InstantSaveDirectory = g_Settings->LoadStringVal(Directory_InstantSave);
     stdstr CurrentSaveName;
     if (Slot != 0)
@@ -663,7 +667,12 @@ std::wstring CMainMenu::GetSaveSlotString(int Slot)
     // Check old file name
     if (LastSaveTime.empty())
     {
-        stdstr _RomName = g_Settings->LoadStringVal(Game_GameName);
+        stdstr tmp;
+
+		//UTF8 -> UTF16(Unicode) -> ANSI(SJIS)
+        tmp.FromUTF16(g_Settings->LoadStringVal(Game_GameName).ToUTF16().c_str(), CP_ACP);
+        
+        stdstr _RomName = tmp.c_str();
         if (Slot > 0)
         {
             FileName.Format("%s%s.pj%d", _InstantSaveDirectory.c_str(), _RomName.c_str(), Slot);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Game-General.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Game-General.cpp
@@ -77,7 +77,7 @@ CGameGeneralPage::CGameGeneralPage(HWND hParent, const RECT & rcDispay)
 		ComboBox->AddItemW(GS(NUMBER_6), 6);
 	}
 
-	SetDlgItemText(IDC_GOOD_NAME, g_Settings->LoadStringVal(Game_GoodName).c_str());
+	SetDlgItemTextW(m_hWnd, IDC_GOOD_NAME, g_Settings->LoadStringVal(Game_GoodName).ToUTF16().c_str());
 
 	CModifiedEditBox * TxtBox = AddModTextBox(GetDlgItem(IDC_VIREFRESH), Game_ViRefreshRate, false);
 	TxtBox->SetTextField(GetDlgItem(IDC_VIREFESH_TEXT));

--- a/Source/Project64/UserInterface/SettingsConfig.cpp
+++ b/Source/Project64/UserInterface/SettingsConfig.cpp
@@ -113,8 +113,10 @@ LRESULT	CSettingConfig::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*
 	{
 		if (g_Settings->LoadBool(Setting_RdbEditor))
 		{
-			SetWindowText(stdstr_f("%ws ** RDB Edit Mode **",GS(OPTIONS_TITLE)).c_str());
-		} else {
+			::SetWindowTextW(m_hWnd, stdwstr_f(L"%ws ** RDB Edit Mode **", GS(OPTIONS_TITLE)).c_str());
+		}
+		else
+		{
 			::SetWindowTextW(m_hWnd, GS(OPTIONS_TITLE));
 		}
 

--- a/Source/Project64/UserInterface/SettingsConfig.cpp
+++ b/Source/Project64/UserInterface/SettingsConfig.cpp
@@ -81,7 +81,8 @@ LRESULT	CSettingConfig::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*
 
 	if (!GameIni.empty())
 	{
-		ConfigRomTitle.Format("Config: %s",g_Settings->LoadStringVal(Game_GoodName).c_str());
+		ConfigRomTitle.FromUTF16(g_Settings->LoadStringVal(Game_GoodName).ToUTF16().c_str(), CP_ACP);
+		ConfigRomTitle.Format("Config: %s", ConfigRomTitle.c_str());
 	}
 
 	RECT rcSettingInfo;
@@ -152,7 +153,7 @@ LRESULT	CSettingConfig::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*
 	//Game Settings
 	if (!GameIni.empty())
 	{
-        CConfigSettingSection * GameSettings = new CConfigSettingSection(ConfigRomTitle.ToUTF16().c_str());
+        CConfigSettingSection * GameSettings = new CConfigSettingSection(ConfigRomTitle.ToUTF16(CP_ACP).c_str());
 		GameSettings->AddPage(new CGameGeneralPage(this->m_hWnd,rcSettingInfo ));
 		GameSettings->AddPage(new CGameRecompilePage(this->m_hWnd,rcSettingInfo ));
 		GameSettings->AddPage(new CGamePluginPage(this->m_hWnd,rcSettingInfo ));


### PR DESCRIPTION
Fixed savestate and dialog titles are garbled in custom RDB(editing Good Name)
![fix](https://cloud.githubusercontent.com/assets/11252775/11683710/e76ff9b0-9eaf-11e5-867f-06654f291698.jpg)
