### PR TITLE
[64DD] Load 64DD IPL on g_DDRom seperately

### DIFF
--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -219,7 +219,9 @@ bool CN64System::RunFileImage(const char * FileLoc)
         if (g_Rom->CicChipID() == CIC_NUS_8303)
         {
             //64DD IPL
-            g_DDRom = g_Rom;
+            if (g_DDRom == NULL)
+                g_DDRom = new CN64Rom();
+            g_DDRom->LoadN64ImageIPL(FileLoc);
             g_Settings->SaveString(File_DiskIPLPath, FileLoc);
         }
 

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -220,7 +220,9 @@ bool CN64System::RunFileImage(const char * FileLoc)
         {
             //64DD IPL
             if (g_DDRom == NULL)
+            {
                 g_DDRom = new CN64Rom();
+            }
             g_DDRom->LoadN64ImageIPL(FileLoc);
             g_Settings->SaveString(File_DiskIPLPath, FileLoc);
         }


### PR DESCRIPTION
Fixes double g_Rom delete which makes Windows not happy.