### PR TITLE
[Settings] Get it building on non-Windows platforms.

### DIFF
--- a/Source/Script/Unix/settings.sh
+++ b/Source/Script/Unix/settings.sh
@@ -1,0 +1,29 @@
+src=./../../Settings
+obj=./Settings
+
+mkdir -p $obj
+
+FLAGS_x86="\
+ -S \
+ -fPIC \
+ -I$src/.. \
+ -masm=intel \
+ -march=native \
+ -Os"
+
+C_FLAGS=$FLAGS_x86
+
+CC=g++
+AS=as
+
+echo Compiling settings library sources for Project64...
+$CC -o $obj/Settings.asm                $src/Settings.cpp $C_FLAGS
+
+echo Assembling settings library sources...
+$AS -o $obj/Settings.o                  $obj/Settings.asm
+
+OBJ_LIST="\
+ $obj/Settings.o"
+
+echo Linking static library objects for Settings...
+ar rcs $obj/libsettings.a $OBJ_LIST

--- a/Source/Settings/Settings.cpp
+++ b/Source/Settings/Settings.cpp
@@ -55,24 +55,24 @@ static bool             g_PluginInitilized = false;
 static char             g_PluginSettingName[300];
 
 extern "C" {
-__declspec(dllexport) void SetSettingInfo (PLUGIN_SETTINGS * info);
-__declspec(dllexport) void SetSettingInfo2 (PLUGIN_SETTINGS2 * info);
-__declspec(dllexport) void SetSettingInfo3 (PLUGIN_SETTINGS3 * info);
+EXPORT void SetSettingInfo (PLUGIN_SETTINGS * info);
+EXPORT void SetSettingInfo2 (PLUGIN_SETTINGS2 * info);
+EXPORT void SetSettingInfo3 (PLUGIN_SETTINGS3 * info);
 }
 
-__declspec(dllexport) void SetSettingInfo (PLUGIN_SETTINGS * info) 
+EXPORT void SetSettingInfo (PLUGIN_SETTINGS * info) 
 {
 	g_PluginSettings   = *info;
 	g_PluginInitilized = true;
 	info->UseUnregisteredSetting = UseUnregisteredSetting;
 }
 
-__declspec(dllexport) void SetSettingInfo2 (PLUGIN_SETTINGS2 * info) 
+EXPORT void SetSettingInfo2 (PLUGIN_SETTINGS2 * info) 
 {
 	g_PluginSettings2 = *info;
 }
 
-__declspec(dllexport) void SetSettingInfo3 (PLUGIN_SETTINGS3 * info) 
+EXPORT void SetSettingInfo3 (PLUGIN_SETTINGS3 * info) 
 {
 	g_PluginSettings3 = *info;
 }

--- a/Source/Settings/Settings.cpp
+++ b/Source/Settings/Settings.cpp
@@ -1,4 +1,6 @@
 #include <stdio.h>
+
+#include <Common/stdtypes.h>
 #include "Settings.h"
 
 enum SettingLocation {
@@ -23,7 +25,7 @@ enum SettingDataType {
 };
 
 typedef struct {
-	DWORD  dwSize;
+    uint32_t dwSize;
 	int    DefaultStartRange;
 	int    SettingStartRange;
 	int    MaximumSettings;
@@ -34,9 +36,9 @@ typedef struct {
 	const char * (*GetSettingSz)    ( void * handle, int ID, char * Buffer, int BufferLen );
     void         (*SetSetting)      ( void * handle, int ID, unsigned int Value );
     void         (*SetSettingSz)    ( void * handle, int ID, const char * Value );
-	void         (*RegisterSetting) ( void * handle, int ID, int DefaultID, SettingDataType Type, 
-                                      SettingLocation Location, const char * Category, const char * DefaultStr, DWORD Value );
-	void         (*UseUnregisteredSetting) (int ID);
+    void         (*RegisterSetting) (void * handle, int ID, int DefaultID, SettingDataType Type,
+        SettingLocation Location, const char * Category, const char * DefaultStr, uint32_t Value);
+    void         (*UseUnregisteredSetting) (int ID);
 } PLUGIN_SETTINGS;
 
 typedef struct {

--- a/Source/Settings/Settings.cpp
+++ b/Source/Settings/Settings.cpp
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 #include <Common/stdtypes.h>
 #include <Common/Platform.h>

--- a/Source/Settings/Settings.cpp
+++ b/Source/Settings/Settings.cpp
@@ -1,6 +1,7 @@
 #include <stdio.h>
 
 #include <Common/stdtypes.h>
+#include <Common/Platform.h>
 #include "Settings.h"
 
 enum SettingLocation {

--- a/Source/Settings/Settings.cpp
+++ b/Source/Settings/Settings.cpp
@@ -1,4 +1,3 @@
-#include <windows.h>
 #include <stdio.h>
 #include "Settings.h"
 

--- a/Source/Settings/Settings.h
+++ b/Source/Settings/Settings.h
@@ -4,6 +4,12 @@
 extern "C" {
 #endif
 
+#if defined(_WIN32)
+#define EXPORT          __declspec(dllexport)
+#else
+#define EXPORT          __attribute__((visibility("default")))
+#endif
+
 // Get Plugin Settings, take a setting id
 unsigned int GetSetting        ( short SettingID );
 const char * GetSettingSz      ( short SettingID, char * Buffer, int BufferLen );


### PR DESCRIPTION
Easiest shell script that I had to write so far for Project64.

I needed to get Settings static library to build for doing `-lsettings` in my continued efforts to resolve all of that which is unresolved in getting PJ64Glide64 to open up on mupen.