### PR TITLE
[Common] leftover remnant of Win32 command shell

### DIFF
--- a/Source/Script/Unix/common.sh
+++ b/Source/Script/Unix/common.sh
@@ -40,7 +40,7 @@ $AS -o $obj/SyncEvent.o                 $obj/SyncEvent.asm
 $AS -o $obj/Trace.o                     $obj/Trace.asm
 $AS -o $obj/Util.o                      $obj/Util.asm
 
-set OBJ_LIST="\
+OBJ_LIST="\
  $obj/Util.o \
  $obj/Trace.o \
  $obj/SyncEvent.o \


### PR DESCRIPTION
I found out the hard way while getting `libglitch64.a` to link into PJ64 Glide64 on Linux that I was getting an 8-byte static library file.  This was because the Unix shell variable `$OBJ_LIST` was null, due to using the `set` keyword which was a result of lazy copy pasta while porting my MinGW script to compile the PJ64 Common library on Windows.