### PR TITLE
Change Mario 64 filtering to automatic.

### DIFF
--- a/Config/Glide64.rdb
+++ b/Config/Glide64.rdb
@@ -3162,7 +3162,7 @@ Good Name=Super Mario 64 (E) (M3)
 Internal Name=SUPER MARIO 64
 depth_bias=32
 depthmode=1
-filtering=1
+filtering=0
 lodmode=1
 
 [4EAA3D0E-74757C24-C:4A]
@@ -3170,7 +3170,7 @@ Good Name=Super Mario 64 (J)
 Internal Name=SUPER MARIO 64
 depth_bias=32
 depthmode=1
-filtering=1
+filtering=0
 lodmode=1
 
 [635A2BFF-8B022326-C:45]
@@ -3178,7 +3178,7 @@ Good Name=Super Mario 64 (U)
 Internal Name=SUPER MARIO 64
 depth_bias=32
 depthmode=1
-filtering=1
+filtering=0
 lodmode=1
 
 [D6FBA4A8-6326AA2C-C:4A]
@@ -3186,7 +3186,7 @@ Good Name=Super Mario 64 - Shindou Edition (J)
 Internal Name=SUPERMARIO64
 depth_bias=32
 depthmode=1
-filtering=1
+filtering=0
 lodmode=1
 
 [66572080-28E348E1-C:4A]


### PR DESCRIPTION
I have no idea why it was changed to Force Bilinear to begin with. None of Glide64's texture filtering options are fully accurate, but Automatic is closest. The text is most certainly not supposed to be filtered the way it is currently.

Angrylion's:
![nsme0000](https://cloud.githubusercontent.com/assets/10704701/12377489/d2a94420-bd6b-11e5-96c0-15c32c00e9e1.jpg)

Bilinear:
![glide64_super_mario_64_01](https://cloud.githubusercontent.com/assets/10704701/12377491/def47bdc-bd6b-11e5-8e5e-9e70df9f6a62.png)

Automatic:
![glide64_super_mario_64_02](https://cloud.githubusercontent.com/assets/10704701/12377492/e56db190-bd6b-11e5-84fa-662f9ebf36d5.png)
