### PR TITLE
[RSP] Attempt to typedef-out WIN32 types to custom standards?

### DIFF
--- a/Source/RSP/Rsp.h
+++ b/Source/RSP/Rsp.h
@@ -29,6 +29,7 @@ extern "C" {
 #endif
 
 #include <Common/stdtypes.h>
+#include "Types.h"
 
 #if defined(_WIN32)
 #define EXPORT          __declspec(dllexport)
@@ -100,6 +101,18 @@ typedef struct {
 } RSP_INFO;
 
 typedef struct {
+    long left, top, right, bottom;
+} rectangle; /* <windows.h> equivalent:  RECT */
+typedef struct {
+    void * hdc;
+    Boolean fErase;
+    rectangle rcPaint;
+    Boolean fRestore;
+    Boolean fIncUpdate;
+    uint8_t rgbReserved[32];
+} window_paint; /* <windows.h> equivalent:  PAINTSTRUCT */
+
+typedef struct {
 	/* Menu */
 	/* Items should have an ID between 5001 and 5100 */
     void * hRSPMenu;
@@ -109,9 +122,9 @@ typedef struct {
     int UseBPoints;
 	char BPPanelName[20];
 	void (*Add_BPoint)      ( void );
-    void (*CreateBPPanel) (void * hDlg, RECT rcBox);
+    void (*CreateBPPanel) (void * hDlg, rectangle rcBox);
 	void (*HideBPPanel)     ( void );
-	void (*PaintBPPanel)    ( PAINTSTRUCT ps );
+    void (*PaintBPPanel)  (window_paint ps);
 	void (*ShowBPPanel)     ( void );
     void (*RefreshBpoints)(void * hList);
     void (*RemoveBpoint)  (void * hList, int index);


### PR DESCRIPTION
This, together with #999, gets our very first successful compilation of a PJ64 RSP source code file outside of Microsoft Windows.  My problem with it is I'm not sure on my approach, so critique welcome.

Normally with WIN32-specific code like MessageBox, PAINTSTRUCT/RECT etc. one would just write a non-Windows equivalent for defining their own message echo system, rectangle drawing/painting in some other API.  The problem with this is that here we have the WIN32 code inside the RSP plugin spec definitions, which makes this approach more limited.  I tried to create my own custom type definitions (which should be binary-compatible with the current ones on MSDN for RECT and PAINTSTRUCT), but this isn't guaranteed to work if Microsoft were to change/add/remove members to the struct in future versions of the operating system.  Although, carefully reading/writing only from certain members of the struct for other platforms for custom debugging code should evade that issue.

Or should the Win32 UI features just be disabled out of the spec files altogether?