### PR TITLE
[core] Don't demand Win32-specific features like __cdecl.

### DIFF
--- a/Source/Project64-core/Plugins/AudioPlugin.h
+++ b/Source/Project64-core/Plugins/AudioPlugin.h
@@ -20,9 +20,9 @@ public:
     void DacrateChanged(SYSTEM_TYPE Type);
     bool Initiate(CN64System * System, RenderWindow * Window);
 
-    void(__cdecl *AiLenChanged)(void);
-    uint32_t(__cdecl *AiReadLength)(void);
-    void(__cdecl *ProcessAList)(void);
+    void(CALL *AiLenChanged)(void);
+    uint32_t(CALL *AiReadLength)(void);
+    void(CALL *ProcessAList)(void);
 
 private:
     CAudioPlugin(const CAudioPlugin&);				// Disable copy constructor
@@ -37,8 +37,8 @@ private:
     bool LoadFunctions(void);
     void UnloadPluginDetails(void);
 
-    void(__cdecl *AiUpdate)		(int32_t Wait);
-    void(__cdecl *AiDacrateChanged)(SYSTEM_TYPE Type);
+    void(CALL *AiUpdate)        (int32_t Wait);
+    void(CALL *AiDacrateChanged)(SYSTEM_TYPE Type);
 
     // Function used in a thread for using audio
     static void AudioThread(CAudioPlugin * _this);

--- a/Source/Project64-core/Plugins/ControllerPlugin.h
+++ b/Source/Project64-core/Plugins/ControllerPlugin.h
@@ -102,12 +102,12 @@ public:
     void SetControl(CControl_Plugin const * const Plugin);
     void UpdateKeys(void);
 
-    void(__cdecl *WM_KeyDown)       (uint32_t wParam, uint32_t lParam);
-    void(__cdecl *WM_KeyUp)         (uint32_t wParam, uint32_t lParam);
-    void(__cdecl *RumbleCommand)	(int32_t Control, int32_t bRumble);
-    void(__cdecl *GetKeys)          (int32_t Control, BUTTONS * Keys);
-    void(__cdecl *ReadController)   (int32_t Control, uint8_t * Command);
-    void(__cdecl *ControllerCommand)(int32_t Control, uint8_t * Command);
+    void(CALL *WM_KeyDown)          (uint32_t wParam, uint32_t lParam);
+    void(CALL *WM_KeyUp)            (uint32_t wParam, uint32_t lParam);
+    void(CALL *RumbleCommand)       (int32_t Control, int32_t bRumble);
+    void(CALL *GetKeys)             (int32_t Control, BUTTONS * Keys);
+    void(CALL *ReadController)      (int32_t Control, uint8_t * Command);
+    void(CALL *ControllerCommand)   (int32_t Control, uint8_t * Command);
 
     inline CCONTROL const * Controller(int32_t control) { return m_Controllers[control]; }
     inline CONTROL * PluginControllers(void) { return m_PluginControllers; }

--- a/Source/Project64-core/Plugins/GFXPlugin.h
+++ b/Source/Project64-core/Plugins/GFXPlugin.h
@@ -18,34 +18,34 @@ class CGfxPlugin : public CPlugin
         /* Menu */
         /* Items should have an ID between 5101 and 5200 */
         void * hGFXMenu;
-        void(__cdecl *ProcessMenuItem) (int32_t ID);
+        void(CALL *ProcessMenuItem)(int32_t ID);
 
         /* Break Points */
         int32_t UseBPoints;
         char BPPanelName[20];
-        void(__cdecl *Add_BPoint)      (void);
-        void(__cdecl *CreateBPPanel)   (void * hDlg, void * rcBox);
-        void(__cdecl *HideBPPanel)     (void);
-        void(__cdecl *PaintBPPanel)    (void * ps);
-        void(__cdecl *ShowBPPanel)     (void);
-        void(__cdecl *RefreshBpoints)  (void * hList);
-        void(__cdecl *RemoveBpoint)    (void * hList, int32_t index);
-        void(__cdecl *RemoveAllBpoint) (void);
+        void(CALL *Add_BPoint)      (void);
+        void(CALL *CreateBPPanel)   (void * hDlg, void * rcBox);
+        void(CALL *HideBPPanel)     (void);
+        void(CALL *PaintBPPanel)    (void * ps);
+        void(CALL *ShowBPPanel)     (void);
+        void(CALL *RefreshBpoints)  (void * hList);
+        void(CALL *RemoveBpoint)    (void * hList, int32_t index);
+        void(CALL *RemoveAllBpoint) (void);
 
         /* GFX command Window */
