### PR TITLE
[RSP] Get Dma.c to start to compile outside Windows.

### DIFF
--- a/Source/RSP/Cpu.c
+++ b/Source/RSP/Cpu.c
@@ -27,7 +27,7 @@
 #include <windows.h>
 #include <stdio.h>
 #include <float.h>
-#include "RSP.h"
+#include "Rsp.h"
 #include "Cpu.h"
 #include "RSP registers.h"
 #include "RSP Command.h"

--- a/Source/RSP/Interpreter CPU.c
+++ b/Source/RSP/Interpreter CPU.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <float.h>
 #include "breakpoint.h"
-#include "RSP.h"
+#include "Rsp.h"
 #include "Cpu.h"
 #include "Interpreter Ops.h"
 #include "Interpreter CPU.h"

--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -27,7 +27,7 @@
 #include <windows.h>
 #include <stdio.h>
 #include <math.h>
-#include "RSP.h"
+#include "Rsp.h"
 #include "CPU.h"
 #include "RSP Command.h"
 #include "RSP Registers.h"

--- a/Source/RSP/Mmx.c
+++ b/Source/RSP/Mmx.c
@@ -26,7 +26,7 @@
 
 #include <windows.h>
 #include <stdio.h>
-#include "rsp.h"
+#include "Rsp.h"
 #include "x86.h"
 #include "memory.h"
 #include "RSP registers.h"

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 
 #include "opcode.h"
-#include "RSP.h"
+#include "Rsp.h"
 #include "CPU.h"
 #include "RSP Registers.h"
 #include "RSP Command.h"

--- a/Source/RSP/RSP Register.c
+++ b/Source/RSP/RSP Register.c
@@ -27,7 +27,7 @@
 #include <windows.h>
 #include <commctrl.h>
 #include <stdio.h>
-#include "rsp.h"
+#include "Rsp.h"
 #include "types.h"
 
 #define GeneralPurpose			1

--- a/Source/RSP/RSP Registers.h
+++ b/Source/RSP/RSP Registers.h
@@ -24,7 +24,7 @@
  *
  */
 
-#include "types.h"
+#include "Types.h"
 
 #define SP_STATUS_HALT			0x001		/* Bit  0: halt */
 #define SP_STATUS_BROKE			0x002		/* Bit  1: broke */

--- a/Source/RSP/Recompiler Analysis.c
+++ b/Source/RSP/Recompiler Analysis.c
@@ -25,7 +25,7 @@
  */
 
 #include <windows.h>
-#include "rsp.h"
+#include "Rsp.h"
 #include "CPU.h"
 #include "Interpreter CPU.h"
 #include "Recompiler CPU.h"

--- a/Source/RSP/Recompiler CPU.c
+++ b/Source/RSP/Recompiler CPU.c
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <float.h>
 #include <stdlib.h>
-#include "RSP.h"
+#include "Rsp.h"
 #include "Cpu.h"
 #include "Interpreter CPU.h"
 #include "Recompiler CPU.h"

--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -26,7 +26,7 @@
 
 #include <windows.h>
 #include <stdio.h>
-#include "RSP.h"
+#include "Rsp.h"
 #include "CPU.h"
 #include "Interpreter CPU.h"
 #include "Interpreter Ops.h"

--- a/Source/RSP/Recompiler Sections.c
+++ b/Source/RSP/Recompiler Sections.c
@@ -26,7 +26,7 @@
 
 #include <windows.h>
 #include <stdio.h>
-#include "RSP.h"
+#include "Rsp.h"
 #include "CPU.h"
 #include "Recompiler CPU.h"
 #include "RSP Command.h"

--- a/Source/RSP/Rsp.h
+++ b/Source/RSP/Rsp.h
@@ -142,7 +142,7 @@ EXPORT void InitiateRSPDebugger(DEBUG_INFO Debug_Info);
 EXPORT void RomOpen(void);
 EXPORT void RomClosed(void);
 EXPORT void DllConfig(void * hWnd);
