### PR TITLE
[core] staticized Load32DPCommand

### DIFF
--- a/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
+++ b/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
@@ -4929,20 +4929,27 @@ void CMipsMemoryVM::Load32SPRegisters(void)
 
 void CMipsMemoryVM::Load32DPCommand(void)
 {
-    switch (m_MemLookupAddress & 0x1FFFFFFF)
+    uint32_t addr;
+    static const uint32_t* DPC_regs[] = {
+        &(g_Reg -> DPC_STATUS_REG),
+        &(g_Reg -> DPC_CLOCK_REG),
+        &(g_Reg -> DPC_BUFBUSY_REG),
+        &(g_Reg -> DPC_PIPEBUSY_REG),
+        &(g_Reg -> DPC_TMEM_REG),
+    };
+
+    addr  = m_MemLookupAddress & 0x1FFFFFFF;
+    addr -= 0x0410000C; /* virtual memory address of DPC_STATUS_REG */
+    if (addr & 0x00000003 || (addr >> 2) >= sizeof(DPC_regs) / sizeof(DPC_regs[0]))
     {
-    case 0x0410000C: m_MemLookupValue.UW[0] = g_Reg->DPC_STATUS_REG; break;
-    case 0x04100010: m_MemLookupValue.UW[0] = g_Reg->DPC_CLOCK_REG; break;
-    case 0x04100014: m_MemLookupValue.UW[0] = g_Reg->DPC_BUFBUSY_REG; break;
-    case 0x04100018: m_MemLookupValue.UW[0] = g_Reg->DPC_PIPEBUSY_REG; break;
-    case 0x0410001C: m_MemLookupValue.UW[0] = g_Reg->DPC_TMEM_REG; break;
-    default:
         m_MemLookupValue.UW[0] = 0;
         if (bHaveDebugger())
         {
             g_Notify->BreakPoint(__FILE__, __LINE__);
         }
+        return;
     }
+    m_MemLookupValue.UW[0] = *(DPC_regs[addr >> 2]);
 }
 
 void CMipsMemoryVM::Load32MIPSInterface(void)


### PR DESCRIPTION
I picked a more complicated example to highlight potential disadvantages of doing this sort of rewrite repeatedly throughout the whole memory unit, to make it known earlier on if we really want these changes to be merged or not.

Advantages:

* less repetition of the same code over and over (e.g., "m_LookupValue.UW[0] = ..." 6 times)
* fewer lines of code in the function body (although obviously not in the LUT initialiser)
* static, cleaner algorithm that executes the exact same way every time
* removes the performance complications of executing a jump instruction through a `switch`
* not only that but removes executing a jump instruction period

Disadvantages:

* technically harder to read... stuff like `(addr >> 2) >= sizeof(DPC_regs) / sizeof(DPC_regs[0])`
* somewhat harder to maintain for debugging... If you want to add special rules or unique operations per only one case of the switch then you would just add it to that case of the switch; here you can't do that directly because of the LUT approach removing the switch.
* Normally EXE size will be smaller, but in this case it grows a little because DPC_regs[] is a local variable and not a global variable.  I could make it a global variable...but then I need to run-time initialize DPC_regs[] as a non-const global variable in some other function that first allocates memory for the `g_Reg` class after the RCP memory map is first VirtualAlloc'd.

However in the meantime I have tested the change for crashes (based on purposely breaking the LUT) to verify that it works.  This can be proven... because, `(addr >> 2) >= sizeof(DPC_regs) / sizeof(DPC_regs[0])` means `addr >>= 2; if (addr >= 5)` because there are 5 elements in the LUT initializer.

Now for the purpose of example, let's say in the future you wanted to add DPC_CURRENT_REG.

You would change this:
```c
    static const uint32_t* DPC_regs[] = {
+       &(g_Reg -> DPC_CURRENT_REG), /* <-- newly added */
        &(g_Reg -> DPC_STATUS_REG),
        &(g_Reg -> DPC_CLOCK_REG),
        &(g_Reg -> DPC_BUFBUSY_REG),
        &(g_Reg -> DPC_PIPEBUSY_REG),
        &(g_Reg -> DPC_TMEM_REG),
    };
```
... and you would also update this:
```c
 // addr -= 0x0410000C; /* virtual memory address of DPC_STATUS_REG */
    addr -= 0x04100008; /* virtual memory address of DPC_CURRENT_REG */
```
The number of elements in DPC_regs[] would now be 6, it will still check (addr & 3) for 32-bit alignment, and it will still check (((addr - 0x04100008)>>3) < 6) to see if the LUT of supported DPC reg pointers can return a value to it.  Otherwise it jumps to what was the `default:` case of zilmar's original switch statement for the exception.