-        void(__cdecl *Enter_GFX_Commands_Window) (void);
+        void(CALL *Enter_GFX_Commands_Window)(void);
     } GFXDEBUG_INFO;
 
     typedef struct
     {
-        void(__cdecl *UpdateBreakPoints)(void);
-        void(__cdecl *UpdateMemory)(void);
-        void(__cdecl *UpdateR4300iRegisters)(void);
-        void(__cdecl *Enter_BPoint_Window)(void);
-        void(__cdecl *Enter_R4300i_Commands_Window)(void);
-        void(__cdecl *Enter_R4300i_Register_Window)(void);
-        void(__cdecl *Enter_RSP_Commands_Window) (void);
-        void(__cdecl *Enter_Memory_Window)(void);
+        void(CALL *UpdateBreakPoints)(void);
+        void(CALL *UpdateMemory)(void);
+        void(CALL *UpdateR4300iRegisters)(void);
+        void(CALL *Enter_BPoint_Window)(void);
+        void(CALL *Enter_R4300i_Commands_Window)(void);
+        void(CALL *Enter_R4300i_Register_Window)(void);
+        void(CALL *Enter_RSP_Commands_Window)(void);
+        void(CALL *Enter_Memory_Window)(void);
     } DEBUG_INFO;
 
 public:
@@ -55,22 +55,22 @@ public:
     bool LoadFunctions(void);
     bool Initiate(CN64System * System, RenderWindow * Window);
 
-    void(__cdecl *CaptureScreen)      (const char *);
-    void(__cdecl *ChangeWindow)       (void);
-    void(__cdecl *DrawScreen)         (void);
-    void(__cdecl *DrawStatus)         (const char * lpString, int32_t RightAlign);
-    void(__cdecl *MoveScreen)         (int32_t xpos, int32_t ypos);
-    void(__cdecl *ProcessDList)       (void);
-    void(__cdecl *ProcessRDPList)     (void);
-    void(__cdecl *ShowCFB)			   (void);
-    void(__cdecl *UpdateScreen)       (void);
-    void(__cdecl *ViStatusChanged)    (void);
-    void(__cdecl *ViWidthChanged)     (void);
-    void(__cdecl *SoftReset)          (void);
+    void(CALL *CaptureScreen)   (const char *);
+    void(CALL *ChangeWindow)    (void);
+    void(CALL *DrawScreen)      (void);
+    void(CALL *DrawStatus)      (const char * lpString, int32_t RightAlign);
+    void(CALL *MoveScreen)      (int32_t xpos, int32_t ypos);
+    void(CALL *ProcessDList)    (void);
+    void(CALL *ProcessRDPList)  (void);
+    void(CALL *ShowCFB)         (void);
+    void(CALL *UpdateScreen)    (void);
+    void(CALL *ViStatusChanged) (void);
+    void(CALL *ViWidthChanged)  (void);
+    void(CALL *SoftReset)       (void);
 
     //Rom Browser
-    void *(__cdecl * GetRomBrowserMenu)  (void); /* Items should have an ID between 4101 and 4200 */
-    void(__cdecl * OnRomBrowserMenuItem) (int32_t MenuID, void * hParent, uint8_t * HEADER);
+    void *(CALL * GetRomBrowserMenu)(void); /* Items should have an ID between 4101 and 4200 */
+    void(CALL * OnRomBrowserMenuItem)(int32_t MenuID, void * hParent, uint8_t * HEADER);
 
     void * GetDebugMenu(void) { return m_GFXDebug.hGFXMenu; }
     void ProcessMenuItem(int32_t id);
@@ -87,12 +87,12 @@ private:
 
     GFXDEBUG_INFO m_GFXDebug;
 
