### PR TITLE
Don't force other contributors to make unreadable PRs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,3 @@
-# Files that will always have CRLF line endings on checkout
-*.sln text eol=crlf
-*.vcproj text eol=crlf
-*.vcxproj text eol=crlf
-*.filters text eol=crlf
-*.props text eol=crlf
-*.vsprops text eol=crlf
-*.vbs text eol=crlf
-
 # All files that are binary and should not be normalized
 
 # Images

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,21 +1,3 @@
-# Automatically detect text files and perform LF line ending normalization
-* text=auto
-
-# Files you want to always be normalized and converted
-# to native line endings on checkout
-*.c text
-*.cpp text
-*.h text
-*.in text
-*.dsp text
-*.iss text
-*.rc text
-*.cpf text
-*.sc text
-*.cmd text
-*.sh text
-*.txt text
-
 # Files that will always have CRLF line endings on checkout
 *.sln text eol=crlf
 *.vcproj text eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@
 *.gif binary
 *.bmp binary
 *.ico binary
-*.xpm binary
 *.cur binary
 
 # Binary data


### PR DESCRIPTION
Three commits in this PR--three reasons why the .gitattributes is not necessitated by anything.

Though the first commit is the only real important one.

Deleting the entire file is something I wanted to do, but I decided to leave the mostly harmless (but neutral and invisible) idea to treat binary files as binary files in there.  Best case scenario it prevents people from poking binary changes to Git repositories which should be text, so I left that in.