### PR TITLE
[core] removed extra, unnecessary branch for the NORMAL case

### DIFF
--- a/Source/Project64-core/N64System/Interpreter/InterpreterCPU.cpp
+++ b/Source/Project64-core/N64System/Interpreter/InterpreterCPU.cpp
@@ -301,22 +301,20 @@ void CInterpreterCPU::ExecuteCPU()
             m_R4300i_Opcode[Opcode.op]();
             NextTimer -= CountPerOp;
 
+            PROGRAM_COUNTER += 4;
             switch (R4300iOp::m_NextInstruction)
             {
             case NORMAL:
-                PROGRAM_COUNTER += 4;
                 break;
             case DELAY_SLOT:
                 R4300iOp::m_NextInstruction = JUMP;
-                PROGRAM_COUNTER += 4;
                 break;
             case PERMLOOP_DO_DELAY:
                 R4300iOp::m_NextInstruction = PERMLOOP_DELAY_DONE;
-                PROGRAM_COUNTER += 4;
                 break;
             case JUMP:
             {
-                bool CheckTimer = (JumpToLocation < PROGRAM_COUNTER || TestTimer);
+                bool CheckTimer = (JumpToLocation < PROGRAM_COUNTER - 4 || TestTimer);
                 PROGRAM_COUNTER = JumpToLocation;
                 R4300iOp::m_NextInstruction = NORMAL;
                 if (CheckTimer)


### PR DESCRIPTION
This is another speed optimization to the interpreter CPU--tested primarily with 64-bit.

In this case what is being optimized is `case NORMAL:`.

So instead of doing this:
```c
while (CPU_running == true) {
    fetch();
    execute();

    switch (R4300iOp::m_NextInstruction) {
    case NORMAL:
        PROGRAM_COUNTER += 4;
        break;
    /* ... etc. */
    }
    continue;
}
```
... we instead get to have the compiler optimize to this:
```c
while (CPU_running == true) {
    fetch();
    execute();

    PROGRAM_COUNTER += 4;
    switch (R4300iOp::m_NextInstruction) {
    case NORMAL:
        continue; /* Notice, here, this case merely goes straight to the top of the loop. */
    /* ... etc. */
    }
}
```
Based simply on testing the VI/s speed counter without the speed limiter in effect, two different games show a 2% speed increase in the CPU (or about 5 extra VI/s on average for both games).