### PR TITLE
[core] fixed almost all fatal compile errors for Unix build

### DIFF
--- a/Source/Project64-core/AppInit.cpp
+++ b/Source/Project64-core/AppInit.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 #include <Common/path.h>
-#include <Common/trace.h>
+#include <Common/Trace.h>
 #include <Common/Util.h>
 #include <Project64-core/N64System/Mips/MemoryVirtualMem.h>
 #include <Project64-core/N64System/SystemGlobals.h>

--- a/Source/Project64-core/Logging.cpp
+++ b/Source/Project64-core/Logging.cpp
@@ -9,7 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
-#include "logging.h"
+#include "Logging.h"
 #include <Common/path.h>
 #include <Project64-core/N64System/SystemGlobals.h>
 #include <Project64-core/N64System/Mips/TranslateVaddr.h>

--- a/Source/Project64-core/Multilanguage/LanguageClass.h
+++ b/Source/Project64-core/Multilanguage/LanguageClass.h
@@ -14,7 +14,7 @@
 #include <string>   //stl string
 #include <map>      //stl map
 #include <list>     //stl list
-#include <common/stdtypes.h>
+#include <Common/stdtypes.h>
 
 typedef std::map<int32_t, std::wstring, std::less<int32_t> > LANG_STRINGS;
 typedef LANG_STRINGS::value_type               LANG_STR;

--- a/Source/Project64-core/N64System/CheatClass.cpp
+++ b/Source/Project64-core/N64System/CheatClass.cpp
@@ -12,7 +12,7 @@
 
 #include "CheatClass.h"
 #include <Project64-core/Settings/SettingType/SettingsType-Cheats.h>
-#include <Project64-core/Plugins/GFXplugin.h>
+#include <Project64-core/Plugins/GFXPlugin.h>
 #include <Project64-core/Plugins/AudioPlugin.h>
 #include <Project64-core/Plugins/RSPPlugin.h>
 #include <Project64-core/Plugins/ControllerPlugin.h>

--- a/Source/Project64-core/N64System/EmulationThread.cpp
+++ b/Source/Project64-core/N64System/EmulationThread.cpp
@@ -11,7 +11,7 @@
 #include "stdafx.h"
 #include <Project64-core/N64System/N64Class.h>
 #include <Project64-core/Notification.h>
-#include <common/Util.h>
+#include <Common/Util.h>
 #include <Windows.h>
 #include <Objbase.h>
 

--- a/Source/Project64-core/N64System/Interpreter/InterpreterCPU.cpp
+++ b/Source/Project64-core/N64System/Interpreter/InterpreterCPU.cpp
@@ -16,7 +16,7 @@
 #include <Project64-core/N64System/Mips/OpcodeName.h>
 #include <Project64-core/N64System/Interpreter/InterpreterOps32.h>
 #include <Project64-core/Plugins/PluginClass.h>
-#include <Project64-core/Plugins/GFXplugin.h>
+#include <Project64-core/Plugins/GFXPlugin.h>
 #include <Project64-core/ExceptionHandler.h>
 
 R4300iOp::Func * CInterpreterCPU::m_R4300i_Opcode = NULL;

--- a/Source/Project64-core/N64System/Mips/Mempak.cpp
+++ b/Source/Project64-core/N64System/Mips/Mempak.cpp
@@ -10,7 +10,7 @@
 ****************************************************************************/
 #include "stdafx.h"
 #include "Mempak.H"
-#include <common/path.h>
+#include <Common/path.h>
 #include <Windows.h>
 
 static uint8_t Mempaks[4][0x8000];

--- a/Source/Project64-core/N64System/Mips/SystemEvents.h
+++ b/Source/Project64-core/N64System/Mips/SystemEvents.h
@@ -10,7 +10,7 @@
 ****************************************************************************/
 #pragma once
 
