### PR TITLE
[core] replaced surviving occurrences of __int64

### DIFF
--- a/Source/Project64-core/N64System/FramePerSecondClass.h
+++ b/Source/Project64-core/N64System/FramePerSecondClass.h
@@ -31,6 +31,6 @@ private:
 
 	enum { NoOfFrames = 7 };
 
-	__int64 m_Frequency, m_Frames[NoOfFrames], m_LastFrame;
+    int64_t m_Frequency, m_Frames[NoOfFrames], m_LastFrame;
 	int m_CurrentFrame;
 };

--- a/Source/Project64-core/N64System/Mips/SystemTiming.cpp
+++ b/Source/Project64-core/N64System/Mips/SystemTiming.cpp
@@ -55,12 +55,12 @@ void CSystemTimer::SetTimer(TimerType Type, uint32_t Cycles, bool bRelative)
         }
         else
         {
-            m_TimerDetatils[Type].CyclesToTimer = (__int64)Cycles - (__int64)m_NextTimer;  //replace the new cycles
+            m_TimerDetatils[Type].CyclesToTimer = (int64_t)Cycles - (int64_t)m_NextTimer;  //replace the new cycles
         }
     }
     else
     {
-        m_TimerDetatils[Type].CyclesToTimer = (__int64)Cycles - (__int64)m_NextTimer;  //replace the new cycles
+        m_TimerDetatils[Type].CyclesToTimer = (int64_t)Cycles - (int64_t)m_NextTimer;  //replace the new cycles
     }
     FixTimers();
 }
@@ -76,7 +76,7 @@ uint32_t CSystemTimer::GetTimer(TimerType Type)
     {
         return 0;
     }
-    __int64 CyclesToTimer = m_TimerDetatils[Type].CyclesToTimer + m_NextTimer;
+    int64_t CyclesToTimer = m_TimerDetatils[Type].CyclesToTimer + m_NextTimer;
     if (CyclesToTimer < 0)
     {
         return 0;

--- a/Source/Project64-core/N64System/Mips/SystemTiming.h
+++ b/Source/Project64-core/N64System/Mips/SystemTiming.h
@@ -35,7 +35,7 @@ public:
     struct TIMER_DETAILS
     {
         bool    Active;
-        __int64 CyclesToTimer;
+        int64_t CyclesToTimer;
     };
 
 public:

--- a/Source/Project64-core/N64System/ProfilingClass.cpp
+++ b/Source/Project64-core/N64System/ProfilingClass.cpp
@@ -62,9 +62,9 @@ SPECIAL_TIMERS CProfiling::StopTimer() {
 	g_Notify->BreakPoint(__FILE__, __LINE__);
 #endif
 
-	__int64 StopTime  = ((unsigned __int64)HiValue << 32) + (unsigned __int64)LoValue;
-	__int64 StartTime = ((unsigned __int64)m_StartTimeHi << 32) + (unsigned __int64)m_StartTimeLo;
-	__int64 TimeTaken = StopTime - StartTime;
+    int64_t StopTime  = ((uint64_t)HiValue << 32) + (uint64_t)LoValue;
+    int64_t StartTime = ((uint64_t)m_StartTimeHi << 32) + (uint64_t)m_StartTimeLo;
+    int64_t TimeTaken = StopTime - StartTime;
 	
 	PROFILE_ENRTY Entry = m_Entries.find(m_CurrentTimerAddr);
 	if (Entry != m_Entries.end()) {
@@ -79,7 +79,7 @@ SPECIAL_TIMERS CProfiling::StopTimer() {
 }
 
 void CProfiling::ShowCPU_Usage() {
-	__int64 TotalTime, CPU = 0, Alist = 0, Dlist = 0, Idle = 0;
+    int64_t TotalTime, CPU = 0, Alist = 0, Dlist = 0, Idle = 0;
 	PROFILE_ENRTY Entry;
 	
 	if (m_CurrentDisplayCount > 0) { m_CurrentDisplayCount -= 1; return;  }
@@ -132,7 +132,7 @@ void CProfiling::GenerateLog() {
 		LogFileName = Log.FileName();
 
 		//Get the total time
-		__int64 TotalTime = 0;
+        int64_t TotalTime = 0;
 		for (PROFILE_ENRTY itemTime = m_Entries.begin(); itemTime != m_Entries.end(); itemTime++ ) {
 			TotalTime += itemTime->second;
 		}

--- a/Source/Project64-core/N64System/ProfilingClass.h
+++ b/Source/Project64-core/N64System/ProfilingClass.h
@@ -11,7 +11,7 @@
 #pragma once
 #include <Project64-core/N64System/N64Types.h>
 
-typedef std::map<SPECIAL_TIMERS, __int64 >     PROFILE_ENRTIES;
+typedef std::map<SPECIAL_TIMERS, int64_t >     PROFILE_ENRTIES;
 typedef PROFILE_ENRTIES::iterator     PROFILE_ENRTY;
 typedef PROFILE_ENRTIES::value_type   PROFILE_VALUE;
 


### PR DESCRIPTION
As the `__int64` type is compiler-specific and non-standard, we're better off using POSIX type names from `<stdint.h>` than any such MSVC-specific type like `__int64`.