### PR TITLE
64DD RTC support, Enable Disk setting

### DIFF
--- a/Source/Project64-core/N64System/Mips/Disk.cpp
+++ b/Source/Project64-core/N64System/Mips/Disk.cpp
@@ -1,0 +1,84 @@
+/****************************************************************************
+*                                                                           *
+* Project64 - A Nintendo 64 emulator.                                      *
+* http://www.pj64-emu.com/                                                  *
+* Copyright (C) 2012 Project64. All rights reserved.                        *
+*                                                                           *
+* License:                                                                  *
+* GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
+*                                                                           *
+****************************************************************************/
+#pragma once
+#include "stdafx.h"
+#include <Project64-core/N64System/SystemGlobals.h>
+#include <Project64-core/N64System/Mips/RegisterClass.h>
+
+void DiskCommand()
+{
+	//ASIC_CMD_STATUS - Commands
+	uint32_t cmd = g_Reg->ASIC_CMD;
+
+#ifdef _WIN32
+	SYSTEMTIME sysTime;
+	::GetLocalTime(&sysTime);
+	//stdstr_f timestamp("%04d/%02d/%02d %02d:%02d:%02d.%03d %05d,", sysTime.wYear, sysTime.wMonth, sysTime.wDay, sysTime.wHour, sysTime.wMinute, sysTime.wSecond, sysTime.wMilliseconds, GetCurrentThreadId());
+
+	//BCD format needed for 64DD RTC
+	uint8_t year = (uint8_t)(((sysTime.wYear / 10) << 4) | (sysTime.wYear % 10));
+	uint8_t month = (uint8_t)(((sysTime.wMonth / 10) << 4) | (sysTime.wMonth % 10));
+	uint8_t day = (uint8_t)(((sysTime.wDay / 10) << 4) | (sysTime.wDay % 10));
+	uint8_t hour = (uint8_t)(((sysTime.wHour / 10) << 4) | (sysTime.wHour % 10));
+	uint8_t minute = (uint8_t)(((sysTime.wMinute / 10) << 4) | (sysTime.wMinute % 10));
+	uint8_t second = (uint8_t)(((sysTime.wSecond / 10) << 4) | (sysTime.wSecond % 10));
+#else
+	time_t ltime;
+	ltime = time(&ltime);
+	
+	struct tm result = { 0 };
+	localtime_r(&ltime, &result);
+
+	//stdstr_f timestamp("%04d/%02d/%02d %02d:%02d:%02d.%03d %05d,", result.tm_year + 1900, result.tm_mon + 1, result.tm_mday, result.tm_hour, result.tm_min, result.tm_sec, milliseconds, GetCurrentThreadId());
+
+	//BCD format needed for 64DD RTC
+	uint8_t year = (uint8_t)(((result.tm_year / 10) << 4) | (result.tm_year % 10));
+	uint8_t month = (uint8_t)(((result.tm_mon / 10) << 4) | (result.tm_mon % 10));
+	uint8_t day = (uint8_t)(((result.tm_mday / 10) << 4) | (result.tm_mday % 10));
+	uint8_t hour = (uint8_t)(((result.tm_hour / 10) << 4) | (result.tm_hour % 10));
+	uint8_t minute = (uint8_t)(((result.tm_min / 10) << 4) | (result.tm_min % 10));
+	uint8_t second = (uint8_t)(((result.tm_sec / 10) << 4) | (result.tm_sec % 10));
+#endif
+
+	switch (cmd & 0xFFFF0000)
+	{
+	case 0x00080000:
+		//Unset Disk Changed Bit
+		g_Reg->ASIC_STATUS &= ~DD_STATUS_DISK_CHNG; break;
+	case 0x00090000:
+		//Unset Reset Bit
+		g_Reg->ASIC_STATUS &= ~DD_STATUS_RST_STATE; break;
+	case 0x00120000:
+		//RTC Get Year & Month
+		g_Reg->ASIC_DATA = (year << 24) | (month << 16); break;
+	case 0x00130000:
+		//RTC Get Day & Hour
+		g_Reg->ASIC_DATA = (day << 24) | (hour << 16); break;
+	case 0x00140000:
+		//RTC Get Minute & Second
+		g_Reg->ASIC_DATA = (minute << 24) | (second << 16); break;
+	}
+}
+
+void DiskReset(void)
+{
+	//ASIC_HARD_RESET 0xAAAA0000
+	g_Reg->ASIC_STATUS |= DD_STATUS_RST_STATE;
+}
+
+void DiskBMControl(void)
+{
+	if (g_Reg->ASIC_BM_CTL & DD_BM_CTL_MECHA_RST)
+	{
+		g_Reg->ASIC_STATUS &= ~DD_STATUS_MECHA_INT;
+		g_Reg->FAKE_CAUSE_REGISTER &= ~CAUSE_IP3;
+	}
+}

