### PR TITLE
[Common] Have required sys/time.h POSIX inc for new time code.

### DIFF
--- a/Source/Common/Trace.cpp
+++ b/Source/Common/Trace.cpp
@@ -1,6 +1,8 @@
 #include "stdafx.h"
 #ifdef _WIN32
 #include <Windows.h>
+#else
+#include <sys/time.h>
 #endif
 
 typedef std::map<uint32_t, stdstr> ModuleNameMap;


### PR DESCRIPTION
In today's commits, zilmar has successfully added POSIX counterparts to the WIN32 timer code.

The only thing missing is the relevant include to detect the function as declared, existent.