### PR TITLE
error:  `sprintf' was not declared in this scope.

### DIFF
--- a/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
+++ b/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
@@ -16,6 +16,8 @@
 #include <Project64-core/N64System/Recompiler/x86CodeLog.h>
 #include <Project64-core/N64System/Mips/OpcodeName.h>
 #include <Project64-core/ExceptionHandler.h>
+
+#include <stdio.h>
 #include <Common/MemoryManagement.h>
 
 uint32_t RegModValue;


### PR DESCRIPTION
```
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_LB(CX86Ops::x86Reg, uint32_t, bool)’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:616:47: error: ‘sprintf’ was not declared in this scope
         sprintf(VarName, "m_RDRAM + %X", PAddr);
                                               ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_LH(CX86Ops::x86Reg, uint32_t, bool)’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:687:47: error: ‘sprintf’ was not declared in this scope
         sprintf(VarName, "m_RDRAM + %X", PAddr);
                                               ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_LW(CX86Ops::x86Reg, uint32_t)’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:744:51: error: ‘sprintf’ was not declared in this scope
             sprintf(VarName, "m_RDRAM + %X", PAddr);
                                                   ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_SB_Const(uint8_t, uint32_t)’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:976:47: error: ‘sprintf’ was not declared in this scope
         sprintf(VarName, "m_RDRAM + %X", PAddr);
                                               ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_SB_Register(CX86Ops::x86Reg, uint32_t)’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:1027:47: error: ‘sprintf’ was not declared in this scope
         sprintf(VarName, "m_RDRAM + %X", PAddr);
                                               ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_SH_Const(uint16_t, uint32_t)’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:1075:47: error: ‘sprintf’ was not declared in this scope
         sprintf(VarName, "m_RDRAM + %X", PAddr);
                                               ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_SH_Register(CX86Ops::x86Reg, uint32_t)’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:1125:47: error: ‘sprintf’ was not declared in this scope
         sprintf(VarName, "m_RDRAM + %X", PAddr);
                                               ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_SW_Const(uint32_t, uint32_t)’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:1175:47: error: ‘sprintf’ was not declared in this scope
         sprintf(VarName, "m_RDRAM + %X", PAddr);
                                               ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_SW_Register(CX86Ops::x86Reg, uint32_t)’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:1648:47: error: ‘sprintf’ was not declared in this scope
         sprintf(VarName, "m_RDRAM + %X", PAddr);
                                               ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_LW(bool, bool)’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:2641:54: error: ‘sprintf’ was not declared in this scope
         sprintf(String, "%Xh", (int16_t)Opcode.offset);
                                                      ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_LWC1()’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:2773:46: error: ‘sprintf’ was not declared in this scope
         sprintf(Name, "_FPR_S[%d]", Opcode.ft);
                                              ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:2843:42: error: ‘sprintf’ was not declared in this scope
     sprintf(Name, "_FPR_S[%d]", Opcode.ft);
                                          ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_LDC1()’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:3118:46: error: ‘sprintf’ was not declared in this scope
         sprintf(Name, "_FPR_D[%d]", Opcode.ft);
                                              ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:3187:46: error: ‘sprintf’ was not declared in this scope
         sprintf(Name, "_FPR_S[%d]", Opcode.ft);
                                              ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:3203:46: error: ‘sprintf’ was not declared in this scope
         sprintf(Name, "_FPR_S[%d]", Opcode.ft);
                                              ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_SWC1()’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:3617:46: error: ‘sprintf’ was not declared in this scope
         sprintf(Name, "_FPR_S[%d]", Opcode.ft);
                                              ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:3665:46: error: ‘sprintf’ was not declared in this scope
         sprintf(Name, "_FPR_S[%d]", Opcode.ft);
                                              ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:3674:46: error: ‘sprintf’ was not declared in this scope
         sprintf(Name, "_FPR_S[%d]", Opcode.ft);
                                              ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘void CMipsMemoryVM::Compile_SDC1()’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:4096:46: error: ‘sprintf’ was not declared in this scope
         sprintf(Name, "_FPR_D[%d]", Opcode.ft);
                                              ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:4149:46: error: ‘sprintf’ was not declared in this scope
         sprintf(Name, "_FPR_D[%d]", Opcode.ft);
                                              ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:4165:46: error: ‘sprintf’ was not declared in this scope
         sprintf(Name, "_FPR_D[%d]", Opcode.ft);
                                              ^
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp: In member function ‘const char* CMipsMemoryVM::LabelName(uint32_t) const’:
./../../Project64-core/N64System/Mips/MemoryVirtualMem.cpp:4229:46: error: ‘sprintf’ was not declared in this scope
     sprintf(m_strLabelName, "0x%08X", Address);
                                              ^
```