### PR TITLE
[core] fixed strtoul() for more compile errors

### DIFF
--- a/Source/Project64-core/N64System/CheatClass.cpp
+++ b/Source/Project64-core/N64System/CheatClass.cpp
@@ -40,7 +40,7 @@ bool CCheats::LoadCode(int CheatNo, const char * CheatString)
     {
         GAMESHARK_CODE CodeEntry;
 
-        CodeEntry.Command = std::strtoul(ReadPos, 0, 16);
+        CodeEntry.Command = strtoul(ReadPos, 0, 16);
         ReadPos = strchr(ReadPos, ' ');
         if (ReadPos == NULL) { break; }
         ReadPos += 1;
@@ -50,27 +50,27 @@ bool CCheats::LoadCode(int CheatNo, const char * CheatString)
             if (CheatNo < 0 || CheatNo > MaxCheats) { return false; }
             stdstr CheatExt = g_Settings->LoadStringIndex(Cheat_Extension, CheatNo);
             if (CheatExt.empty()) { return false; }
-            CodeEntry.Value = CheatExt[0] == '$' ? (uint16_t)std::strtoul(&CheatExt.c_str()[1], 0, 16) : (uint16_t)atol(CheatExt.c_str());
+            CodeEntry.Value = CheatExt[0] == '$' ? (uint16_t)strtoul(&CheatExt.c_str()[1], 0, 16) : (uint16_t)atol(CheatExt.c_str());
         }
         else if (strncmp(ReadPos, "??", 2) == 0)
         {
             if (CheatNo < 0 || CheatNo > MaxCheats) { return false; }
             stdstr CheatExt = g_Settings->LoadStringIndex(Cheat_Extension, CheatNo);
             if (CheatExt.empty()) { return false; }
-            CodeEntry.Value = (uint8_t)(std::strtoul(ReadPos, 0, 16));
-            CodeEntry.Value |= (CheatExt[0] == '$' ? (uint8_t)std::strtoul(&CheatExt.c_str()[1], 0, 16) : (uint8_t)atol(CheatExt.c_str())) << 16;
+            CodeEntry.Value = (uint8_t)(strtoul(ReadPos, 0, 16));
+            CodeEntry.Value |= (CheatExt[0] == '$' ? (uint8_t)strtoul(&CheatExt.c_str()[1], 0, 16) : (uint8_t)atol(CheatExt.c_str())) << 16;
         }
         else if (strncmp(&ReadPos[2], "??", 2) == 0)
         {
             if (CheatNo < 0 || CheatNo > MaxCheats) { return false; }
             stdstr CheatExt = g_Settings->LoadStringIndex(Cheat_Extension, CheatNo);
             if (CheatExt.empty()) { return false; }
-            CodeEntry.Value = (uint16_t)(std::strtoul(ReadPos, 0, 16) << 16);
-            CodeEntry.Value |= CheatExt[0] == '$' ? (uint8_t)std::strtoul(&CheatExt.c_str()[1], 0, 16) : (uint8_t)atol(CheatExt.c_str());
+            CodeEntry.Value = (uint16_t)(strtoul(ReadPos, 0, 16) << 16);
+            CodeEntry.Value |= CheatExt[0] == '$' ? (uint8_t)strtoul(&CheatExt.c_str()[1], 0, 16) : (uint8_t)atol(CheatExt.c_str());
         }
         else
         {
-            CodeEntry.Value = (uint16_t)std::strtoul(ReadPos, 0, 16);
+            CodeEntry.Value = (uint16_t)strtoul(ReadPos, 0, 16);
         }
         Code.push_back(CodeEntry);
 
