### PR TITLE
[core] Explicitly ensure that the necessary includes are included.

### DIFF
--- a/Source/Common/md5.h
+++ b/Source/Common/md5.h
@@ -45,6 +45,7 @@ documentation and/or software.
 #include <functional>
 
 #include <stdio.h>
+#include <string.h>
 #include "path.h"
 
 struct MD5Digest

--- a/Source/Common/md5.h
+++ b/Source/Common/md5.h
@@ -43,6 +43,8 @@ documentation and/or software.
 
 #include <string>
 #include <functional>
+
+#include <stdio.h>
 #include "path.h"
 
 struct MD5Digest

--- a/Source/Project64-core/Logging.cpp
+++ b/Source/Project64-core/Logging.cpp
@@ -10,6 +10,8 @@
 ****************************************************************************/
 #include "stdafx.h"
 #include "Logging.h"
+
+#include <string.h>
 #include <Common/path.h>
 #include <Project64-core/N64System/SystemGlobals.h>
 #include <Project64-core/N64System/Mips/TranslateVaddr.h>

--- a/Source/Project64-core/Logging.cpp
+++ b/Source/Project64-core/Logging.cpp
@@ -12,6 +12,8 @@
 #include "Logging.h"
 
 #include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
 #include <Common/path.h>
 #include <Project64-core/N64System/SystemGlobals.h>
 #include <Project64-core/N64System/Mips/TranslateVaddr.h>

--- a/Source/Project64-core/Multilanguage/LanguageClass.cpp
+++ b/Source/Project64-core/Multilanguage/LanguageClass.cpp
@@ -9,6 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+#include <stdio.h>
 #include <Common/stdtypes.h>
 #include <Common/path.h>
 

--- a/Source/Project64-core/N64System/CheatClass.cpp
+++ b/Source/Project64-core/N64System/CheatClass.cpp
@@ -9,8 +9,9 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
-
+#include <string.h>
 #include "CheatClass.h"
+
 #include <Project64-core/Settings/SettingType/SettingsType-Cheats.h>
 #include <Project64-core/Plugins/GFXPlugin.h>
 #include <Project64-core/Plugins/AudioPlugin.h>

--- a/Source/Project64-core/N64System/Mips/OpcodeName.cpp
+++ b/Source/Project64-core/N64System/Mips/OpcodeName.cpp
@@ -9,6 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+#include <stdio.h>
 #include "OpCode.h"
 #include "RegisterClass.h"
 

--- a/Source/Project64-core/N64System/Mips/PifRam.cpp
+++ b/Source/Project64-core/N64System/Mips/PifRam.cpp
@@ -9,7 +9,9 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+#include <string.h>
 #include "PifRam.h"
+
 #include <Project64-core/N64System/SystemGlobals.h>
 #include <Project64-core/Plugins/ControllerPlugin.h>
 #include <Project64-core/N64System/Mips/RegisterClass.h>

--- a/Source/Project64-core/N64System/Mips/PifRam.cpp
+++ b/Source/Project64-core/N64System/Mips/PifRam.cpp
@@ -9,6 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+#include <stdio.h>
 #include <string.h>
 #include "PifRam.h"
 

--- a/Source/Project64-core/N64System/Mips/RegisterClass.cpp
+++ b/Source/Project64-core/N64System/Mips/RegisterClass.cpp
@@ -9,7 +9,9 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+#include <string.h>
 #include "RegisterClass.h"
+
 #include <Project64-core/N64System/N64Class.h>
 #include <Project64-core/N64System/SystemGlobals.h>
 #include <Project64-core/Logging.h>

--- a/Source/Project64-core/N64System/N64Types.h
+++ b/Source/Project64-core/N64System/N64Types.h
@@ -10,6 +10,8 @@
 ****************************************************************************/
 #pragma once
 
+#include <Common/stdtypes.h>
+
 enum PauseType
 {
 	PauseType_FromMenu,

--- a/Source/Project64-core/N64System/Recompiler/CodeBlock.cpp
+++ b/Source/Project64-core/N64System/Recompiler/CodeBlock.cpp
@@ -9,8 +9,10 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+#include <string.h>
 #include "CodeBlock.h"
 #include "x86CodeLog.h"
+
 #include <Project64-core/N64System/SystemGlobals.h>
 #include <Project64-core/N64System/Mips/TranslateVaddr.h>
 #include <Project64-core/N64System/N64Class.h>

--- a/Source/Project64-core/N64System/Recompiler/LoopAnalysis.cpp
+++ b/Source/Project64-core/N64System/Recompiler/LoopAnalysis.cpp
@@ -9,7 +9,9 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
+#include <string.h>
 #include "LoopAnalysis.h"
+
 #include <Project64-core/N64System/N64Types.h>
 #include <Project64-core/N64System/Recompiler/CodeBlock.h>
 #include <Project64-core/N64System/Recompiler/x86CodeLog.h>

--- a/Source/Project64-core/N64System/Recompiler/RecompilerOps.cpp
+++ b/Source/Project64-core/N64System/Recompiler/RecompilerOps.cpp
@@ -15,6 +15,8 @@
 #include <Project64-core/N64System/Interpreter/InterpreterOps.h>
 #include <Project64-core/N64System/Interpreter/InterpreterCPU.h>
 #include <Project64-core/N64System/N64Class.h>
+
+#include <stdio.h>
 #include "RecompilerClass.h"
 #include "RecompilerOps.h"
 #include "CodeSection.h"

--- a/Source/Project64-core/N64System/Recompiler/RegInfo.cpp
+++ b/Source/Project64-core/N64System/Recompiler/RegInfo.cpp
@@ -12,6 +12,7 @@
 #include <Project64-core/N64System/SystemGlobals.h>
 #include <Project64-core/N64System/N64Class.h>
 
+#include <stdio.h>
 #include <string.h>
 #include "RegInfo.h"
 #include "RecompilerClass.h"

--- a/Source/Project64-core/N64System/Recompiler/RegInfo.cpp
+++ b/Source/Project64-core/N64System/Recompiler/RegInfo.cpp
@@ -11,6 +11,8 @@
 #include "stdafx.h"
 #include <Project64-core/N64System/SystemGlobals.h>
 #include <Project64-core/N64System/N64Class.h>
+
+#include <string.h>
 #include "RegInfo.h"
 #include "RecompilerClass.h"
 #include "x86CodeLog.h"


### PR DESCRIPTION
Things which this PR doesn't fix...

* `_vsnwprintf`
* `_strnicmp`, other non-standard functions prefixed with `_`,
* SSE type names like `__m128` (which I guess `<windows.h>` was including for us)
* and sexually transmitted diseases like `std::memset`, even though `<string.h>` is included and probably wants me to `#include <string>`.  But I think later I will just delete the `std::`.