### PR TITLE
Glide64: Make fb_render true by default

### DIFF
--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -1647,7 +1647,7 @@ void CALL PluginLoaded(void)
     game_setting(Set_read_back_to_screen, "read_back_to_screen", 0);
     game_setting(Set_detect_cpu_write, "detect_cpu_write", 0);
     game_setting(Set_fb_get_info, "fb_get_info", 0);
-    game_setting(Set_fb_render, "fb_render", 0);
+    game_setting(Set_fb_render, "fb_render", 1);
 }
 
 /******************************************************************


### PR DESCRIPTION
On Glide64 Final this is the default, this option enabled by default can fix some regressions.