### PR TITLE
[Settings] InitializeSettings() can return bool.

### DIFF
--- a/Source/Settings/Settings.cpp
+++ b/Source/Settings/Settings.cpp
@@ -77,7 +77,7 @@ __declspec(dllexport) void SetSettingInfo3 (PLUGIN_SETTINGS3 * info)
 	g_PluginSettings3 = *info;
 }
 
-BOOL SettingsInitilized ( void )
+bool SettingsInitilized(void)
 {
 	return g_PluginInitilized;
 }

--- a/Source/Settings/Settings.h
+++ b/Source/Settings/Settings.h
@@ -29,7 +29,7 @@ enum SETTING_DATA_TYPE {
 };
 
 // set other information about different settings
-BOOL SettingsInitilized ( void );
+bool SettingsInitilized ( void );
 void SetModuleName      ( const char * Name );
 void RegisterSetting    ( short SettingID, SETTING_DATA_TYPE Type, const char * Name, const char * Category,
 					        unsigned int DefaultDW, const char * DefaultStr );


### PR DESCRIPTION
Mostly to fix the repetitive errors when compiling Glide64 outside of Windows, which blames this.