### PR TITLE
[core] fixed undeclared SSE2 intrinsics on non-Win32

### DIFF
--- a/Source/Project64-core/N64System/N64Types.h
+++ b/Source/Project64-core/N64System/N64Types.h
@@ -12,6 +12,17 @@
 
 #include <Common/stdtypes.h>
 
+/*
+ * The limits of COP1 extend to native SSE2 register capabilities, but for
+ * now this is only being included to dodge the MSVC inline asm for x86.
+ *
+ * As better cross-platform methods of handling FP precision are implemented
+ * for non-Intel-architecture builds, this #include may become obsolete.
+ */
+#if defined(__i386) || defined(__x86_64__) || defined(_M_X64)
+#include <emmintrin.h>
+#endif
+
 enum PauseType
 {
 	PauseType_FromMenu,


### PR DESCRIPTION
I guess `<windows.h>` was including this for _WIN64 builds, because where I'm at it's not included.

When I first got Win64 builds of Project64 working in-game, I played it "safe" by using SSE2 instructions for handling COP1 floating-point rounding/precision details, in as close of a way as possible to the primitive x87 inline assembly code for MSVC to use with 32-bit builds.

In the future this should be replaced with confirmed, cross-platform floating-point code that optimizes to SSE (or NEON in the case of Android) just fine and evades the necessity for including this x86-specific header.  But for now this is to avoid the MSVC-specific inline asm that won't work for Linux builds.