### PR TITLE
Retail 64DD IPL ROM support (boots)

### DIFF
--- a/Source/Project64-core/N64System/Mips/Dma.cpp
+++ b/Source/Project64-core/N64System/Mips/Dma.cpp
@@ -34,6 +34,7 @@ void CDMA::OnFirstDMA()
     {
     case CIC_NUS_6101:  offset = +0x0318; break;
     case CIC_NUS_5167:  offset = +0x0318; break;
+    case CIC_NUS_8303:  offset = +0x0318; break;
     case CIC_UNKNOWN:
     case CIC_NUS_6102:  offset = +0x0318; break;
     case CIC_NUS_6103:  offset = +0x0318; break;
@@ -75,7 +76,7 @@ void CDMA::PI_DMA_READ()
         uint8_t * ROM = g_Rom->GetRomAddress();
         uint8_t * RDRAM = g_MMU->Rdram();
 
-		ProtectMemory(ROM, g_Rom->GetRomSize(), MEM_READWRITE);
+        ProtectMemory(ROM, g_Rom->GetRomSize(), MEM_READWRITE);
         g_Reg->PI_CART_ADDR_REG -= 0x10000000;
         if (g_Reg->PI_CART_ADDR_REG + PI_RD_LEN_REG < g_Rom->GetRomSize())
         {
@@ -105,7 +106,7 @@ void CDMA::PI_DMA_READ()
             g_Recompiler->ClearRecompCode_Phys(g_Reg->PI_DRAM_ADDR_REG, g_Reg->PI_WR_LEN_REG, CRecompiler::Remove_DMA);
         }
 
-		ProtectMemory(ROM, g_Rom->GetRomSize(), MEM_READONLY);
+        ProtectMemory(ROM, g_Rom->GetRomSize(), MEM_READONLY);
 
         g_Reg->PI_STATUS_REG &= ~PI_STATUS_DMA_BUSY;
         g_Reg->MI_INTR_REG |= MI_INTR_PI;
@@ -178,6 +179,75 @@ void CDMA::PI_DMA_WRITE()
         g_Reg->PI_STATUS_REG &= ~PI_STATUS_DMA_BUSY;
         g_Reg->MI_INTR_REG |= MI_INTR_PI;
         g_Reg->CheckInterrupts();
+        return;
+    }
+
+    //64DD IPL ROM
+    if (g_Reg->PI_CART_ADDR_REG >= 0x06000000 && g_Reg->PI_CART_ADDR_REG <= 0x063FFFFF)
+    {
+        uint32_t i;
+
+#ifdef legacycode
+#ifdef ROM_IN_MAPSPACE
+        if (WrittenToRom)
+        {
+            uint32_t OldProtect;
+            VirtualProtect(ROM, m_RomFileSize, PAGE_READONLY, &OldProtect);
+        }
+#endif
+#endif
+
+        uint8_t * ROM = g_DDRom->GetRomAddress();
+        uint8_t * RDRAM = g_MMU->Rdram();
+        g_Reg->PI_CART_ADDR_REG -= 0x06000000;
+        if (g_Reg->PI_CART_ADDR_REG + PI_WR_LEN_REG < g_DDRom->GetRomSize())
+        {
+            for (i = 0; i < PI_WR_LEN_REG; i++)
+            {
+                *(RDRAM + ((g_Reg->PI_DRAM_ADDR_REG + i) ^ 3)) = *(ROM + ((g_Reg->PI_CART_ADDR_REG + i) ^ 3));
+            }
+        }
+        else if (g_Reg->PI_CART_ADDR_REG >= g_DDRom->GetRomSize())
+        {
+            uint32_t cart = g_Reg->PI_CART_ADDR_REG - g_DDRom->GetRomSize();
+            while (cart >= g_DDRom->GetRomSize())
+            {
+                cart -= g_DDRom->GetRomSize();
+            }
+            for (i = 0; i < PI_WR_LEN_REG; i++)
+            {
+                *(RDRAM + ((g_Reg->PI_DRAM_ADDR_REG + i) ^ 3)) = *(ROM + ((cart + i) ^ 3));
+            }
+        }
+        else
+        {
+            uint32_t Len;
+            Len = g_DDRom->GetRomSize() - g_Reg->PI_CART_ADDR_REG;
+            for (i = 0; i < Len; i++)
+            {
+                *(RDRAM + ((g_Reg->PI_DRAM_ADDR_REG + i) ^ 3)) = *(ROM + ((g_Reg->PI_CART_ADDR_REG + i) ^ 3));
+            }
+            for (i = Len; i < PI_WR_LEN_REG - Len; i++)
+            {
+                *(RDRAM + ((g_Reg->PI_DRAM_ADDR_REG + i) ^ 3)) = 0;
+            }
+        }
+        g_Reg->PI_CART_ADDR_REG += 0x06000000;
+
+        if (!g_System->DmaUsed())
+        {
+            g_System->SetDmaUsed(true);
+            OnFirstDMA();
+        }
+        if (g_Recompiler && g_System->bSMM_PIDMA())
+        {
+            g_Recompiler->ClearRecompCode_Phys(g_Reg->PI_DRAM_ADDR_REG, g_Reg->PI_WR_LEN_REG, CRecompiler::Remove_DMA);
+        }
+        g_Reg->PI_STATUS_REG &= ~PI_STATUS_DMA_BUSY;
+        g_Reg->MI_INTR_REG |= MI_INTR_PI;
+        g_Reg->CheckInterrupts();
+        //ChangeTimer(PiTimer,(int32_t)(PI_WR_LEN_REG * 8.9) + 50);
+        //ChangeTimer(PiTimer,(int32_t)(PI_WR_LEN_REG * 8.9));
         return;
     }
 

