### PR TITLE
[Common] some safety measures to guaranteeing __interface type

### DIFF
--- a/Source/Common/Trace.h
+++ b/Source/Common/Trace.h
@@ -11,8 +11,10 @@ enum TraceSeverity
     TraceVerbose = 0x00000006,
 };
 
-#ifndef _WIN32
-#define __interface struct
+#if defined(_WIN32)
+#include <objbase.h>
+#else
+#define __interface     struct
 #endif
 
 __interface CTraceModule

--- a/Source/Common/Trace.h
+++ b/Source/Common/Trace.h
@@ -11,7 +11,7 @@ enum TraceSeverity
     TraceVerbose = 0x00000006,
 };
 
-#ifndef _MSC_VER
+#ifndef _WIN32
 #define __interface struct
 #endif
 


### PR DESCRIPTION
So two changes/commits here:

* Have an additional #else for when it really is _WIN32, and guarantee that __interface is defined by including objbase.h if it is not already included.
* Think in terms of #ifndef _WIN32 instead of #ifndef _MSC_VER.

In-lining a #define for `__interface` is probably dangerous because you could do the #define yourself, then include windows.h-related things that do a define after your define and risk a collision.  The safest thing to do is to include the low-level source of where __interface is being declared, which is `objbase.h.`.

Additionally, MinGW and other non-MSVC compilers for Windows provide this header, so the toggle point should be based on whether _WIN32 is defined instead of whether _MSC_VER is defined.

None of this affects Linux portability...just a minor detail I saw in the commits and felt like doing.