### PR TITLE
[Glide64] small updates for fixing compile errors on non-Windows

### DIFF
--- a/Source/Glide64/Combine.cpp
+++ b/Source/Glide64/Combine.cpp
@@ -37,6 +37,7 @@
 //
 //****************************************************************
 
+#include <string.h>
 #include "Gfx_1.3.h"
 #include "Util.h"
 #include "Combine.h"

--- a/Source/Glide64/Debugger.cpp
+++ b/Source/Glide64/Debugger.cpp
@@ -37,7 +37,9 @@
 //
 //****************************************************************
 
+#include <stdarg.h>
 #include <string.h>
+
 #include "Gfx_1.3.h"
 #include "Util.h"
 #include "Debugger.h"

--- a/Source/Glide64/Debugger.cpp
+++ b/Source/Glide64/Debugger.cpp
@@ -37,6 +37,7 @@
 //
 //****************************************************************
 
+#include <string.h>
 #include "Gfx_1.3.h"
 #include "Util.h"
 #include "Debugger.h"

--- a/Source/Glide64/Gfx_1.3.h
+++ b/Source/Glide64/Gfx_1.3.h
@@ -74,7 +74,7 @@ the plugin
 #include "GlideExtensions.h"
 #include "rdp.h"
 #include "Keys.h"
-#include "config.h"
+#include "Config.h"
 
 #if defined __VISUALC__
 typedef unsigned char boolean;

--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -37,6 +37,7 @@
 //
 //****************************************************************
 
+#include <string.h>
 #include <Common/StdString.h>
 #include "Gfx_1.3.h"
 #include "Version.h"

--- a/Source/Glide64/MiClWr32b.h
+++ b/Source/Glide64/MiClWr32b.h
@@ -41,6 +41,8 @@
 //
 //****************************************************************
 
+#include <string.h>
+
 static inline void mirror32bS(uint8_t *tex, uint8_t *start, int width, int height, int mask, int line, int full, int count)
 {
     uint32_t *v8;

--- a/Source/Glide64/TexBuffer.cpp
+++ b/Source/Glide64/TexBuffer.cpp
@@ -42,6 +42,7 @@
 //
 //****************************************************************
 
+#include <string.h>
 #include "Gfx_1.3.h"
 #include "TexBuffer.h"
 #include "CRC.h"

--- a/Source/Glide64/TexLoad.h
+++ b/Source/Glide64/TexLoad.h
@@ -42,6 +42,8 @@
 #include "TexLoad16b.h"
 #include "TexLoad32b.h"
 
+#include <string.h>
+
 uint32_t LoadNone(uintptr_t /*dst*/, uintptr_t /*src*/, int /*wid_64*/, int /*height*/, int /*line*/, int /*real_width*/, int /*tile*/)
 {
     memset(texture, 0, 4096 * 4);

--- a/Source/Glide64/Util.cpp
+++ b/Source/Glide64/Util.cpp
@@ -38,6 +38,8 @@
 //****************************************************************
 
 #include <math.h>
+#include <string.h>
+
 #include "Gfx_1.3.h"
 #include "Util.h"
 #include "Combine.h"

--- a/Source/Glide64/rdp.cpp
+++ b/Source/Glide64/rdp.cpp
@@ -38,6 +38,8 @@
 //****************************************************************
 
 #include <math.h>
+#include <string.h>
+
 #include "Gfx_1.3.h"
 #include "3dmath.h"
 #include "Util.h"


### PR DESCRIPTION
The only remaining compile errors now in Glide64 are related to zilmar's in-progress motions of removing the wx dependency from the sources--basically just these two repeated header include errors (plus, subsequently, several one-time errors in Main.cpp):
```
In file included from ./../../Glide64/TexCache.cpp:43:0:
./../../Glide64/Gfx_1.3.h:171:12: error: 'wxDateTime' does not name a type
     extern wxDateTime fps_last;
            ^
./../../Glide64/Gfx_1.3.h:172:12: error: 'wxDateTime' does not name a type
     extern wxDateTime fps_next;
            ^
```