### PR TITLE
[Common] fixed undeclared strcasecmp()

### DIFF
--- a/Source/Common/IniFileClass.h
+++ b/Source/Common/IniFileClass.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#ifndef _WIN32
+/* for POSIX method away from Win32 _stricmp--see "Platform.h" */
+#include <strings.h>
+#endif
 #include "Platform.h"
+
 #include "FileClass.h"
 #include "CriticalSection.h"
 #include "StdString.h"
@@ -10,7 +15,10 @@ class CIniFileBase
 {
     struct insensitive_compare
     {
-        bool operator() (const std::string & a, const std::string & b) const { return _stricmp(a.c_str(), b.c_str()) < 0; }
+        bool operator() (const std::string & a, const std::string & b) const
+        {
+            return _stricmp(a.c_str(), b.c_str()) < 0;
+        }
     };
 
     typedef std::string ansi_string;


### PR DESCRIPTION
fixes the following errors:
```
In file included from ./../../Common/stdafx.h:11:0,
                 from ./../../Common/FileClass.cpp:1:
./../../Common/IniFileClass.h: In member function ‘bool CIniFileBase::insensitive_compare::operator()(const string&, const string&) const’:
./../../Common/IniFileClass.h:13:116: error: ‘strcasecmp’ was not declared in this scope
         bool operator() (const std::string & a, const std::string & b) const { return _stricmp(a.c_str(), b.c_str()) < 0; }
                                                                                                                    ^
In file included from ./../../Common/stdafx.h:11:0,
                 from ./../../Common/IniFileClass.cpp:1:
./../../Common/IniFileClass.h: In member function ‘bool CIniFileBase::insensitive_compare::operator()(const string&, const string&) const’:
./../../Common/IniFileClass.h:13:116: error: ‘strcasecmp’ was not declared in this scope
         bool operator() (const std::string & a, const std::string & b) const { return _stricmp(a.c_str(), b.c_str()) < 0; }
                                                                                                                    ^
In file included from ./../../Common/stdafx.h:11:0,
                 from ./../../Common/LogClass.cpp:1:
./../../Common/IniFileClass.h: In member function ‘bool CIniFileBase::insensitive_compare::operator()(const string&, const string&) const’:
./../../Common/IniFileClass.h:13:116: error: ‘strcasecmp’ was not declared in this scope
         bool operator() (const std::string & a, const std::string & b) const { return _stricmp(a.c_str(), b.c_str()) < 0; }
                                                                                                                    ^
In file included from ./../../Common/stdafx.h:11:0,
                 from ./../../Common/md5.cpp:42:
./../../Common/IniFileClass.h: In member function ‘bool CIniFileBase::insensitive_compare::operator()(const string&, const string&) const’:
./../../Common/IniFileClass.h:13:116: error: ‘strcasecmp’ was not declared in this scope
         bool operator() (const std::string & a, const std::string & b) const { return _stricmp(a.c_str(), b.c_str()) < 0; }
                                                                                                                    ^
In file included from ./../../Common/stdafx.h:11:0,
                 from ./../../Common/MemTest.cpp:1:
./../../Common/IniFileClass.h: In member function ‘bool CIniFileBase::insensitive_compare::operator()(const string&, const string&) const’:
./../../Common/IniFileClass.h:13:116: error: ‘strcasecmp’ was not declared in this scope
         bool operator() (const std::string & a, const std::string & b) const { return _stricmp(a.c_str(), b.c_str()) < 0; }
                                                                                                                    ^
In file included from ./../../Common/stdafx.h:11:0,
                 from ./../../Common/StdString.cpp:1:
./../../Common/IniFileClass.h: In member function ‘bool CIniFileBase::insensitive_compare::operator()(const string&, const string&) const’:
./../../Common/IniFileClass.h:13:116: error: ‘strcasecmp’ was not declared in this scope
         bool operator() (const std::string & a, const std::string & b) const { return _stricmp(a.c_str(), b.c_str()) < 0; }
                                                                                                                    ^
In file included from ./../../Common/stdafx.h:11:0,
                 from ./../../Common/Trace.cpp:1:
./../../Common/IniFileClass.h: In member function ‘bool CIniFileBase::insensitive_compare::operator()(const string&, const string&) const’:
./../../Common/IniFileClass.h:13:116: error: ‘strcasecmp’ was not declared in this scope
         bool operator() (const std::string & a, const std::string & b) const { return _stricmp(a.c_str(), b.c_str()) < 0; }
                                                                                                                    ^
```