### PR TITLE
[core] std::memcpy() undeclared, so use memcpy().

### DIFF
--- a/Source/Project64-core/N64System/Mips/PifRam.cpp
+++ b/Source/Project64-core/N64System/Mips/PifRam.cpp
@@ -182,13 +182,13 @@ void CPifRam::PifRamWrite()
             {
                 ResponseValue = (ResponseValue << 8) | ((Response[(z - 1) * 2] << 4) + Response[(z - 1) * 2 + 1]);
             }
-            std::memcpy(&m_PifRam[48], &ResponseValue, sizeof(uint64_t));
+            memcpy(&m_PifRam[48], &ResponseValue, sizeof(uint64_t));
             ResponseValue = 0;
             for (int z = 7; z > 0; z--)
             {
                 ResponseValue = (ResponseValue << 8) | ((Response[((z + 8) - 1) * 2] << 4) + Response[((z + 8) - 1) * 2 + 1]);
             }
-            std::memcpy(&m_PifRam[56], &ResponseValue, sizeof(uint64_t));
+            memcpy(&m_PifRam[56], &ResponseValue, sizeof(uint64_t));
         }
         break;
         case 0x08:
@@ -618,7 +618,7 @@ void CPifRam::ReadControllerCommand(int Control, uint8_t * Command) {
             }
 
             const uint32_t buttons = g_BaseSystem->GetButtons(Control);
-            std::memcpy(&Command[3], &buttons, sizeof(uint32_t));
+            memcpy(&Command[3], &buttons, sizeof(uint32_t));
         }
         break;
     case 0x02: //read from controller pack


### PR DESCRIPTION
This fixes 3 error messages total (plus extra garbage paragraphs attached to each).

It's the same PR as the one I did a while back to remove all the STD's, except evidently I missed a few.  (Either that or there was a fatal error blocking their usage at the time.)  Since `<string.h>` is included now in `"stdafx.h"` it would make more sense to just take advantage of that, rather than double up on the includes by stacking a `#include <string>` in there as well.