### PR TITLE
Ensures paks are only being initialized when they have actually been …

### DIFF
--- a/Source/Project64-core/N64System/Mips/Mempak.H
+++ b/Source/Project64-core/N64System/Mips/Mempak.H
@@ -14,7 +14,7 @@ class Mempak
 {
 public:
     static uint8_t CalculateCrc(uint8_t * DataToCrc);
-    static void Load();
+    static void Load(int32_t Control);
     static void Format(int32_t Control);
     static void ReadFrom(int32_t Control, uint32_t address, uint8_t * data);
     static void WriteTo(int32_t Control, uint32_t address, uint8_t * data);

--- a/Source/Project64-core/N64System/Mips/Mempak.cpp
+++ b/Source/Project64-core/N64System/Mips/Mempak.cpp
@@ -17,30 +17,27 @@
 uint8_t Mempaks[4][128 * 256]; /* [CONTROLLERS][PAGES][BYTES_PER_PAGE] */
 CPath MempakNames[4];
 
-void Mempak::Load()
+void Mempak::Load(int32_t Control)
 {
     stdstr MempakName;
 
-    for (int i = 0; i < 3; i++)
+    MempakName.Format("%s_Cont_%d", g_Settings->LoadStringVal(Game_GameName).c_str(), Control + 1);
+
+    MempakNames[Control] = CPath(g_Settings->LoadStringVal(Directory_NativeSave).c_str(), stdstr_f("%s.mpk",MempakName.c_str()).c_str());
+    if (!MempakNames[Control].DirectoryExists())
     {
-        MempakName.Format("%s_Cont_%d", g_Settings->LoadStringVal(Game_GameName).c_str(), i + 1);
+        MempakNames[Control].DirectoryCreate();
+    }
 
-        MempakNames[i] = CPath(g_Settings->LoadStringVal(Directory_NativeSave).c_str(), stdstr_f("%s.mpk",MempakName.c_str()).c_str());
-        if (!MempakNames[i].DirectoryExists())
-        {
-            MempakNames[i].DirectoryCreate();
-        }
-
-        if (MempakNames[i].Exists())
-        {
-            FILE *mempak = fopen(MempakNames[i], "rb");
-            fread(Mempaks[i], 1, 0x8000, mempak);
-            fclose(mempak);
-        }
-        else
-        {
-            Mempak::Format(i);
-        }
+    if (MempakNames[Control].Exists())
+    {
+        FILE *mempak = fopen(MempakNames[Control], "rb");
+        fread(Mempaks[Control], 1, 0x8000, mempak);
+        fclose(mempak);
+    }
+    else
+    {
+        Mempak::Format(Control);
     }
 }
 

--- a/Source/Project64-core/N64System/Mips/Transferpak.cpp
+++ b/Source/Project64-core/N64System/Mips/Transferpak.cpp
@@ -21,11 +21,13 @@ uint16_t gb_cart_address(unsigned int bank, uint16_t address)
 
 void Transferpak::Init()
 {
-    
-	memset(&tpak, 0, sizeof(tpak));
-	tpak.access_mode = (!GBCart::init_gb_cart(&tpak.gb_cart, g_Settings->LoadStringVal(Game_Transferpak_ROM).c_str())) ? CART_NOT_INSERTED : CART_ACCESS_MODE_0;
-
-    tpak.access_mode_changed = 0x44;
+    //Quick check to ensure we dont have a ROM already
+    if (tpak.gb_cart.rom == NULL)
+    {
+        memset(&tpak, 0, sizeof(tpak));
+        tpak.access_mode = (!GBCart::init_gb_cart(&tpak.gb_cart, g_Settings->LoadStringVal(Game_Transferpak_ROM).c_str())) ? CART_NOT_INSERTED : CART_ACCESS_MODE_0;
+        tpak.access_mode_changed = 0x44;
+    }
 }
 
 void Transferpak::Release()

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -66,8 +66,6 @@ m_CheatsSlectionChanged(false)
     m_Limiter.SetHertz(gameHertz);
     g_Settings->SaveDword(GameRunning_ScreenHertz, gameHertz);
     m_Cheats.LoadCheats(!g_Settings->LoadDword(Setting_RememberCheats), Plugins);
-    Mempak::Load();
-    Transferpak::Init();
 }
 
 CN64System::~CN64System()
@@ -693,6 +691,25 @@ bool CN64System::SetActiveSystem(bool bActive)
         if (!bRes)
         {
             WriteTrace(TraceN64System, TraceError, "g_Plugins->Initiate Failed");
+        }
+        else
+        {
+            CONTROL * Controllers = g_Plugins->Control()->PluginControllers();
+            for (int i = 0; i < 3; i++)
+            {
+                if (Controllers[i].Present)
+                {
+                    switch (Controllers[i].Plugin)
+                    {
+                    case PLUGIN_TANSFER_PAK:
+                        Transferpak::Init();
+                        break;
+                    case PLUGIN_MEMPAK:
+                        Mempak::Load(i);
+                        break;
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
…selected, Transferpak needs multi controller support eventually as it currently just loads from the one singular option.

Fixes issue #989 and issue #980 

@project64 need your advice on how to use the settings system cleanly to allow the user to specify a GBC file and ROM file for each controller.
had code for it, but it seemed a little to bloated so scrapped it.