--- a/Source/Project64-core/N64System/Mips/Disk.h
+++ b/Source/Project64-core/N64System/Mips/Disk.h
@@ -1,0 +1,16 @@
+/****************************************************************************
+*                                                                           *
+* Project64 - A Nintendo 64 emulator.                                      *
+* http://www.pj64-emu.com/                                                  *
+* Copyright (C) 2012 Project64. All rights reserved.                        *
+*                                                                           *
+* License:                                                                  *
+* GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
+*                                                                           *
+****************************************************************************/
+#pragma once
+#include "stdafx.h"
+
+void DiskCommand(void);
+void DiskReset(void);
+void DiskBMControl(void);

--- a/Source/Project64-core/N64System/Mips/MemoryVirtualMem.h
+++ b/Source/Project64-core/N64System/Mips/MemoryVirtualMem.h
@@ -201,6 +201,7 @@ private:
     static void Write32PeripheralInterface(void);
     static void Write32RDRAMInterface(void);
     static void Write32SerialInterface(void);
+    static void Write32CartridgeDomain2Address1(void);
     static void Write32CartridgeDomain2Address2(void);
     static void Write32PifRam(void);
 

--- a/Source/Project64-core/N64System/Mips/RegisterClass.cpp
+++ b/Source/Project64-core/N64System/Mips/RegisterClass.cpp
@@ -213,6 +213,32 @@ SI_STATUS_REG(SerialInterface[3])
 {
 }
 
+Disk_InterfaceReg::Disk_InterfaceReg(uint32_t * DiskInterface) :
+ASIC_DATA(DiskInterface[0]),
+ASIC_MISC_REG(DiskInterface[1]),
+ASIC_STATUS(DiskInterface[2]),
+ASIC_CUR_TK(DiskInterface[3]),
+ASIC_BM_STATUS(DiskInterface[4]),
+ASIC_ERR_SECTOR(DiskInterface[5]),
+ASIC_SEQ_STATUS(DiskInterface[6]),
+ASIC_CUR_SECTOR(DiskInterface[7]),
+ASIC_HARD_RESET(DiskInterface[8]),
+ASIC_C1_S0(DiskInterface[9]),
+ASIC_HOST_SECBYTE(DiskInterface[10]),
+ASIC_C1_S2(DiskInterface[11]),
+ASIC_SEC_BYTE(DiskInterface[12]),
+ASIC_C1_S4(DiskInterface[13]),
+ASIC_C1_S6(DiskInterface[14]),
+ASIC_CUR_ADDR(DiskInterface[15]),
+ASIC_ID_REG(DiskInterface[16]),
+ASIC_TEST_REG(DiskInterface[17]),
+ASIC_TEST_PIN_SEL(DiskInterface[18]),
+ASIC_CMD(DiskInterface[19]),
+ASIC_BM_CTL(DiskInterface[20]),
+ASIC_SEQ_CTL(DiskInterface[21])
+{
+}
+
 CRegisters::CRegisters(CN64System * System, CSystemEvents * SystemEvents) :
 CP0registers(m_CP0),
 Rdram_InterfaceReg(m_RDRAM_Registers),
@@ -224,6 +250,7 @@ RDRAMInt_InterfaceReg(m_RDRAM_Interface),
 SigProcessor_InterfaceReg(m_SigProcessor_Interface),
 DisplayControlReg(m_Display_ControlReg),
 Serial_InterfaceReg(m_SerialInterface),
