### PR TITLE
[Common] 64-bit needs -fPIC for sectional linkage.

### DIFF
--- a/Source/Script/Unix/common.sh
+++ b/Source/Script/Unix/common.sh
@@ -5,6 +5,7 @@ mkdir -p $obj
 
 FLAGS_x86="\
  -S \
+ -fPIC \
  -masm=intel \
  -march=native \
  -Os"


### PR DESCRIPTION
Generally 32-bit doesn't need this, but 64-bit does, except on MinGW64 or something.

If it's not needed it should get optimized out.