### PR TITLE
[core] Staticize the CPU loop's next instruction type updates per cycle.

### DIFF
--- a/Source/Project64-core/N64System/Interpreter/InterpreterCPU.cpp
+++ b/Source/Project64-core/N64System/Interpreter/InterpreterCPU.cpp
@@ -302,15 +302,17 @@ void CInterpreterCPU::ExecuteCPU()
             NextTimer -= CountPerOp;
 
             PROGRAM_COUNTER += 4;
-            switch (R4300iOp::m_NextInstruction)
+            const uint32_t next_instruction_type = R4300iOp::m_NextInstruction;
+            R4300iOp::m_NextInstruction *= 2; // DELAY_SLOT --> JUMP; NORMAL --> NORMAL
+            switch (next_instruction_type)
             {
             case NORMAL:
                 break;
             case DELAY_SLOT:
-                R4300iOp::m_NextInstruction = JUMP;
+             // R4300iOp::m_NextInstruction = JUMP;
                 break;
             case PERMLOOP_DO_DELAY:
-                R4300iOp::m_NextInstruction = PERMLOOP_DELAY_DONE;
+             // R4300iOp::m_NextInstruction = PERMLOOP_DELAY_DONE;
                 break;
             case JUMP:
             {

--- a/Source/Project64-core/N64System/N64Types.h
+++ b/Source/Project64-core/N64System/N64Types.h
@@ -72,6 +72,13 @@ enum SPECIAL_TIMERS
 	Timer_InheritParentInfo = -19, Timer_AddX86Code = -20,
 };
 
+/*
+ * To keep the optimized CPU interpreter loop working, always make sure:
+ *     1.  NORMAL              = 2 * NORMAL (i.e., NORMAL = 0)
+ *     2.  JUMP                = 2 * DELAY_SLOT
+ *     3.  PERMLOOP_DELAY_DONE = 2 * PERMLOOP_DO_DELAY
+ * This is so the loop can simply double the instruction mode every cycle.
+ */
 enum STEP_TYPE
 {
 	NORMAL = 0,
@@ -85,7 +92,7 @@ enum STEP_TYPE
 	LIKELY_DELAY_SLOT_DONE = 8,
 	END_BLOCK = 9,
 	PERMLOOP_DO_DELAY = 10,
-	PERMLOOP_DELAY_DONE = 11,
+	PERMLOOP_DELAY_DONE = 20,
 };
 
 union MIPS_WORD


### PR DESCRIPTION
By taking advantage of special patterns between the `enum` values, we can further optimize the running CPU loop from instead of having to do this:
```c
while (CPU_running) {
    ...

    switch (next_instruction_type) {
    case NORMAL:
        JMP end_of_loop;
    case DELAY_SLOT:
        MOV DWORD PTR m_NextInstruction, JUMP;
        JMP end_of_loop;
    case PERMLOOP_DO_DELAY:
        MOV DWORD PTR m_NextInstruction, PERMLOOP_DELAY_DONE;
        JMP end_of_loop;
}
```
... to being able to do this:
```c
while (CPU_running) {
    ...

    MOV edx, (next_instruction_type);
    ADD (next_instruction_type), (next_instruction_type); # or SHL by 1
    switch (%edx) {
    case NORMAL:
        continue; # JMP start_of_loop;
    case DELAY_SLOT:
        continue; # JMP start_of_loop;
    case PERMLOOP_DO_DELAY:
        continue; # JMP start_of_loop;
}
```
So this makes the code more static and, according to a preliminary benchmark result, faster.  This code could actually be slower due to the loss of the dynamic code behavior optimizing the NORMAL case (due to the extra two instructions), but I have a subsequent idea for greatly optimizing this switch statement overall in a future pull request to continue making it faster.  It depends on these changes being tried first.