### PR TITLE
[RSP] Get Main.cpp to start to compile outside of Windows.

### DIFF
--- a/Source/RSP/Cpu.h
+++ b/Source/RSP/Cpu.h
@@ -24,7 +24,7 @@
  *
  */
 
-#include "opcode.h"
+#include "OpCode.h"
 
 extern UDWORD EleSpec[32], Indx[32];
 

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -24,9 +24,11 @@
  *
  */
 
+#ifdef _WIN32
 #include <Windows.h>
 #include <windowsx.h>
 #include <commctrl.h>
+#endif
 #include <stdio.h>
 
 #include <common/StdString.h>

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -98,14 +98,15 @@ const char * AboutMsg ( void )
 }
 
 /************ Functions ***********/
-DWORD AsciiToHex (char * HexValue)
+uint32_t AsciiToHex(char * HexValue)
 {
-	DWORD Value = 0;
+    size_t Finish, Count;
+    uint32_t Value = 0;
 
-	size_t Finish = strlen(HexValue);
+    Finish = strlen(HexValue);
 	if (Finish > 8 ) { Finish = 8; }
 
-	for (size_t Count = 0; Count < Finish; Count++)
+    for (Count = 0; Count < Finish; Count++)
 	{
 		Value = (Value << 4);
 		switch( HexValue[Count] )

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -59,13 +59,13 @@ BOOL DebuggingEnabled = FALSE,
 	BreakOnStart = FALSE,
 	LogRDP = FALSE,
 	LogX86Code = FALSE;
-DWORD CPUCore = RecompilerCPU;
+uint32_t CPUCore = RecompilerCPU;
 
 HANDLE hMutex = NULL;
 
 DEBUG_INFO DebugInfo;
 RSP_INFO RSPInfo;
-HINSTANCE hinstDLL;
+void * hinstDLL;
 HMENU hRSPMenu = NULL;
 
 extern BYTE * pLastSecondary;

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -31,18 +31,18 @@
 #endif
 #include <stdio.h>
 
-#include <common/StdString.h>
+#include <Common/StdString.h>
 #include "../Settings/Settings.h"
 
 extern "C" {
 #include "Rsp.h"
-#include "CPU.h"
+#include "Cpu.h"
 #include "Recompiler CPU.h"
-#include "Rsp Command.h"
-#include "Rsp Registers.h"
+#include "RSP Command.h"
+#include "RSP Registers.h"
 #include "memory.h"
 #include "breakpoint.h"
-#include "profiling.h"
+#include "Profiling.h"
 #include "log.h"
 #include "resource.h"
 #include "Version.h"

--- a/Source/RSP/Recompiler CPU.h
+++ b/Source/RSP/Recompiler CPU.h
@@ -24,7 +24,7 @@
  *
  */
 
-#include "opcode.h"
+#include "OpCode.h"
 
 extern DWORD CompilePC, NextInstruction, JumpTableSize;
 extern BOOL ChangedPC;


### PR DESCRIPTION
I chose `Main.cpp` this time because that's the file that JK's error list for the Windows build kept reporting.  However, until it's fully ported to GNU, Unix or whatever doesn't use `<windows.h>`, I still cannot have the compiler tell me the list of external references in tens of other files I would have to search through.  Therefore, it's really not feasible to guarantee that this fixes all of the WIN32 build errors, but it should do part of the job.