### PR TITLE
[core] Fix more incompatible string concatenations in CPU messages.

### DIFF
--- a/Source/Project64-core/N64System/Mips/PifRam.cpp
+++ b/Source/Project64-core/N64System/Mips/PifRam.cpp
@@ -289,7 +289,10 @@ void CPifRam::SI_DMA_READ()
     {
         if (bShowPifRamErrors())
         {
-            g_Notify->DisplayError(__FUNCTION__ "\nSI_DRAM_ADDR_REG not in RDRam space");
+            g_Notify->DisplayError(
+                __FUNCTION__ \
+                "\nSI_DRAM_ADDR_REG not in RDRam space"
+            );
         }
         return;
     }

--- a/Source/Project64-core/N64System/Mips/PifRam.cpp
+++ b/Source/Project64-core/N64System/Mips/PifRam.cpp
@@ -289,10 +289,7 @@ void CPifRam::SI_DMA_READ()
     {
         if (bShowPifRamErrors())
         {
-            g_Notify->DisplayError(
-                __FUNCTION__ \
-                "\nSI_DRAM_ADDR_REG not in RDRam space"
-            );
+            g_Notify->DisplayError(stdstr_f("%s\nSI_DRAM_ADDR_REG not in RDRam space", __FUNCTION__).c_str());
         }
         return;
     }

