### PR TITLE
[Glide64] poop :)

### DIFF
--- a/Source/Glide64/rdp.cpp
+++ b/Source/Glide64/rdp.cpp
@@ -336,9 +336,9 @@ void microcheck()
 
         ReleaseGfx();
 #ifdef _WIN32
-        MessageBox(gfx.hWnd, stdstr_f("Error: uCode crc not found in INI, using currently selected uCode\n\n%08lx", uc_crc).c_str(), "Error", MB_OK | MB_ICONEXCLAMATION);
-
+        MessageBox(gfx.hWnd, stdstr_f("Error: uCode crc not found in INI, using currently selected uCode\n\n%08lx", uc_crc).c_str(), NULL, MB_OK | MB_ICONEXCLAMATION);
 #endif
+
         ucode_error_report = FALSE; // don't report any more ucode errors from this game
     }
     else if (uc == -1 && ucode_error_report)
@@ -347,7 +347,7 @@ void microcheck()
 
         ReleaseGfx();
 #ifdef _WIN32
-        MessageBox(gfx.hWnd, stdstr_f("Error: Unsupported uCode!\n\ncrc: %08lx", uc_crc).c_str(), "Error", MB_OK | MB_ICONEXCLAMATION);
+        MessageBox(gfx.hWnd, stdstr_f("Error: Unsupported uCode!\n\ncrc: %08lx", uc_crc).c_str(), NULL, MB_OK | MB_ICONEXCLAMATION);
 #endif
 
         ucode_error_report = FALSE; // don't report any more ucode errors from this game

--- a/Source/Glide64/rdp.cpp
+++ b/Source/Glide64/rdp.cpp
@@ -336,7 +336,7 @@ void microcheck()
 
         ReleaseGfx();
 #ifdef _WIN32
-        MessageBox(gfx.hWnd, stdstr_f("Error: uCode crc not found in INI, using currently selected uCode\n\n%08lx", uc_crc).c_str(), NULL, MB_OK | MB_ICONEXCLAMATION);
+        MessageBox(gfx.hWnd, stdstr_f("Error: uCode crc not found in INI, using currently selected uCode\n\n%08lx", uc_crc).c_str(), "Error", MB_OK | MB_ICONEXCLAMATION);
 #endif
 
         ucode_error_report = FALSE; // don't report any more ucode errors from this game
@@ -347,7 +347,7 @@ void microcheck()
 
         ReleaseGfx();
 #ifdef _WIN32
-        MessageBox(gfx.hWnd, stdstr_f("Error: Unsupported uCode!\n\ncrc: %08lx", uc_crc).c_str(), NULL, MB_OK | MB_ICONEXCLAMATION);
+        MessageBox(gfx.hWnd, stdstr_f("Error: Unsupported uCode!\n\ncrc: %08lx", uc_crc).c_str(), "Error", MB_OK | MB_ICONEXCLAMATION);
 #endif
 
         ucode_error_report = FALSE; // don't report any more ucode errors from this game


### PR DESCRIPTION
According to MSDN, a MessageBox whose title param is a null pointer defaults to the text "Error".
So instead of allocating extra bytes to pass a pointer to the string `"Error"`, why not pass NULL?

Actually the real reason why I made this PR was me having OCD against a cosmetic spacing inconsistency introduced in this commit:  https://github.com/project64/project64/commit/aefe8e603c04d543e2071174fab2f32e1c951476 .  So if you prefer "Error" over NULL I'll just undo that part of this PR and keep the line break change in instead. :P