--- a/Source/Project64-core/N64System/Mips/MemoryVirtualMem.h
+++ b/Source/Project64-core/N64System/Mips/MemoryVirtualMem.h
@@ -216,6 +216,11 @@ private:
     bool          m_RomWrittenTo;
     uint32_t      m_RomWroteValue;
 
+    //DDRom Information
+    bool          m_DDRomMapped;
+    uint8_t *     m_DDRom;
+    uint32_t      m_DDRomSize;
+
     //Current Half line
     void UpdateHalfLine();
     uint32_t         m_HalfLine;

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -212,6 +212,12 @@ bool CN64System::RunFileImage(const char * FileLoc)
     WriteTrace(TraceN64System, TraceDebug, "Loading \"%s\"", FileLoc);
     if (g_Rom->LoadN64Image(FileLoc))
     {
+        if (g_Rom->CicChipID() == CIC_NUS_8303)
+        {
+            //64DD IPL
+            g_DDRom = g_Rom;
+        }
+
         g_System->RefreshGameSettings();
 
         g_Settings->SaveString(Game_File, FileLoc);

--- a/Source/Project64-core/N64System/SystemGlobals.cpp
+++ b/Source/Project64-core/N64System/SystemGlobals.cpp
@@ -21,6 +21,7 @@ CRegisters    * g_Reg = NULL; //Current Register Set attacted to the g_MMU
 CNotification * g_Notify = NULL;
 CPlugins      * g_Plugins = NULL;
 CN64Rom       * g_Rom = NULL;      //The current rom that this system is executing.. it can only execute one file at the time
+CN64Rom       * g_DDRom = NULL;    //64DD IPL ROM
 CAudio        * g_Audio = NULL;
 CSystemTimer  * g_SystemTimer = NULL;
 CTransVaddr   * g_TransVaddr = NULL;

--- a/Source/Project64-core/N64System/SystemGlobals.h
+++ b/Source/Project64-core/N64System/SystemGlobals.h
@@ -35,6 +35,7 @@ extern CPlugins      * g_Plugins;
 
 class CN64Rom;
 extern CN64Rom       * g_Rom;      //The current rom that this system is executing.. it can only execute one file at the time
+extern CN64Rom       * g_DDRom;    //64DD IPL ROM
 
 class CAudio;
 extern CAudio        * g_Audio;


### PR DESCRIPTION
For now only works when you load retail 64DD IPL ROM like a normal ROM.
I prepared g_DDRom for future 64DD emulation, as it always needs to be mapped at 0x06000000.