### PR TITLE
Glide64 change default plugin

### DIFF
--- a/Source/Project64-core/Settings/SettingsClass.cpp
+++ b/Source/Project64-core/Settings/SettingsClass.cpp
@@ -343,7 +343,7 @@ void CSettings::AddHowToHandleSetting()
 
     //Plugin
     AddHandler(Plugin_RSP_Current, new CSettingTypeApplication("Plugin", "RSP Dll", "RSP\\RSP 1.7.dll"));
-    AddHandler(Plugin_GFX_Current, new CSettingTypeApplication("Plugin", "Graphics Dll", "GFX\\Jabo_Direct3D8.dll"));
+    AddHandler(Plugin_GFX_Current, new CSettingTypeApplication("Plugin", "Graphics Dll", "GFX\\PJ64Glide64.dll"));
     AddHandler(Plugin_AUDIO_Current, new CSettingTypeApplication("Plugin", "Audio Dll", "Audio\\Jabo_Dsound.dll"));
     AddHandler(Plugin_CONT_Current, new CSettingTypeApplication("Plugin", "Controller Dll", "Input\\PJ64_NRage.dll"));
 


### PR DESCRIPTION
I'm splitting the old PR into two different PRs. One (this one) to switch the default plugin -- and another, far more extensive and painful, to update the RDB to reflect Glide64's much higher compatiblity. (And unique bugs of its own.)
