### PR TITLE
[RSP] Try to introduce a new type for Booleans.

### DIFF
--- a/Source/RSP/Types.h
+++ b/Source/RSP/Types.h
@@ -35,6 +35,17 @@
  */
 typedef void(*p_func)(void);
 
+/*
+ * `BOOL` is Windows-specific so is going to tend to be avoided.
+ * `int` is the exact replacement.
+ *
+ * However, saying "int" all the time for true/false is a little ambiguous.
+ *
+ * Maybe in the future, with C++ (or C99) rewrites, we can switch to `bool`.
+ * Until then, a simple type definition will help emphasize true/false logic.
+ */
+typedef int Boolean;
+
 typedef union tagUWORD {
     int32_t     W;
     uint32_t    UW;


### PR DESCRIPTION
Only one commit this time, because I think this will elicit some debate about the next steps.

The most exact replacement of `BOOL` is `int`, which has always been a tradition of function return values that return 0 for failure and non-zero for success or the other way around.  However, maybe @project64 would prefer `int8_t` or `int32_t`?  I suppose `int1_t` would be best if it was defined. :P

So before I fix the BOOL problems with compiling the RSP outside of windows.h, how should I be doing it?  I want to just have a readable, clear type name like "Boolean".  See dictionary.com:  http://dictionary.reference.com/browse/boolean?s=t

It is possible to use `bool`, `true` and `false` keywords as well if the MSVC version is new enough to implement enough of C99, or if the RSP is rewritten as C++.