### PR TITLE
[Glide64] undeclared memset and strlen in trace.cpp

### DIFF
--- a/Source/Glide64/trace.cpp
+++ b/Source/Glide64/trace.cpp
@@ -1,5 +1,7 @@
 #include "trace.h"
 #include "Config.h"
+
+#include <string.h>
 #include <Common/Trace.h>
 #include <Common/path.h>
 #include <Common/LogClass.h>


### PR DESCRIPTION
I was not getting these errors before because I forgot to add `Config.cpp` and the recently added `trace.cpp` and `Settings.cpp` which @project64 added to the repository a few days ago.

Just added them to my Unix make script to work out some errors Mupen is giving when trying to initialize the plugin so that I can finally start emulation with it.  For now, this just fixes:
```
Compiling Glide64 plugin sources...
./../../Glide64/trace.cpp: In function 'void SetupTrace()':
./../../Glide64/trace.cpp:64:39: error: 'memset' was not declared in this scope
     memset(log_dir, 0, sizeof(log_dir));
                                       ^
./../../Glide64/trace.cpp:67:23: error: 'strlen' was not declared in this scope
     if (strlen(log_dir) == 0)
                       ^
```