### PR TITLE
Get Tamiya Racing 64 booting

### DIFF
--- a/Config/Glide64.rdb
+++ b/Config/Glide64.rdb
@@ -4021,3 +4021,6 @@ buff_clear=0
 force_microcheck=1
 swapmode=0
 
+[37955E65-C6F2B7B3-C:0]
+Good Name=Tamiya Racing 64 (Unreleased)
+force_microcheck=1


### PR DESCRIPTION
Game needs microcode check to render. Graphics bugged, but it renders. Will also update RDB to remove forced LLE.