-#include <common/CriticalSection.h>
+#include <Common/CriticalSection.h>
 
 enum SystemEvent
 {

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -9,7 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
-#include "N64class.h"
+#include "N64Class.h"
 #include <Project64-core/3rdParty/zip.h>
 #include <Project64-core/N64System/Recompiler/x86CodeLog.h>
 #include <Project64-core/N64System/SystemGlobals.h>

--- a/Source/Project64-core/N64System/Recompiler/CodeBlock.h
+++ b/Source/Project64-core/N64System/Recompiler/CodeBlock.h
@@ -9,7 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #pragma once
-#include <common/md5.h>
+#include <Common/md5.h>
 #include "RecompilerOps.h"
 #include "ExitInfo.h"
 #include "CodeSection.h"

--- a/Source/Project64-core/N64System/SpeedLimiterClass.cpp
+++ b/Source/Project64-core/N64System/SpeedLimiterClass.cpp
@@ -10,7 +10,7 @@
 ****************************************************************************/
 #include "stdafx.h"
 #include "SpeedLimiterClass.h"
-#include <Common/util.h>
+#include <Common/Util.h>
 #include <Windows.h>
 #include <Mmsystem.h>
 

--- a/Source/Project64-core/N64System/SpeedLimiterClass.cpp
+++ b/Source/Project64-core/N64System/SpeedLimiterClass.cpp
@@ -10,7 +10,7 @@
 ****************************************************************************/
 #include "stdafx.h"
 #include "SpeedLimiterClass.h"
-#include <common/util.h>
+#include <Common/util.h>
 #include <Windows.h>
 #include <Mmsystem.h>
 

--- a/Source/Project64-core/Plugins/GFXPlugin.cpp
+++ b/Source/Project64-core/Plugins/GFXPlugin.cpp
@@ -13,7 +13,7 @@
 #include <Project64-core/N64System/N64RomClass.h>
 #include <Project64-core/N64System/Mips/MemoryClass.h>
 #include <Project64-core/N64System/Mips/RegisterClass.h>
-#include "GFXplugin.h"
+#include "GFXPlugin.h"
 #include <Windows.h>
 
 CGfxPlugin::CGfxPlugin() :

--- a/Source/Project64-core/Plugins/RSPPlugin.cpp
+++ b/Source/Project64-core/Plugins/RSPPlugin.cpp
@@ -13,7 +13,7 @@
 #include <Project64-core/N64System/Mips/MemoryClass.h>
 #include <Project64-core/N64System/Mips/RegisterClass.h>
 #include "RSPPlugin.h"
-#include "GFXplugin.h"
+#include "GFXPlugin.h"
 #include "AudioPlugin.h"
 #include <Windows.h>
 

--- a/Source/Project64-core/Settings/SettingType/SettingsType-Application.h
+++ b/Source/Project64-core/Settings/SettingType/SettingsType-Application.h
@@ -10,7 +10,7 @@
 ****************************************************************************/
 #pragma once
 
-#include <common/IniFileClass.h>
+#include <Common/IniFileClass.h>
 #include "SettingsType-Base.h"
 
 class CSettingTypeApplication :

--- a/Source/Project64-core/Settings/SettingType/SettingsType-ApplicationPath.cpp
+++ b/Source/Project64-core/Settings/SettingType/SettingsType-ApplicationPath.cpp
@@ -11,7 +11,7 @@
 #include "stdafx.h"
 #include "SettingsType-Application.h"
 #include "SettingsType-ApplicationPath.h"
-#include <common/path.h>
+#include <Common/path.h>
 
 CSettingTypeApplicationPath::CSettingTypeApplicationPath(const char * Section, const char * Name, SettingID DefaultSetting ) :
 	CSettingTypeApplication(Section,Name,DefaultSetting)

--- a/Source/Project64-core/Settings/SettingType/SettingsType-Cheats.h
+++ b/Source/Project64-core/Settings/SettingType/SettingsType-Cheats.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "SettingsType-Base.h"
-#include <common/IniFileClass.h>
+#include <Common/IniFileClass.h>
 
 class CSettingTypeCheats :
     public CSettingType

--- a/Source/Project64-core/Settings/SettingType/SettingsType-RomDatabase.h
+++ b/Source/Project64-core/Settings/SettingType/SettingsType-RomDatabase.h
@@ -10,7 +10,7 @@
 ****************************************************************************/
 #pragma once
 
-#include <common/IniFileClass.h>
+#include <Common/IniFileClass.h>
 #include "SettingsType-Base.h"
 
 class CSettingTypeRomDatabase :

--- a/Source/Project64-core/stdafx.h
+++ b/Source/Project64-core/stdafx.h
@@ -4,6 +4,6 @@
 
 #include "Multilanguage.h"
 #include "Notification.h"
-#include "version.h"
+#include "Version.h"
 #include "Settings/SettingsClass.h"
 #include "TraceModulesProject64.h"


### PR DESCRIPTION
Took me a lot of days, but I finally have a working Unix shell script for compiling Project64 on GNU.

All of the fatal "no such file" errors were fixed up until `#include <windows.h>`, at which point I stopped.

It's actually sort of a shame since I'm not really a fan of capitalizing file names unnecessarily--I do prefer `<common/stdtypes.h>` over `<Common/stdtypes.h>` and dislike the use of capital letters in compliant file names, but in this case we're just trying to avoid intervention with existing file names staged to the Git repository and simply try to fix all of those on the C source's end.