### PR TITLE
Fix a few sync errors

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -2605,6 +2605,7 @@ RDRAM Size=8
 RSP-JumpTableSize=3584
 SMM-FUNC=0
 SMM-PI DMA=0
+SMM-Protect=1
 SMM-TLB=0
 ViRefresh=1800
 
@@ -2624,6 +2625,7 @@ RDRAM Size=8
 RSP-JumpTableSize=3584
 SMM-FUNC=0
 SMM-PI DMA=0
+SMM-Protect=1
 SMM-TLB=0
 ViRefresh=2050
 

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -4085,6 +4085,7 @@ Good Name=Nuclear Strike 64 (E) (M2)
 Internal Name=NUCLEARSTRIKE64
 Status=Compatible
 Core Note=high system requirement
+Linking=Off
 RDRAM Size=8
 
 [8F50B845-D729D22F-C:44]
@@ -4092,6 +4093,7 @@ Good Name=Nuclear Strike 64 (G)
 Internal Name=NUCLEARSTRIKE64
 Status=Compatible
 Core Note=high system requirement
+Linking=Off
 RDRAM Size=8
 
 [4998DDBB-F7B7AEBC-C:45]
@@ -4099,6 +4101,7 @@ Good Name=Nuclear Strike 64 (U)
 Internal Name=NUCLEARSTRIKE64
 Status=Compatible
 Core Note=high system requirement
+Linking=Off
 RDRAM Size=8
 
 [D83BB920-CC406416-C:4A]

--- a/Source/Project64-core/N64System/Recompiler/RecompilerOps.cpp
+++ b/Source/Project64-core/N64System/Recompiler/RecompilerOps.cpp
@@ -4876,7 +4876,7 @@ void CRecompilerOps::SPECIAL_DADDU()
         if (IsConst(source2))
         {
             AddConstToX86Reg(GetMipsRegMapLo(m_Opcode.rd), GetMipsRegLo(source2));
-            AddConstToX86Reg(GetMipsRegMapHi(m_Opcode.rd), GetMipsRegHi(source2));
+            AdcConstToX86Reg(GetMipsRegMapHi(m_Opcode.rd), GetMipsRegHi(source2));
         }
         else if (IsMapped(source2))
         {


### PR DESCRIPTION
Nuclear Strike 64, Indiana Jones, and FIFA Soccer 64 should work better in cpu recompiler now.