-    void(__cdecl *GetDebugInfo)	(GFXDEBUG_INFO * GFXDebugInfo);
-    void(__cdecl *InitiateDebugger)(DEBUG_INFO DebugInfo);
+    void(CALL *GetDebugInfo)    (GFXDEBUG_INFO * GFXDebugInfo);
+    void(CALL *InitiateDebugger)(DEBUG_INFO DebugInfo);
 
-    static void __cdecl DummyDrawScreen(void) {}
-    static void __cdecl DummyMoveScreen(int32_t /*xpos*/, int32_t /*ypos*/) {}
-    static void __cdecl DummyViStatusChanged(void) {}
-    static void __cdecl DummyViWidthChanged(void) {}
-    static void __cdecl DummySoftReset(void) {}
+    static void CALL DummyDrawScreen(void) {}
+    static void CALL DummyMoveScreen(int32_t /*xpos*/, int32_t /*ypos*/) {}
+    static void CALL DummyViStatusChanged(void) {}
+    static void CALL DummyViWidthChanged(void) {}
+    static void CALL DummySoftReset(void) {}
 };

--- a/Source/Project64-core/Plugins/PluginBase.h
+++ b/Source/Project64-core/Plugins/PluginBase.h
@@ -14,15 +14,10 @@
 #include <Project64-core/TraceModulesProject64.h>
 #include "PluginClass.h"
 
-/*
- * Usage of Win32-specific `__cdecl' seems limited to just the plugin files.
- *
- * If we really do need specific call conventions, maybe have a #define CALL.
- * Otherwise, it'd be best to just delete this macro and all uses of __cdecl.
- */
-#ifndef _WIN32
-#define __cdecl
-/* dummy definition to pre-process this Win32-ism as blank garbage */
+#if defined(_WIN32)
+#define CALL        __cdecl
+#else
+#define CALL
 #endif
 
 class CPlugin :
@@ -44,8 +39,8 @@ public:
     void GameReset();
     void Close();
 
-    void(__cdecl *DllAbout)  (void * hWnd);
-    void(__cdecl *DllConfig) (void * hParent);
+    void(CALL *DllAbout)  (void * hWnd);
+    void(CALL *DllConfig) (void * hParent);
 
     static bool ValidPluginVersion(PLUGIN_INFO & PluginInfo);
 
@@ -57,13 +52,13 @@ protected:
     virtual PLUGIN_TYPE type() = 0;
     virtual bool LoadFunctions(void) = 0;
 
-    void(__cdecl *CloseDLL)		(void);
-    void(__cdecl *RomOpen)			(void);
-    void(__cdecl *RomClosed)	    (void);
-    void(__cdecl *PluginOpened)(void);
-    void(__cdecl *SetSettingInfo)	(PLUGIN_SETTINGS  *);
-    void(__cdecl *SetSettingInfo2)	(PLUGIN_SETTINGS2 *);
-    void(__cdecl *SetSettingInfo3)	(PLUGIN_SETTINGS3 *);
+    void(CALL *CloseDLL)            (void);
+    void(CALL *RomOpen)             (void);
+    void(CALL *RomClosed)           (void);
+    void(CALL *PluginOpened)(void);
+    void(CALL *SetSettingInfo)      (PLUGIN_SETTINGS  *);
+    void(CALL *SetSettingInfo2)     (PLUGIN_SETTINGS2 *);
+    void(CALL *SetSettingInfo3)     (PLUGIN_SETTINGS3 *);
 
     void * m_hDll;
     bool   m_Initialized, m_RomOpen;

--- a/Source/Project64-core/Plugins/PluginBase.h
+++ b/Source/Project64-core/Plugins/PluginBase.h
@@ -14,6 +14,17 @@
 #include <Project64-core/TraceModulesProject64.h>
 #include "PluginClass.h"
 
