### PR TITLE
[RSP] Get Dma.c to compile without errors/warnings outside Windows.

### DIFF
--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -138,15 +138,19 @@ DWORD AsciiToHex (char * HexValue)
 	return Value;
 }
 
-void DisplayError (char * Message, ...)
+void DisplayError(char* Message, ...)
 {
-	char Msg[400];
-	va_list ap;
+    char Msg[400];
+    va_list ap;
 
 	va_start( ap, Message );
 	vsprintf( Msg, Message, ap );
 	va_end( ap );
-	MessageBox(NULL,Msg,"Error",MB_OK|MB_ICONERROR);
+#ifdef _WIN32
+    MessageBox(NULL, Msg, "Error", MB_OK | MB_ICONERROR);
+#else
+    fputs(&Msg[0], stderr);
+#endif
 }
 
 /******************************************************************

--- a/Source/RSP/Rsp.h
+++ b/Source/RSP/Rsp.h
@@ -146,7 +146,7 @@ EXPORT void EnableDebugging(int Enabled);
 EXPORT void PluginLoaded(void);
 
 uint32_t AsciiToHex(char * HexValue);
-void DisplayError (char * Message, ...);
+void DisplayError(char * Message, ...);
 int GetStoredWinPos(char * WinName, uint32_t * X, uint32_t * Y);
 
 #define InterpreterCPU	0

--- a/Source/RSP/dma.c
+++ b/Source/RSP/dma.c
@@ -26,6 +26,8 @@
 
 #include <Windows.h>
 #include <stdio.h>
+#include <Common/stdtypes.h>
+
 #include "Rsp.h"
 #include "RSP Registers.h"
 #include "memory.h"
@@ -34,8 +36,8 @@
 
 void SP_DMA_READ (void)
 {
-	DWORD i, j, Length, Skip, Count, End, addr;
-	BYTE *Dest, *Source;
+    uint32_t i, j, Length, Skip, Count, End, addr;
+    uint8_t *Dest, *Source;
 
     addr = (*RSPInfo.SP_DRAM_ADDR_REG) & 0x00FFFFFF;
 
@@ -110,8 +112,8 @@ void SP_DMA_READ (void)
 
 void SP_DMA_WRITE (void)
 {
-	DWORD i, j, Length, Skip, Count, addr;
-	BYTE *Dest, *Source;
+    uint32_t i, j, Length, Skip, Count, addr;
+    uint8_t *Dest, *Source;
 
     addr = (*RSPInfo.SP_DRAM_ADDR_REG) & 0x00FFFFFF;
 

--- a/Source/RSP/dma.c
+++ b/Source/RSP/dma.c
@@ -28,6 +28,7 @@
 #include <Windows.h>
 #endif
 #include <stdio.h>
+#include <string.h>
 #include <Common/stdtypes.h>
 
 #include "Rsp.h"

--- a/Source/RSP/dma.c
+++ b/Source/RSP/dma.c
@@ -24,7 +24,9 @@
  *
  */
 
+#ifdef _WIN32
 #include <Windows.h>
+#endif
 #include <stdio.h>
 #include <Common/stdtypes.h>
 
@@ -43,13 +45,13 @@ void SP_DMA_READ (void)
 
 	if (addr > 0x7FFFFF)
 	{
-		MessageBox(NULL,"SP DMA READ\nSP_DRAM_ADDR_REG not in RDRam space","Error",MB_OK);
+        DisplayError("SP DMA READ\nSP_DRAM_ADDR_REG not in RDRam space");
 		return;
 	}
 	
 	if ((*RSPInfo.SP_RD_LEN_REG & 0xFFF) + 1  + (*RSPInfo.SP_MEM_ADDR_REG & 0xFFF) > 0x1000)
 	{
-		MessageBox(NULL,"SP DMA READ\ncould not fit copy in memory segment","Error",MB_OK);
+        DisplayError("SP DMA READ\ncould not fit copy in memory segment");
 		return;
 	}
 
@@ -119,13 +121,13 @@ void SP_DMA_WRITE (void)
 
 	if (addr > 0x7FFFFF)
 	{
-		MessageBox(NULL,"SP DMA WRITE\nSP_DRAM_ADDR_REG not in RDRam space","Error",MB_OK);
+        DisplayError("SP DMA WRITE\nSP_DRAM_ADDR_REG not in RDRam space");
 		return;
 	}
 
 	if ((*RSPInfo.SP_WR_LEN_REG & 0xFFF) + 1  + (*RSPInfo.SP_MEM_ADDR_REG & 0xFFF) > 0x1000)
 	{
-		MessageBox(NULL,"SP DMA WRITE\ncould not fit copy in memory segment","Error",MB_OK);
+        DisplayError("SP DMA WRITE\ncould not fit copy in memory segment");
 		return;
 	}
 

--- a/Source/RSP/dma.c
+++ b/Source/RSP/dma.c
@@ -24,9 +24,6 @@
  *
  */
 
-#ifdef _WIN32
-#include <Windows.h>
-#endif
 #include <stdio.h>
 #include <string.h>
 #include <Common/stdtypes.h>


### PR DESCRIPTION
Now the whole thing compiles without any errors or warnings, except for only this:
```
In file included from ./../../RSP/dma.c:34:0:
./../../RSP/Rsp.h:112:41: error: unknown type name 'RECT'
     void (*CreateBPPanel) (void * hDlg, RECT rcBox);
                                         ^
./../../RSP/Rsp.h:114:28: error: unknown type name 'PAINTSTRUCT'
  void (*PaintBPPanel)    ( PAINTSTRUCT ps );
                            ^
```

The usage of _WIN32-specific types like RECT and PAINTSTRUCT inside the very definitions of the plugin system is a more complicated issue which I was not sure how to solve, so making a separate PR for that right after this one.