### PR TITLE
[Project64-core] Have <memory> included to guarantee std::auto_ptr.

### DIFF
--- a/Source/Project64-core/N64System/Mips/GBCart.cpp
+++ b/Source/Project64-core/N64System/Mips/GBCart.cpp
@@ -12,6 +12,7 @@
 #include "GBCart.h"
 
 #include <time.h>
+#include <memory>
 
 static void read_gb_cart_normal(struct gb_cart* gb_cart, uint16_t address, uint8_t* data)
 {


### PR DESCRIPTION
```
./../../Project64-core/N64System/Mips/GBCart.cpp: In static member function 'static bool GBCart::init_gb_cart(gb_cart*, const char*)':
./../../Project64-core/N64System/Mips/GBCart.cpp:693:5: error: 'auto_ptr' is not a member of 'std'
     std::auto_ptr<uint8_t> rom;
     ^
./../../Project64-core/N64System/Mips/GBCart.cpp:693:26: error: expected primary-expression before '>' token
     std::auto_ptr<uint8_t> rom;
                          ^
./../../Project64-core/N64System/Mips/GBCart.cpp:693:28: error: 'rom' was not declared in this scope
     std::auto_ptr<uint8_t> rom;
                            ^
./../../Project64-core/N64System/Mips/GBCart.cpp:695:5: error: 'auto_ptr' is not a member of 'std'
     std::auto_ptr<uint8_t> ram;
     ^
./../../Project64-core/N64System/Mips/GBCart.cpp:695:26: error: expected primary-expression before '>' token
     std::auto_ptr<uint8_t> ram;
                          ^
./../../Project64-core/N64System/Mips/GBCart.cpp:695:28: error: 'ram' was not declared in this scope
     std::auto_ptr<uint8_t> ram;
                            ^
```