+/*
+ * Usage of Win32-specific `__cdecl' seems limited to just the plugin files.
+ *
+ * If we really do need specific call conventions, maybe have a #define CALL.
+ * Otherwise, it'd be best to just delete this macro and all uses of __cdecl.
+ */
+#ifndef _WIN32
+#define __cdecl
+/* dummy definition to pre-process this Win32-ism as blank garbage */
+#endif
+
 class CPlugin :
     private CDebugSettings
 {

--- a/Source/Project64-core/Plugins/RSPPlugin.h
+++ b/Source/Project64-core/Plugins/RSPPlugin.h
@@ -17,32 +17,33 @@ class CRSP_Plugin : public CPlugin
         /* Menu */
         /* Items should have an ID between 5001 and 5100 */
         void * hRSPMenu;
-        void(__cdecl *ProcessMenuItem) (int32_t ID);
+        void(CALL *ProcessMenuItem) (int32_t ID);
 
         /* Break Points */
         int32_t UseBPoints;
         char BPPanelName[20];
-        void(__cdecl *Add_BPoint)      (void);
-        void(__cdecl *CreateBPPanel)   (void);
-        void(__cdecl *HideBPPanel)     (void);
-        void(__cdecl *PaintBPPanel)    (void);
-        void(__cdecl *ShowBPPanel)     (void);
-        void(__cdecl *RefreshBpoints)  (void * hList);
-        void(__cdecl *RemoveBpoint)    (void * hList, int32_t index);
-        void(__cdecl *RemoveAllBpoint) (void);
+        void(CALL *Add_BPoint)      (void);
+        void(CALL *CreateBPPanel)   (void);
+        void(CALL *HideBPPanel)     (void);
+        void(CALL *PaintBPPanel)    (void);
+        void(CALL *ShowBPPanel)     (void);
+        void(CALL *RefreshBpoints)  (void * hList);
+        void(CALL *RemoveBpoint)    (void * hList, int32_t index);
+        void(CALL *RemoveAllBpoint) (void);
+
         /* RSP command Window */
-        void(__cdecl *Enter_RSP_Commands_Window) (void);
+        void(CALL *Enter_RSP_Commands_Window)(void);
     } RSPDEBUG_INFO;
 
     typedef struct {
-        void(__cdecl *UpdateBreakPoints)(void);
-        void(__cdecl *UpdateMemory)(void);
-        void(__cdecl *UpdateR4300iRegisters)(void);
-        void(__cdecl *Enter_BPoint_Window)(void);
-        void(__cdecl *Enter_R4300i_Commands_Window)(void);
-        void(__cdecl *Enter_R4300i_Register_Window)(void);
-        void(__cdecl *Enter_RSP_Commands_Window) (void);
-        void(__cdecl *Enter_Memory_Window)(void);
+        void(CALL *UpdateBreakPoints)(void);
+        void(CALL *UpdateMemory)(void);
+        void(CALL *UpdateR4300iRegisters)(void);
+        void(CALL *Enter_BPoint_Window)(void);
+        void(CALL *Enter_R4300i_Commands_Window)(void);
+        void(CALL *Enter_R4300i_Register_Window)(void);
+        void(CALL *Enter_RSP_Commands_Window)(void);
+        void(CALL *Enter_Memory_Window)(void);
     } DEBUG_INFO;
 
 public:
@@ -51,8 +52,8 @@ public:
 
     bool Initiate(CPlugins * Plugins, CN64System * System);
 
-    uint32_t(__cdecl *DoRspCycles)	(uint32_t);
-    void(__cdecl *EnableDebugging)(int32_t Enable);
+    uint32_t(CALL *DoRspCycles)(uint32_t);
+    void(CALL *EnableDebugging)(int32_t Enable);
 
     void * GetDebugMenu(void) { return m_RSPDebug.hRSPMenu; }
     void ProcessMenuItem(int32_t id);
@@ -71,6 +72,6 @@ private:
     RSPDEBUG_INFO m_RSPDebug;
     uint32_t      m_CycleCount;
 
-    void(__cdecl *GetDebugInfo)     (RSPDEBUG_INFO * GFXDebugInfo);
-    void(__cdecl *InitiateDebugger) (DEBUG_INFO DebugInfo);
+    void(CALL *GetDebugInfo)    (RSPDEBUG_INFO * GFXDebugInfo);
+    void(CALL *InitiateDebugger)(DEBUG_INFO DebugInfo);
 };


### PR DESCRIPTION
Right now, this is the most important commit to have for porting to Unix because without it, the compile output spams the same hundreds of error lines related to `__cdecl` being unknown, hundreds of times.  I swear that just by making this change the console output has lost tens of thousands of bytes, making it way easier for me to read the actual, unique remaining errors with compiling it outside Windows.