@@ -264,7 +264,7 @@ bool CCheats::IsValid16BitCode(const char * CheatString)
     {
         GAMESHARK_CODE CodeEntry;
 
-        CodeEntry.Command = std::strtoul(ReadPos, 0, 16);
+        CodeEntry.Command = strtoul(ReadPos, 0, 16);
         ReadPos = strchr(ReadPos, ' ');
         if (ReadPos == NULL) { break; }
         ReadPos += 1;


### PR DESCRIPTION
fixes the following in the compile output when trying to build on *nix:
```
./N64System/CheatClass.cpp: In member function ‘bool CCheats::LoadCode(int, const char*)’:
./N64System/CheatClass.cpp:43:29: error: ‘strtoul’ is not a member of ‘std’
         CodeEntry.Command = std::strtoul(ReadPos, 0, 16);
                             ^
./N64System/CheatClass.cpp:43:29: note: suggested alternative:
In file included from /usr/lib/gcc/i686-linux-gnu/4.8/include/mm_malloc.h:27:0,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/xmmintrin.h:38,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/emmintrin.h:35,
                 from ./../Project64-core/N64System/N64Types.h:23,
                 from ./N64System/N64RomClass.h:13,
                 from ./N64System/CheatClass.h:12,
                 from ./N64System/CheatClass.cpp:13:
/usr/include/stdlib.h:187:26: note:   ‘strtoul’
 extern unsigned long int strtoul (const char *__restrict __nptr,
                          ^
./N64System/CheatClass.cpp:53:62: error: ‘strtoul’ is not a member of ‘std’
             CodeEntry.Value = CheatExt[0] == '$' ? (uint16_t)std::strtoul(&CheatExt.c_str()[1], 0, 16) : (uint16_t)atol(CheatExt.c_str());
                                                              ^
./N64System/CheatClass.cpp:53:62: note: suggested alternative:
In file included from /usr/lib/gcc/i686-linux-gnu/4.8/include/mm_malloc.h:27:0,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/xmmintrin.h:38,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/emmintrin.h:35,
                 from ./../Project64-core/N64System/N64Types.h:23,
                 from ./N64System/N64RomClass.h:13,
                 from ./N64System/CheatClass.h:12,
                 from ./N64System/CheatClass.cpp:13:
/usr/include/stdlib.h:187:26: note:   ‘strtoul’
 extern unsigned long int strtoul (const char *__restrict __nptr,
                          ^
./N64System/CheatClass.cpp:60:41: error: ‘strtoul’ is not a member of ‘std’
             CodeEntry.Value = (uint8_t)(std::strtoul(ReadPos, 0, 16));
                                         ^
./N64System/CheatClass.cpp:60:41: note: suggested alternative:
In file included from /usr/lib/gcc/i686-linux-gnu/4.8/include/mm_malloc.h:27:0,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/xmmintrin.h:38,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/emmintrin.h:35,
                 from ./../Project64-core/N64System/N64Types.h:23,
                 from ./N64System/N64RomClass.h:13,
                 from ./N64System/CheatClass.h:12,
                 from ./N64System/CheatClass.cpp:13:
/usr/include/stdlib.h:187:26: note:   ‘strtoul’
 extern unsigned long int strtoul (const char *__restrict __nptr,
                          ^
./N64System/CheatClass.cpp:61:63: error: ‘strtoul’ is not a member of ‘std’
             CodeEntry.Value |= (CheatExt[0] == '$' ? (uint8_t)std::strtoul(&CheatExt.c_str()[1], 0, 16) : (uint8_t)atol(CheatExt.c_str())) << 16;
                                                               ^
./N64System/CheatClass.cpp:61:63: note: suggested alternative:
In file included from /usr/lib/gcc/i686-linux-gnu/4.8/include/mm_malloc.h:27:0,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/xmmintrin.h:38,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/emmintrin.h:35,
                 from ./../Project64-core/N64System/N64Types.h:23,
                 from ./N64System/N64RomClass.h:13,
                 from ./N64System/CheatClass.h:12,
                 from ./N64System/CheatClass.cpp:13:
/usr/include/stdlib.h:187:26: note:   ‘strtoul’
 extern unsigned long int strtoul (const char *__restrict __nptr,
                          ^
./N64System/CheatClass.cpp:68:42: error: ‘strtoul’ is not a member of ‘std’
             CodeEntry.Value = (uint16_t)(std::strtoul(ReadPos, 0, 16) << 16);
                                          ^
./N64System/CheatClass.cpp:68:42: note: suggested alternative:
In file included from /usr/lib/gcc/i686-linux-gnu/4.8/include/mm_malloc.h:27:0,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/xmmintrin.h:38,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/emmintrin.h:35,
                 from ./../Project64-core/N64System/N64Types.h:23,
                 from ./N64System/N64RomClass.h:13,
                 from ./N64System/CheatClass.h:12,
                 from ./N64System/CheatClass.cpp:13:
/usr/include/stdlib.h:187:26: note:   ‘strtoul’
 extern unsigned long int strtoul (const char *__restrict __nptr,
                          ^
./N64System/CheatClass.cpp:69:62: error: ‘strtoul’ is not a member of ‘std’
             CodeEntry.Value |= CheatExt[0] == '$' ? (uint8_t)std::strtoul(&CheatExt.c_str()[1], 0, 16) : (uint8_t)atol(CheatExt.c_str());
                                                              ^
./N64System/CheatClass.cpp:69:62: note: suggested alternative:
In file included from /usr/lib/gcc/i686-linux-gnu/4.8/include/mm_malloc.h:27:0,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/xmmintrin.h:38,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/emmintrin.h:35,
                 from ./../Project64-core/N64System/N64Types.h:23,
                 from ./N64System/N64RomClass.h:13,
                 from ./N64System/CheatClass.h:12,
                 from ./N64System/CheatClass.cpp:13:
/usr/include/stdlib.h:187:26: note:   ‘strtoul’
 extern unsigned long int strtoul (const char *__restrict __nptr,
                          ^
./N64System/CheatClass.cpp:73:41: error: ‘strtoul’ is not a member of ‘std’
             CodeEntry.Value = (uint16_t)std::strtoul(ReadPos, 0, 16);
                                         ^
./N64System/CheatClass.cpp:73:41: note: suggested alternative:
In file included from /usr/lib/gcc/i686-linux-gnu/4.8/include/mm_malloc.h:27:0,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/xmmintrin.h:38,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/emmintrin.h:35,
                 from ./../Project64-core/N64System/N64Types.h:23,
                 from ./N64System/N64RomClass.h:13,
                 from ./N64System/CheatClass.h:12,
                 from ./N64System/CheatClass.cpp:13:
/usr/include/stdlib.h:187:26: note:   ‘strtoul’
 extern unsigned long int strtoul (const char *__restrict __nptr,
                          ^
./N64System/CheatClass.cpp: In static member function ‘static bool CCheats::IsValid16BitCode(const char*)’:
./N64System/CheatClass.cpp:267:29: error: ‘strtoul’ is not a member of ‘std’
         CodeEntry.Command = std::strtoul(ReadPos, 0, 16);
                             ^
./N64System/CheatClass.cpp:267:29: note: suggested alternative:
In file included from /usr/lib/gcc/i686-linux-gnu/4.8/include/mm_malloc.h:27:0,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/xmmintrin.h:38,
                 from /usr/lib/gcc/i686-linux-gnu/4.8/include/emmintrin.h:35,
                 from ./../Project64-core/N64System/N64Types.h:23,
                 from ./N64System/N64RomClass.h:13,
                 from ./N64System/CheatClass.h:12,
                 from ./N64System/CheatClass.cpp:13:
/usr/include/stdlib.h:187:26: note:   ‘strtoul’
 extern unsigned long int strtoul (const char *__restrict __nptr,
                          ^
```