-EXPORT void EnableDebugging(BOOL Enabled);
+EXPORT void EnableDebugging(int Enabled);
 EXPORT void PluginLoaded(void);
 
 uint32_t AsciiToHex(char * HexValue);

--- a/Source/RSP/Rsp.h
+++ b/Source/RSP/Rsp.h
@@ -134,10 +134,10 @@ typedef struct {
 
 EXPORT void CloseDLL(void);
 EXPORT void DllAbout(void * hParent);
-EXPORT DWORD DoRspCycles(DWORD Cycles);
+EXPORT uint32_t DoRspCycles(uint32_t Cycles);
 EXPORT void GetDllInfo(PLUGIN_INFO * PluginInfo);
 EXPORT void GetRspDebugInfo(RSPDEBUG_INFO * DebugInfo);
-EXPORT void InitiateRSP(RSP_INFO Rsp_Info, DWORD * CycleCount);
+EXPORT void InitiateRSP(RSP_INFO Rsp_Info, uint32_t * CycleCount);
 EXPORT void InitiateRSPDebugger(DEBUG_INFO Debug_Info);
 EXPORT void RomOpen(void);
 EXPORT void RomClosed(void);
@@ -145,15 +145,15 @@ EXPORT void DllConfig(void * hWnd);
 EXPORT void EnableDebugging(BOOL Enabled);
 EXPORT void PluginLoaded(void);
 
-DWORD AsciiToHex (char * HexValue);
+uint32_t AsciiToHex(char * HexValue);
 void DisplayError (char * Message, ...);
-int  GetStoredWinPos( char * WinName, DWORD * X, DWORD * Y );
+int GetStoredWinPos(char * WinName, uint32_t * X, uint32_t * Y);
 
 #define InterpreterCPU	0
 #define RecompilerCPU	1
 
 extern int DebuggingEnabled, Profiling, IndvidualBlock, ShowErrors, BreakOnStart, LogRDP, LogX86Code;
-extern DWORD CPUCore;
+extern uint32_t CPUCore;
 extern DEBUG_INFO DebugInfo;
 extern RSP_INFO RSPInfo;
 extern void * hinstDLL;

--- a/Source/RSP/Rsp.h
+++ b/Source/RSP/Rsp.h
@@ -64,7 +64,7 @@ typedef struct {
 } PLUGIN_INFO;
 
 typedef struct {
-	HINSTANCE hInst;
+    void * hInst;
     int MemoryBswaped;    /* If this is set to TRUE, then the memory has been pre
                               bswap on a dword (32 bits) boundry */
     uint8_t * RDRAM;
@@ -102,19 +102,19 @@ typedef struct {
 typedef struct {
 	/* Menu */
 	/* Items should have an ID between 5001 and 5100 */
-	HMENU hRSPMenu;
+    void * hRSPMenu;
 	void (*ProcessMenuItem) ( int ID );
 
 	/* Break Points */
     int UseBPoints;
 	char BPPanelName[20];
 	void (*Add_BPoint)      ( void );
-	void (*CreateBPPanel)   ( HWND hDlg, RECT rcBox );
+    void (*CreateBPPanel) (void * hDlg, RECT rcBox);
 	void (*HideBPPanel)     ( void );
 	void (*PaintBPPanel)    ( PAINTSTRUCT ps );
 	void (*ShowBPPanel)     ( void );
-	void (*RefreshBpoints)  ( HWND hList );
-	void (*RemoveBpoint)    ( HWND hList, int index );
+    void (*RefreshBpoints)(void * hList);
+    void (*RemoveBpoint)  (void * hList, int index);
 	void (*RemoveAllBpoint) ( void );
 	
 	/* RSP command Window */
@@ -133,7 +133,7 @@ typedef struct {
 } DEBUG_INFO;
 
 EXPORT void CloseDLL(void);
-EXPORT void DllAbout(HWND hParent);
+EXPORT void DllAbout(void * hParent);
 EXPORT DWORD DoRspCycles(DWORD Cycles);
 EXPORT void GetDllInfo(PLUGIN_INFO * PluginInfo);
 EXPORT void GetRspDebugInfo(RSPDEBUG_INFO * DebugInfo);
@@ -141,7 +141,7 @@ EXPORT void InitiateRSP(RSP_INFO Rsp_Info, DWORD * CycleCount);
 EXPORT void InitiateRSPDebugger(DEBUG_INFO Debug_Info);
 EXPORT void RomOpen(void);
 EXPORT void RomClosed(void);
-EXPORT void DllConfig(HWND hWnd);
+EXPORT void DllConfig(void * hWnd);
 EXPORT void EnableDebugging(BOOL Enabled);
 EXPORT void PluginLoaded(void);
 
@@ -156,7 +156,7 @@ extern int DebuggingEnabled, Profiling, IndvidualBlock, ShowErrors, BreakOnStart
 extern DWORD CPUCore;
 extern DEBUG_INFO DebugInfo;
 extern RSP_INFO RSPInfo;
-extern HINSTANCE hinstDLL;
+extern void * hinstDLL;
 
 #if defined(__cplusplus)
 }

--- a/Source/RSP/Sse.c
+++ b/Source/RSP/Sse.c
@@ -26,7 +26,7 @@
 
 #include <windows.h>
 #include <stdio.h>
-#include "rsp.h"
+#include "Rsp.h"
 #include "x86.h"
 #include "memory.h"
 #include "RSP registers.h"

--- a/Source/RSP/X86.c
+++ b/Source/RSP/X86.c
@@ -26,7 +26,7 @@
 
 #include <windows.h>
 #include <stdio.h>
-#include "rsp.h"
+#include "Rsp.h"
 #include "x86.h"
 #include "memory.h"
 #include "RSP registers.h"

--- a/Source/RSP/breakpoint.c
+++ b/Source/RSP/breakpoint.c
@@ -26,7 +26,7 @@
 
 #include <windows.h>
 #include <stdio.h>
-#include "rsp.h"
+#include "Rsp.h"
 #include "CPU.h"
 #include "breakpoint.h"
 

--- a/Source/RSP/dma.c
+++ b/Source/RSP/dma.c
@@ -26,7 +26,7 @@
 
 #include <Windows.h>
 #include <stdio.h>
-#include "RSP.h"
+#include "Rsp.h"
 #include "RSP Registers.h"
 #include "memory.h"
 

--- a/Source/RSP/memory.c
+++ b/Source/RSP/memory.c
@@ -27,7 +27,7 @@
 enum { MaxMaps	= 32 };
 
 #include <windows.h>
-#include "rsp.h"
+#include "Rsp.h"
 #include "RSP Registers.h"
 
 DWORD NoOfMaps, MapsCRC[MaxMaps], Table;

--- a/Source/RSP/memory.h
+++ b/Source/RSP/memory.h
@@ -24,7 +24,7 @@
  *
  */
 
-#include "types.h"
+#include "Types.h"
 
 int  AllocateMemory ( void );
 void FreeMemory     ( void );

--- a/Source/RSP/memory.h
+++ b/Source/RSP/memory.h
@@ -24,16 +24,15 @@
  *
  */
 
-#include <windows.h>
 #include "types.h"
 
 int  AllocateMemory ( void );
 void FreeMemory     ( void );
-void SetJumpTable   ( DWORD End );
+void SetJumpTable  (uint32_t End);
 
-extern BYTE * RecompCode, * RecompCodeSecondary, * RecompPos;
+extern uint8_t * RecompCode, * RecompCodeSecondary, * RecompPos;
 extern void ** JumpTable;
-extern DWORD Table;
+extern uint32_t Table;
 
 void RSP_LB_DMEM  ( uint32_t Addr, uint8_t * Value );
 void RSP_LBV_DMEM ( uint32_t Addr, int vect, int element );


### PR DESCRIPTION
Most type errors in header files like `Rsp.h` spec header have been fixed now, with just the special struct types PAINTSTRUCT and RECT left over to replace.  Those will be harder to proofread though, so I can try to PR those later.

As all the sources immediately fail with a fatal error of cannot find windows.h or "rsp.h" or the like, most changes were done to `Rsp.h` to get most of them to begin to compile.