--- a/Source/Project64-core/N64System/Recompiler/CodeBlock.cpp
+++ b/Source/Project64-core/N64System/Recompiler/CodeBlock.cpp
@@ -140,7 +140,7 @@ bool CCodeBlock::SetSection ( CCodeSection * & Section, CCodeSection * CurrentSe
             }
             if (SplitSection->m_EndPC >= TargetPC)
             {
-                CPU_Message(__FUNCTION__ ": Split Section: %d with section: %d",SplitSection->m_SectionID, Section->m_SectionID);
+                CPU_Message("%s: Split Section: %d with section: %d", __FUNCTION__, SplitSection->m_SectionID, Section->m_SectionID);
                 CCodeSection * BaseSection = Section;
                 BaseSection->m_EndPC = SplitSection->m_EndPC;
                 BaseSection->SetJumpAddress(SplitSection->m_Jump.JumpPC, SplitSection->m_Jump.TargetPC,SplitSection->m_Jump.PermLoop);
@@ -232,7 +232,7 @@ bool CCodeBlock::CreateBlockLinkage ( CCodeSection * EnterSection )
 
         if (EndBlock)
         {
-            CPU_Message(__FUNCTION__ ": End Block");
+            CPU_Message("%s: End Block", __FUNCTION__);
             CurrentSection->m_EndSection = true;
             // find other sections that need compiling
             break;
@@ -240,7 +240,7 @@ bool CCodeBlock::CreateBlockLinkage ( CCodeSection * EnterSection )
 
         if (ContinuePC != (uint32_t)-1)
         {
-            CPU_Message(__FUNCTION__ ": SetContinueAddress TestPC = %X ContinuePC = %X",TestPC,ContinuePC);
+            CPU_Message("%s: SetContinueAddress TestPC = %X ContinuePC = %X", __FUNCTION__,TestPC,ContinuePC);
             CurrentSection->SetContinueAddress(TestPC, ContinuePC);
             if (!SetSection(CurrentSection->m_ContinueSection, CurrentSection, ContinuePC,true,TestPC))
             {
@@ -250,7 +250,7 @@ bool CCodeBlock::CreateBlockLinkage ( CCodeSection * EnterSection )
 
         if (LikelyBranch)
         {
-            CPU_Message(__FUNCTION__ ": SetJumpAddress TestPC = %X Target = %X",TestPC,TestPC + 4);
+            CPU_Message("%s: SetJumpAddress TestPC = %X Target = %X", __FUNCTION__,TestPC,TestPC + 4);
             CurrentSection->SetJumpAddress(TestPC, TestPC + 4,false);
             if (SetSection(CurrentSection->m_JumpSection, CurrentSection, TestPC + 4,false,TestPC))
             {
@@ -273,7 +273,7 @@ bool CCodeBlock::CreateBlockLinkage ( CCodeSection * EnterSection )
                 JumpSection->m_EndPC = TestPC + 4;
                 if (BranchEndBlock)
                 {
-                    CPU_Message(__FUNCTION__ ": Jump End Block");
+                    CPU_Message("%s: Jump End Block", __FUNCTION__);
                     JumpSection->m_EndSection = true;
                     TargetPC = (uint32_t)-1;
                 }
@@ -291,7 +291,7 @@ bool CCodeBlock::CreateBlockLinkage ( CCodeSection * EnterSection )
         }
         else if (TargetPC != ((uint32_t)-1))
         {
-            CPU_Message(__FUNCTION__ ": SetJumpAddress TestPC = %X Target = %X",TestPC,TargetPC);
+            CPU_Message("%s: SetJumpAddress TestPC = %X Target = %X", __FUNCTION__,TestPC,TargetPC);
             CurrentSection->SetJumpAddress(TestPC, TargetPC,PermLoop);
             if (PermLoop || !SetSection(CurrentSection->m_JumpSection, CurrentSection, TargetPC,true,TestPC))
             {

--- a/Source/Project64-core/N64System/Recompiler/LoopAnalysis.cpp
+++ b/Source/Project64-core/N64System/Recompiler/LoopAnalysis.cpp
@@ -62,7 +62,7 @@ bool LoopAnalysis::SetupRegisterForLoop()
     {
         return false;
     }
-    CPU_Message(__FUNCTION__ ": Section ID: %d Test: %X", m_EnterSection->m_SectionID, m_Test);
+    CPU_Message("%s: Section ID: %d Test: %X", __FUNCTION__, m_EnterSection->m_SectionID, m_Test);
     if (!CheckLoopRegisterUsage(m_EnterSection))
     {
         return false;
@@ -83,7 +83,7 @@ bool LoopAnalysis::SetupEnterSection(CCodeSection * Section, bool & bChanged, bo
     bSkipedSection = false;
     if (Section->m_ParentSection.empty()) { g_Notify->BreakPoint(__FILE__, __LINE__); return true; }
 
-    CPU_Message(__FUNCTION__ ": Block EnterPC: %X Section ID %d Test: %X Section Test: %X CompiledLocation: %X", m_BlockInfo->VAddrEnter(), Section->m_SectionID, m_Test, Section->m_Test, Section->m_CompiledLocation);
+    CPU_Message("%s: Block EnterPC: %X Section ID %d Test: %X Section Test: %X CompiledLocation: %X", __FUNCTION__, m_BlockInfo->VAddrEnter(), Section->m_SectionID, m_Test, Section->m_Test, Section->m_CompiledLocation);
 
     bool bFirstParent = true;
     CRegInfo RegEnter;
@@ -91,10 +91,10 @@ bool LoopAnalysis::SetupEnterSection(CCodeSection * Section, bool & bChanged, bo
     {
         CCodeSection * Parent = *iter;
 
-        CPU_Message(__FUNCTION__ ": Parent Section ID %d Test: %X Section Test: %X CompiledLocation: %X", Parent->m_SectionID, m_Test, Parent->m_Test, Parent->m_CompiledLocation);
+        CPU_Message("%s: Parent Section ID %d Test: %X Section Test: %X CompiledLocation: %X", __FUNCTION__, Parent->m_SectionID, m_Test, Parent->m_Test, Parent->m_CompiledLocation);
         if (Parent->m_Test != m_Test && (m_EnterSection != Section || Parent->m_CompiledLocation == NULL) && Parent->m_InLoop)
         {
-            CPU_Message(__FUNCTION__ ": Ignore Parent Section ID %d Test: %X  Section Test: %X CompiledLocation: %X", Parent->m_SectionID, m_Test, Parent->m_Test, Parent->m_CompiledLocation);
+            CPU_Message("%s: Ignore Parent Section ID %d Test: %X  Section Test: %X CompiledLocation: %X", __FUNCTION__, Parent->m_SectionID, m_Test, Parent->m_Test, Parent->m_CompiledLocation);
             bSkipedSection = true;
             continue;
         }
@@ -153,7 +153,7 @@ bool LoopAnalysis::CheckLoopRegisterUsage(CCodeSection * Section)
     if (Section == NULL) { return true; }
     if (!Section->m_InLoop) { return true; }
 
-    CPU_Message(__FUNCTION__ ": Section %d Block PC: 0x%X", Section->m_SectionID, m_BlockInfo->VAddrEnter());
+    CPU_Message("%s: Section %d Block PC: 0x%X", __FUNCTION__, Section->m_SectionID, m_BlockInfo->VAddrEnter());
 
     bool bChanged = false, bSkipedSection = false;
     if (Section == m_EnterSection && Section->m_Test == m_Test)
@@ -169,7 +169,7 @@ bool LoopAnalysis::CheckLoopRegisterUsage(CCodeSection * Section)
         return true;
     }
 
-    CPU_Message(__FUNCTION__ ": Set Section %d test to %X from %X", Section->m_SectionID, m_Test, Section->m_Test);
+    CPU_Message("%s: Set Section %d test to %X from %X", __FUNCTION__, Section->m_SectionID, m_Test, Section->m_Test);
     Section->m_Test = m_Test;
     m_PC = Section->m_EnterPC;
 
@@ -817,13 +817,13 @@ bool LoopAnalysis::SyncRegState(CRegInfo & RegSet, const CRegInfo& SyncReg)
     {
         if (RegSet.GetMipsRegState(x) != SyncReg.GetMipsRegState(x))
         {
-            CPU_Message(__FUNCTION__ ": Clear state %s RegEnter State: %X Jump Reg State: %X", CRegName::GPR[x], RegSet.GetMipsRegState(x), SyncReg.GetMipsRegState(x));
+            CPU_Message("%s: Clear state %s RegEnter State: %X Jump Reg State: %X", __FUNCTION__, CRegName::GPR[x], RegSet.GetMipsRegState(x), SyncReg.GetMipsRegState(x));
             RegSet.SetMipsRegState(x, CRegInfo::STATE_MODIFIED);
             bChanged = true;
         }
         else if (RegSet.IsConst(x) && RegSet.Is32Bit(x) && RegSet.GetMipsRegLo(x) != SyncReg.GetMipsRegLo(x))
         {
-            CPU_Message(__FUNCTION__ ": Clear state %s RegEnter State: %X Jump Reg State: %X", CRegName::GPR[x], RegSet.GetMipsRegState(x), SyncReg.GetMipsRegState(x));
+            CPU_Message("%s: Clear state %s RegEnter State: %X Jump Reg State: %X", __FUNCTION__, CRegName::GPR[x], RegSet.GetMipsRegState(x), SyncReg.GetMipsRegState(x));
             RegSet.SetMipsRegState(x, CRegInfo::STATE_MODIFIED);
             bChanged = true;
         }

--- a/Source/Project64-core/N64System/Recompiler/RegInfo.cpp
+++ b/Source/Project64-core/N64System/Recompiler/RegInfo.cpp
@@ -1116,7 +1116,10 @@ void CRegInfo::UnMap_FPR(int32_t Reg, bool WriteBackValue)
                 fpuStoreQwordFromX86Reg(&StackTopPos(), TempReg, true);
                 break;
             default:
-                if (bHaveDebugger()) { g_Notify->DisplayError(stdstr_f(__FUNCTION__ "\nUnknown format to load %d", m_x86fpu_State[StackTopPos()]).c_str()); }
+                if (bHaveDebugger())
+                {
+                    g_Notify->DisplayError(stdstr_f("%s\nUnknown format to load %d", __FUNCTION__, m_x86fpu_State[StackTopPos()]).c_str());
+                }
             }
             SetX86Protected(TempReg, false);
             FpuRoundingModel(RegPos) = RoundDefault;
@@ -1438,7 +1441,7 @@ void CRegInfo::WriteBackRegisters()
             SetMipsRegState(count, CRegInfo::STATE_UNKNOWN);
             break;
         default:
-            CPU_Message(__FUNCTION__ ": Unknown State: %d reg %d (%s)", GetMipsRegState(count), count, CRegName::GPR[count]);
+            CPU_Message("%s: Unknown State: %d reg %d (%s)", __FUNCTION__, GetMipsRegState(count), count, CRegName::GPR[count]);
             g_Notify->BreakPoint(__FILE__, __LINE__);
         }
     }

--- a/Source/Project64-core/N64System/Recompiler/RegInfo.cpp
+++ b/Source/Project64-core/N64System/Recompiler/RegInfo.cpp
@@ -1143,7 +1143,14 @@ void CRegInfo::UnMap_GPR(uint32_t Reg, bool WriteBackValue)
 {
     if (Reg == 0)
     {
-        if (bHaveDebugger()) { g_Notify->DisplayError(__FUNCTION__ "\n\nWhy are you trying to unmap reg 0"); }
+        if (bHaveDebugger())
+        {
+            g_Notify->DisplayError(
+                __FUNCTION__ \
+                "\n\n" \
+                "Why are you trying to unmap reg 0"
+            );
+        }
         return;
     }
 

--- a/Source/Project64-core/N64System/Recompiler/RegInfo.cpp
+++ b/Source/Project64-core/N64System/Recompiler/RegInfo.cpp
@@ -1145,11 +1145,7 @@ void CRegInfo::UnMap_GPR(uint32_t Reg, bool WriteBackValue)
     {
         if (bHaveDebugger())
         {
-            g_Notify->DisplayError(
-                __FUNCTION__ \
-                "\n\n" \
-                "Why are you trying to unmap reg 0"
-            );
+            g_Notify->DisplayError(stdstr_f("%s\n\nWhy are you trying to unmap reg 0", __FUNCTION__).c_str());
         }
         return;
     }


### PR DESCRIPTION
Mostly just following up after the commit here that fixed some of these already:
https://github.com/project64/project64/commit/58f3502bd5b9fe339c844d687651f80a2eede4ce

My approach is the same for the first commit but fixes leftover things outside of just stdstr_f.

For the second commit, I came up with my own fix for the incompatible string concatenation against `__FUNCTION__`, because those were inside DisplayError which doesn't recognize the sprintf `%s` specifier project64 has started using for those.