+Disk_InterfaceReg(m_DiskInterface),
 m_System(System),
 m_SystemEvents(SystemEvents)
 {
@@ -254,6 +281,7 @@ void CRegisters::Reset()
     memset(m_SigProcessor_Interface, 0, sizeof(m_SigProcessor_Interface));
     memset(m_Peripheral_Interface, 0, sizeof(m_Peripheral_Interface));
     memset(m_SerialInterface, 0, sizeof(m_SerialInterface));
+    memset(m_DiskInterface, 0, sizeof(m_DiskInterface));
 
     m_AudioIntrReg = 0;
     m_GfxIntrReg = 0;

--- a/Source/Project64-core/N64System/Mips/RegisterClass.h
+++ b/Source/Project64-core/N64System/Mips/RegisterClass.h
@@ -482,6 +482,72 @@ enum
     SI_STATUS_INTERRUPT	=	0x1000,
 };
 
+//Disk Interface
+class Disk_InterfaceReg
+{
+protected:
+    Disk_InterfaceReg (uint32_t * Disk_Interface);
+
+public:
+    uint32_t & ASIC_DATA;
+    uint32_t & ASIC_MISC_REG;
+    uint32_t & ASIC_STATUS;
+    uint32_t & ASIC_CMD;
+    uint32_t & ASIC_CUR_TK;
+    uint32_t & ASIC_BM_STATUS;
+    uint32_t & ASIC_BM_CTL;
+    uint32_t & ASIC_ERR_SECTOR;
+    uint32_t & ASIC_SEQ_STATUS;
+    uint32_t & ASIC_SEQ_CTL;
+    uint32_t & ASIC_CUR_SECTOR;
+    uint32_t & ASIC_HARD_RESET;
+    uint32_t & ASIC_C1_S0;
+    uint32_t & ASIC_HOST_SECBYTE;
+    uint32_t & ASIC_C1_S2;
+    uint32_t & ASIC_SEC_BYTE;
+    uint32_t & ASIC_C1_S4;
+    uint32_t & ASIC_C1_S6;
+    uint32_t & ASIC_CUR_ADDR;
+    uint32_t & ASIC_ID_REG;
+    uint32_t & ASIC_TEST_REG;
+    uint32_t & ASIC_TEST_PIN_SEL;
+
+private:
+    Disk_InterfaceReg();										// Disable default constructor
+    Disk_InterfaceReg(const Disk_InterfaceReg&);			// Disable copy constructor
+    Disk_InterfaceReg& operator=(const Disk_InterfaceReg&);	// Disable assignment
+};
+
+//Disk Interface Flags
+enum
+{
+    DD_STATUS_DATA_RQ    =	0x40000000,
+    DD_STATUS_C2_XFER    =	0x10000000,
+    DD_STATUS_BM_ERR     =	0x08000000,
+    DD_STATUS_BM_INT     =	0x04000000,
+    DD_STATUS_MECHA_INT  =	0x02000000,
+    DD_STATUS_DISK_PRES  =	0x01000000,
+    DD_STATUS_BUSY_STATE =	0x00800000,
+    DD_STATUS_RST_STATE  =	0x00400000,
+    DD_STATUS_MTR_N_SPIN =	0x00100000,
+    DD_STATUS_HEAD_RTRCT =	0x00080000,
+    DD_STATUS_WR_PR_ERR  =	0x00040000,
+    DD_STATUS_MECHA_ERR  =	0x00020000,
+    DD_STATUS_DISK_CHNG  =	0x00010000,
+
+    DD_BM_STATUS_RUNNING =	0x80000000,
+    DD_BM_STATUS_ERROR   =	0x04000000,
+    DD_BM_STATUS_MICRO   =	0x02000000,
+    DD_BM_STATUS_BLOCK   =	0x01000000,
+
+    DD_BM_CTL_START      =	0x80000000,
+    DD_BM_CTL_MNGRMODE   =	0x40000000,
+    DD_BM_CTL_INTMASK    =	0x20000000,
+    DD_BM_CTL_RESET      =	0x10000000,
+    DD_BM_CTL_BLK_TRANS  =	0x02000000,
+    DD_BM_CTL_MECHA_RST  =	0x01000000
+};
+
 class CRegName
 {
 public:
@@ -526,7 +592,8 @@ class CRegisters :
     public RDRAMInt_InterfaceReg,
     public SigProcessor_InterfaceReg,
     public DisplayControlReg,
-    public Serial_InterfaceReg
+    public Serial_InterfaceReg,
+    public Disk_InterfaceReg
 {
 public:
     CRegisters(CN64System * System, CSystemEvents * SystemEvents);
@@ -556,6 +623,7 @@ public:
     uint32_t           m_Peripheral_Interface[13];
     uint32_t           m_RDRAM_Interface[8];
     uint32_t           m_SerialInterface[4];
+    uint32_t           m_DiskInterface[22];
     uint32_t           m_AudioIntrReg;
     uint32_t           m_GfxIntrReg;
     uint32_t           m_RspIntrReg;

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -592,6 +592,10 @@ void CN64System::InitRegisters(bool bPostPif, CMipsMemoryVM & MMU)
     m_Reg.CONFIG_REGISTER = 0x0006E463;
     m_Reg.STATUS_REGISTER = 0x34000000;
 
+    //64DD Registers
+    m_Reg.ASIC_STATUS = DD_STATUS_RST_STATE;
+    m_Reg.ASIC_ID_REG = 0x00030000;
+
     //m_Reg.REVISION_REGISTER   = 0x00000511;
     m_Reg.FixFpuLocations();
 

--- a/Source/Project64-core/Project64-core.vcxproj
+++ b/Source/Project64-core/Project64-core.vcxproj
@@ -46,6 +46,7 @@
     <ClCompile Include="N64System\Interpreter\InterpreterOps.cpp" />
     <ClCompile Include="N64System\Interpreter\InterpreterOps32.cpp" />
     <ClCompile Include="N64System\Mips\Audio.cpp" />
+    <ClCompile Include="N64System\Mips\Disk.cpp" />
     <ClCompile Include="N64System\Mips\Dma.cpp" />
     <ClCompile Include="N64System\Mips\Eeprom.cpp" />
     <ClCompile Include="N64System\Mips\FlashRam.cpp" />
@@ -129,6 +130,7 @@
     <ClInclude Include="N64System\Interpreter\InterpreterOps32.h" />
     <ClInclude Include="N64System\Interpreter\InterpreterOps.h" />
     <ClInclude Include="N64System\Mips\Audio.h" />
+    <ClInclude Include="N64System\Mips\Disk.h" />
     <ClInclude Include="N64System\Mips\Dma.h" />
     <ClInclude Include="N64System\Mips\Eeprom.h" />
     <ClInclude Include="N64System\Mips\FlashRam.h" />

--- a/Source/Project64-core/Project64-core.vcxproj.filters
+++ b/Source/Project64-core/Project64-core.vcxproj.filters
@@ -294,6 +294,9 @@
     <ClCompile Include="MemoryExceptionFilter.cpp">
       <Filter>Source Files\N64 System</Filter>
     </ClCompile>
+    <ClCompile Include="N64System\Mips\Disk.cpp">
+      <Filter>Source Files\N64 System\Mips</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -571,6 +574,9 @@
     </ClInclude>
     <ClInclude Include="ExceptionHandler.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="N64System\Mips\Disk.h">
+      <Filter>Header Files\N64 System\Mips</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/Source/Project64-core/Settings/Settings.h
+++ b/Source/Project64-core/Settings/Settings.h
@@ -67,6 +67,7 @@ enum SettingID
     Setting_LanguageDir,
     Setting_LanguageDirDefault,
     Setting_CurrentLanguage,
+    Setting_EnableDisk,
 
     //RDB TLB Settings
     Rdb_GoodName,

--- a/Source/Project64-core/Settings/SettingsClass.cpp
+++ b/Source/Project64-core/Settings/SettingsClass.cpp
@@ -132,6 +132,7 @@ void CSettings::AddHowToHandleSetting()
 
     AddHandler(Setting_RememberCheats, new CSettingTypeApplication("", "Remember Cheats", (uint32_t)false));
     AddHandler(Setting_CurrentLanguage, new CSettingTypeApplication("", "Current Language", ""));
+    AddHandler(Setting_EnableDisk, new CSettingTypeApplication("", "Enable Disk", (uint32_t)false));
     AddHandler(Setting_LanguageDirDefault, new CSettingTypeRelativePath("Lang", ""));
     AddHandler(Setting_LanguageDir, new CSettingTypeApplicationPath("Directory", "Lang", Setting_LanguageDirDefault));
 


### PR DESCRIPTION
Add "Enable Disk=1" to Project64.cfg to see it working.

This commit adds Disk.cpp and Disk.h and a new DiskInterface class for the registers.
RTC is supported on Recompiler and Interpreter.
All what's left is actual Disk Drive emulation.