### PR TITLE
[Common] restored some needed header includes to md5.h

### DIFF
--- a/Source/Common/md5.h
+++ b/Source/Common/md5.h
@@ -41,6 +41,8 @@ documentation and/or software.
 
 #pragma once
 
+#include <string.h>
+#include <stdio.h>
 #include <string>
 #include <functional>
 #include "path.h"


### PR DESCRIPTION
They were recently deleted by mistake because the official, genuine `md5.h` does not have these.

However, the FILE*, sprintf, memcmp and memset code used throughout the header clearly is dependent on both of these includes.  Whoever created `md5.h` and decided not having to include those headers was a valid option was probably compiling primarily with `<windows.h>`, which does a lot of `#include <Eminem.h>` inside of it and randomly gets stuff you didn't know was included.