### PR TITLE
Force interpreter on x64 builds

### DIFF
--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -928,7 +928,7 @@ void CN64System::ExecuteCPU()
     switch ((CPU_TYPE)g_Settings->LoadDword(Game_CpuType))
     {
         // Currently the compiler is 32-bit only.  We might have to ignore that RDB setting for now.
-#ifdef _WIN32
+#ifndef _WIN64
     case CPU_Recompiler: ExecuteRecompiler(); break;
     case CPU_SyncCores:  ExecuteSyncCPU();    break;
 #endif


### PR DESCRIPTION
Basically it's the same pull request of #603 since this was probably accidentally reversed by 3e888b9
