### PR TITLE
[Glitch64] need forward slashes for C standard paths

### DIFF
--- a/Source/Glitch64/OGLcombiner.cpp
+++ b/Source/Glitch64/OGLcombiner.cpp
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include "glide.h"
 #include "glitchmain.h"
-#include <Glide64\trace.h>
+#include <Glide64/trace.h>
 
 static int fct[4], source0[4], operand0[4], source1[4], operand1[4], source2[4], operand2[4];
 static int fcta[4], sourcea0[4], operanda0[4], sourcea1[4], operanda1[4], sourcea2[4], operanda2[4];

--- a/Source/Glitch64/OGLgeometry.cpp
+++ b/Source/Glitch64/OGLgeometry.cpp
@@ -4,7 +4,7 @@
 #endif // _WIN32
 #include "glide.h"
 #include "glitchmain.h"
-#include <Glide64\trace.h>
+#include <Glide64/trace.h>
 
 #define Z_MAX (65536.0f)
 

--- a/Source/Glitch64/OGLglitchmain.cpp
+++ b/Source/Glitch64/OGLglitchmain.cpp
@@ -17,7 +17,7 @@
 #include "glide.h"
 #include "g3ext.h"
 #include "glitchmain.h"
-#include <Glide64\trace.h>
+#include <Glide64/trace.h>
 
 #ifdef VPDEBUG
 #include <IL/il.h>

--- a/Source/Glitch64/OGLtextures.cpp
+++ b/Source/Glitch64/OGLtextures.cpp
@@ -7,7 +7,7 @@
 #include "glitchmain.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <Glide64\trace.h>
+#include <Glide64/trace.h>
 
 /* Napalm extensions to GrTextureFormat_t */
 #define GR_TEXFMT_ARGB_CMP_FXT1           0x11


### PR DESCRIPTION
```
Compiling common library sources for Glitch64...
./../../Glitch64/OGLcombiner.cpp:12:27: fatal error: Glide64\trace.h: No such file or directory
 #include <Glide64\trace.h>
                           ^
compilation terminated.
./../../Glitch64/OGLgeometry.cpp:7:27: fatal error: Glide64\trace.h: No such file or directory
 #include <Glide64\trace.h>
                           ^
compilation terminated.
./../../Glitch64/OGLglitchmain.cpp:20:27: fatal error: Glide64\trace.h: No such file or directory
 #include <Glide64\trace.h>
                           ^
compilation terminated.
./../../Glitch64/OGLtextures.cpp:10:27: fatal error: Glide64\trace.h: No such file or directory
 #include <Glide64\trace.h>
                           ^
```