### PR TITLE
Fix Castlevania: LoD missing dissolves.

### DIFF
--- a/Config/Glide64.rdb
+++ b/Config/Glide64.rdb
@@ -263,12 +263,14 @@ Good Name=Akumajou Dracula Mokushiroku - Real Action Adventure (J)
 Internal Name=DRACULA MOKUSHIROKU
 depthmode=0
 fb_clear=1
+old_style_adither=1
 
 [A5533106-B9F25E5B-C:4A]
 Good Name=Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (J)
 Internal Name=DRACULA MOKUSHIROKU2
 depthmode=0
 fb_clear=1
+old_style_adither=1
 
 [D9EDD54D-6BB8E274-C:50]
 Good Name=All-Star Baseball '99 (E)

--- a/Config/Glide64.rdb
+++ b/Config/Glide64.rdb
@@ -633,12 +633,14 @@ Good Name=Castlevania - Legacy of Darkness (E) (M3)
 Internal Name=CASTLEVANIA2
 depthmode=0
 fb_clear=1
+old_style_adither=1
 
 [1CC06338-87388926-C:45]
 Good Name=Castlevania - Legacy of Darkness (U)
 Internal Name=CASTLEVANIA2
 depthmode=0
 fb_clear=1
+old_style_adither=1
 
 [DCCF2134-9DD63578-C:50]
 Good Name=Centre Court Tennis (E)


### PR DESCRIPTION
For whatever reason, while old_style_adither was enabled for Castlevania, it was not enabled for the sequel. I'm not aware of any negative effects.

With hack:
![glide64_castlevania2_01](https://cloud.githubusercontent.com/assets/10704701/12377376/c3c56348-bd67-11e5-85e5-e96c2a3896ca.png)

Without hack:
![glide64_castlevania2_02](https://cloud.githubusercontent.com/assets/10704701/12377378/cefa4300-bd67-11e5-8d9d-a89940345fdc.png)
