### PR TITLE
[Glide64] fixed yet again the case-sensitive include

### DIFF
--- a/Source/Glide64/Gfx_1.3.h
+++ b/Source/Glide64/Gfx_1.3.h
@@ -74,7 +74,7 @@ the plugin
 #include "GlideExtensions.h"
 #include "rdp.h"
 #include "Keys.h"
-#include "config.h"
+#include "Config.h"
 #include "Settings.h"
 
 #if defined __VISUALC__


### PR DESCRIPTION
https://github.com/project64/project64/commit/dba3b94dfbdcf1b4c3da9acf084b62dde3fe2360#diff-6f0a85cd2bb2947392e5a43efa355307L77
This commit was made immediately after my commit that had this incorrect include string fixed.

If it isn't of any inconvenience, try to avoid re-executing this change when merging more Glide changes.
```
Compiling Glide64 plugin sources...
In file included from ./../../Glide64/Main.cpp:42:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/FBtoScreen.cpp:46:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/rdp.cpp:43:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/Keys.cpp:46:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/Config.cpp:47:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/Debugger.cpp:43:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/Util.cpp:43:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/TexCache.cpp:43:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/3dmath.cpp:40:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/Combine.cpp:41:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/DepthBufferRender.cpp:48:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
compilation terminated.
In file included from ./../../Glide64/TexBuffer.cpp:46:0:
./../../Glide64/Gfx_1.3.h:77:20: fatal error: config.h: No such file or directory
 #include "config.h"
                    ^
```