### PR TITLE
[RSP] Kill all errors related to BOOL/TRUE/FALSE.

### DIFF
--- a/Source/RSP/Cpu.c
+++ b/Source/RSP/Cpu.c
@@ -38,6 +38,7 @@
 #include "Profiling.h"
 #include "breakpoint.h"
 #include "x86.h"
+#include "Types.h"
 
 UDWORD EleSpec[32], Indx[32];
 OPCODE RSPOpC;
@@ -194,7 +195,7 @@ DWORD RunRecompilerCPU (DWORD Cycles);
 
 __declspec(dllexport) DWORD DoRspCycles ( DWORD Cycles )
 {
-	extern BOOL AudioHle, GraphicsHle;
+    extern Boolean AudioHle, GraphicsHle;
 	DWORD TaskType = *(DWORD*)(RSPInfo.DMEM + 0xFC0);
 		
 /*	if (*RSPInfo.SP_STATUS_REG & SP_STATUS_SIG0)

--- a/Source/RSP/Cpu.c
+++ b/Source/RSP/Cpu.c
@@ -33,7 +33,7 @@
 #include "RSP Command.h"
 #include "Recompiler CPU.h"
 #include "memory.h"
-#include "opcode.h"
+#include "OpCode.h"
 #include "log.h"
 #include "Profiling.h"
 #include "breakpoint.h"

--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -36,6 +36,7 @@
 #include "dma.h"
 #include "log.h"
 #include "x86.h"
+#include "Types.h"
 
 #include <float.h>
 /*
@@ -55,7 +56,7 @@
 #endif
 
 extern UWORD32 Recp, RecpResult, SQroot, SQrootResult;
-extern BOOL AudioHle, GraphicsHle;
+extern Boolean AudioHle, GraphicsHle;
 
 /************************* OpCode functions *************************/
 void RSP_Opcode_SPECIAL ( void ) {

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -35,6 +35,7 @@
 #include "RSP Command.h"
 #include "memory.h"
 #include "breakpoint.h"
+#include "Types.h"
 
 #define RSP_MaxCommandLines		30
 
@@ -70,7 +71,7 @@ RSPCOMMANDLINE RSPCommandLine[30];
 HWND RSPCommandshWnd, hList, hAddress, hFunctionlist, hGoButton, hBreakButton,
 	hStepButton, hSkipButton, hBPButton, hR4300iRegisters, hR4300iDebugger, hRSPRegisters,
 	hMemory, hScrlBar;
-BOOL InRSPCommandsWindow;
+Boolean InRSPCommandsWindow;
 char CommandName[100];
 DWORD Stepping_Commands, WaitingForStep;
 
@@ -131,7 +132,7 @@ int DisplayRSPCommand (DWORD location, int InsertPos)
 {
 	uint32_t OpCode;
 	DWORD LinesUsed = 1, status;
-	BOOL Redraw = FALSE;
+    Boolean Redraw = FALSE;
 
 	RSP_LW_IMEM(location, &OpCode);
 

--- a/Source/RSP/RSP Command.h
+++ b/Source/RSP/RSP Command.h
@@ -37,4 +37,4 @@ void SetRSPCommandToStepping ( void );
 void SetRSPCommandViewto ( UINT NewLocation );
 
 extern DWORD Stepping_Commands, WaitingForStep;
-extern BOOL InRSPCommandsWindow;
+extern Boolean InRSPCommandsWindow;

--- a/Source/RSP/RSP Register.c
+++ b/Source/RSP/RSP Register.c
@@ -28,7 +28,7 @@
 #include <commctrl.h>
 #include <stdio.h>
 #include "Rsp.h"
-#include "types.h"
+#include "Types.h"
 
 #define GeneralPurpose			1
 #define ControlProcessor0		2

--- a/Source/RSP/Recompiler Analysis.c
+++ b/Source/RSP/Recompiler Analysis.c
@@ -33,17 +33,19 @@
 #include "memory.h"
 #include "opcode.h"
 #include "log.h"
+#include "Types.h"
 
 //#define COMPARE_INSTRUCTIONS_VERBOSE
 
 /************************************************************
 ** IsOpcodeNop
 **
-** Output: BOOLean whether opcode at PC is a NOP
+** Output: Boolean whether opcode at PC is a NOP
 ** Input: PC
 *************************************************************/
 
-BOOL IsOpcodeNop(DWORD PC) {
+Boolean IsOpcodeNop(DWORD PC)
+{
 	OPCODE RspOp;
 	RSP_LW_IMEM(PC, &RspOp.Hex);
 
@@ -61,7 +63,8 @@ BOOL IsOpcodeNop(DWORD PC) {
 ** Input: PC
 *************************************************************/
 
-BOOL IsNextInstructionMmx(DWORD PC) {
+Boolean IsNextInstructionMmx(DWORD PC)
+{
 	OPCODE RspOp;
 	
 	if (IsMmxEnabled == FALSE)
@@ -133,7 +136,8 @@ BOOL IsNextInstructionMmx(DWORD PC) {
 
 #define HIT_BRANCH	0x2
 
-DWORD WriteToAccum2 (int Location, int PC, BOOL RecursiveCall) {
+DWORD WriteToAccum2(int Location, int PC, Boolean RecursiveCall)
+{
 	OPCODE RspOp;
 	DWORD BranchTarget = 0;
 	signed int BranchImmed = 0;
@@ -426,7 +430,8 @@ DWORD WriteToAccum2 (int Location, int PC, BOOL RecursiveCall) {
 	return TRUE;
 }
 
-BOOL WriteToAccum (int Location, int PC) {
+Boolean WriteToAccum(int Location, int PC)
+{
 	DWORD value = WriteToAccum2(Location, PC, FALSE);
 
 	if (value == HIT_BRANCH) {
@@ -445,7 +450,8 @@ BOOL WriteToAccum (int Location, int PC) {
 ** Input: PC, Register
 *************************************************************/
 
-BOOL WriteToVectorDest2 (DWORD DestReg, int PC, BOOL RecursiveCall) {
+Boolean WriteToVectorDest2(DWORD DestReg, int PC, Boolean RecursiveCall)
+{
 	OPCODE RspOp;
 	DWORD BranchTarget = 0;
 	signed int BranchImmed = 0;
@@ -761,7 +767,8 @@ BOOL WriteToVectorDest2 (DWORD DestReg, int PC, BOOL RecursiveCall) {
 	return TRUE;
 }
 
-BOOL WriteToVectorDest (DWORD DestReg, int PC) {
+Boolean WriteToVectorDest(DWORD DestReg, int PC)
+{
 	DWORD value;
 	value = WriteToVectorDest2(DestReg, PC, FALSE);
 
@@ -782,7 +789,8 @@ BOOL WriteToVectorDest (DWORD DestReg, int PC) {
 *************************************************************/
 
 /* TODO: consider delay slots and such in a branch? */
-BOOL UseRspFlags (int PC) {
+Boolean UseRspFlags(int PC)
+{
 	OPCODE RspOp;
 	int Instruction_State = NextInstruction;
 
@@ -1007,7 +1015,8 @@ BOOL UseRspFlags (int PC) {
 ** Input: PC, Pointer to constant to fill
 *************************************************************/
 
-BOOL IsRegisterConstant (DWORD Reg, DWORD * Constant) {
+Boolean IsRegisterConstant(DWORD Reg, DWORD * Constant)
+{
 	DWORD PC = 0;
 	DWORD References = 0;
 	DWORD Const = 0;
@@ -1183,8 +1192,8 @@ BOOL IsRegisterConstant (DWORD Reg, DWORD * Constant) {
 ** Input: PC
 *************************************************************/
 
-BOOL IsOpcodeBranch(DWORD PC, OPCODE RspOp) {
-
+Boolean IsOpcodeBranch(DWORD PC, OPCODE RspOp)
+{
 	PC = PC; // unused
 
 	switch (RspOp.op) {
@@ -1662,7 +1671,8 @@ void GetInstructionInfo(DWORD PC, OPCODE * RspOp, OPCODE_INFO * info) {
 ** Input: PC
 *************************************************************/
 
-BOOL DelaySlotAffectBranch(DWORD PC) {
+Boolean DelaySlotAffectBranch(DWORD PC)
+{
 	OPCODE Branch, Delay;
 	OPCODE_INFO infoBranch, infoDelay;
 
@@ -1705,8 +1715,8 @@ BOOL DelaySlotAffectBranch(DWORD PC) {
 **	Bottom: the current opcode for re-ordering bubble style
 *************************************************************/
 
-BOOL CompareInstructions(DWORD PC, OPCODE * Top, OPCODE * Bottom) {
-
+Boolean CompareInstructions(DWORD PC, OPCODE * Top, OPCODE * Bottom)
+{
 	OPCODE_INFO info0, info1;
 	DWORD InstructionType;
 

--- a/Source/RSP/Recompiler CPU.c
+++ b/Source/RSP/Recompiler CPU.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <float.h>
 #include <stdlib.h>
+
 #include "Rsp.h"
 #include "Cpu.h"
 #include "Interpreter CPU.h"
@@ -40,6 +41,7 @@
 #include "log.h"
 #include "Profiling.h"
 #include "x86.h"
+#include "Types.h"
 
 #pragma warning(disable : 4152) // nonstandard extension, function/data pointer conversion in expression
 
@@ -50,7 +52,7 @@
 
 DWORD CompilePC, JumpTableSize, BlockID = 0;
 DWORD dwBuffer = MainBuffer;
-BOOL ChangedPC;
+Boolean ChangedPC;
 
 RSP_BLOCK CurrentBlock;
 RSP_CODE RspCode;
@@ -546,7 +548,7 @@ void ReOrderSubBlock(RSP_BLOCK * Block) {
 void DetectGPRConstants(RSP_CODE * code) {
 	DWORD Count, Constant = 0;
 
-	memset(&code->bIsRegConst, 0, sizeof(BOOL) * 0x20);
+	memset(&code->bIsRegConst, 0, sizeof(Boolean) * 0x20);
 	memset(&code->MipsRegConst, 0, sizeof(DWORD) * 0x20);
 	
 	if (!Compiler.bGPRConstants) { 
@@ -728,7 +730,8 @@ void BuildBranchLabels(void) {
 #endif
 }
 
-BOOL IsJumpLabel(DWORD PC) {
+Boolean IsJumpLabel(DWORD PC)
+{
 	DWORD Count;
 	
 	if (!RspCode.LabelCount) {

--- a/Source/RSP/Recompiler CPU.h
+++ b/Source/RSP/Recompiler CPU.h
@@ -25,9 +25,10 @@
  */
 
 #include "OpCode.h"
+#include "Types.h"
 
 extern DWORD CompilePC, NextInstruction, JumpTableSize;
-extern BOOL ChangedPC;
+extern Boolean ChangedPC;
 
 #define CompilerWarning if (ShowErrors) DisplayError
 
@@ -36,17 +37,17 @@ extern BOOL ChangedPC;
 #define Low16BitAccum		4
 #define EntireAccum			(Low16BitAccum|Middle16BitAccum|High16BitAccum)
 
-BOOL WriteToAccum (int Location, int PC);
-BOOL WriteToVectorDest (DWORD DestReg, int PC);
-BOOL UseRspFlags (int PC);
+Boolean WriteToAccum(int Location, int PC);
+Boolean WriteToVectorDest(DWORD DestReg, int PC);
+Boolean UseRspFlags(int PC);
 
-BOOL DelaySlotAffectBranch(DWORD PC);
-BOOL CompareInstructions(DWORD PC, OPCODE * Top, OPCODE * Bottom);
-BOOL IsOpcodeBranch(DWORD PC, OPCODE RspOp);
-BOOL IsOpcodeNop(DWORD PC);
+Boolean DelaySlotAffectBranch(DWORD PC);
+Boolean CompareInstructions(DWORD PC, OPCODE * Top, OPCODE * Bottom);
+Boolean IsOpcodeBranch(DWORD PC, OPCODE RspOp);
+Boolean IsOpcodeNop(DWORD PC);
 
-BOOL IsNextInstructionMmx(DWORD PC);
-BOOL IsRegisterConstant (DWORD Reg, DWORD * Constant);
+Boolean IsNextInstructionMmx(DWORD PC);
+Boolean IsRegisterConstant(DWORD Reg, DWORD * Constant);
 
 void RSP_Element2Mmx(int MmxReg);
 void RSP_MultiElement2Mmx(int MmxReg1, int MmxReg2);
@@ -59,7 +60,7 @@ void BuildRecompilerCPU ( void );
 
 void CompilerRSPBlock ( void );
 void CompilerToggleBuffer (void);
-BOOL RSP_DoSections(void);
+Boolean RSP_DoSections(void);
 
 typedef struct {
 	DWORD StartPC, CurrPC;		/* block start */
@@ -75,7 +76,7 @@ typedef struct {
 extern RSP_BLOCK CurrentBlock;
 
 typedef struct {
-	BOOL bIsRegConst[32];		/* BOOLean toggle for constant */
+    Boolean bIsRegConst[32];    /* Boolean toggle for constant */
 	DWORD MipsRegConst[32];		/* Value of register 32-bit */
 	DWORD BranchLabels[250];
 	DWORD LabelCount;
@@ -89,15 +90,15 @@ extern RSP_CODE RspCode;
 #define MipsRegConst(i) (RspCode.MipsRegConst[i])
 
 typedef struct {
-	BOOL mmx, mmx2, sse;	/* CPU specs and compiling */
-	BOOL bFlags;			/* RSP Flag Analysis */
-	BOOL bReOrdering;		/* Instruction reordering */
-	BOOL bSections;			/* Microcode sections */
-	BOOL bDest;				/* Vector destionation toggle */
-	BOOL bAccum;			/* Accumulator toggle */
-	BOOL bGPRConstants;		/* Analyze GPR constants */
-	BOOL bAlignVector;		/* Align known vector loads */
-	BOOL bAudioUcode;		/* Audio ucode analysis */
+    Boolean mmx, mmx2, sse;     /* CPU specs and compiling */
+    Boolean bFlags;             /* RSP Flag Analysis */
+    Boolean bReOrdering;        /* Instruction reordering */
+    Boolean bSections;          /* Microcode sections */
+    Boolean bDest;              /* Vector destionation toggle */
+    Boolean bAccum;             /* Accumulator toggle */
+    Boolean bGPRConstants;      /* Analyze GPR constants */
+    Boolean bAlignVector;       /* Align known vector loads */
+    Boolean bAudioUcode;        /* Audio ucode analysis */
 } RSP_COMPILER;
 
 extern RSP_COMPILER Compiler;

--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -38,10 +38,11 @@
 #include "log.h"
 #include "x86.h"
 #include "Profiling.h"
+#include "Types.h"
 
 #pragma warning(disable : 4152) // nonstandard extension, function/data pointer conversion in expression
 
-extern BOOL AudioHle, GraphicsHle;
+extern Boolean AudioHle, GraphicsHle;
 UWORD32 Recp, RecpResult, SQroot, SQrootResult;
 DWORD ESP_RegSave = 0, EBP_RegSave = 0;
 DWORD BranchCompare = 0;
@@ -240,8 +241,9 @@ void Compile_JAL ( void ) {
 	}
 }
 
-void Compile_BEQ ( void ) {
-	static BOOL bDelayAffect;
+void Compile_BEQ(void)
+{
+    static Boolean bDelayAffect;
 
 	if ( NextInstruction == NORMAL ) {
 		CPU_Message("  %X %s",CompilePC,RSPOpcodeName(RSPOpC.Hex,CompilePC));
@@ -299,8 +301,9 @@ void Compile_BEQ ( void ) {
 	}
 }
 
-void Compile_BNE ( void ) {
-	static BOOL bDelayAffect;
+void Compile_BNE(void)
+{
+    static Boolean bDelayAffect;
 
 	if ( NextInstruction == NORMAL ) {
 		CPU_Message("  %X %s",CompilePC,RSPOpcodeName(RSPOpC.Hex,CompilePC));
@@ -358,8 +361,9 @@ void Compile_BNE ( void ) {
 	}
 }
 
-void Compile_BLEZ ( void ) {
-	static BOOL bDelayAffect;
+void Compile_BLEZ(void)
+{
+    static Boolean bDelayAffect;
 
 	if ( NextInstruction == NORMAL ) {
 		CPU_Message("  %X %s",CompilePC,RSPOpcodeName(RSPOpC.Hex,CompilePC));
@@ -404,8 +408,9 @@ void Compile_BLEZ ( void ) {
 	}
 }
 
-void Compile_BGTZ ( void ) {
-	static BOOL bDelayAffect;
+void Compile_BGTZ(void)
+{
+    static Boolean bDelayAffect;
 
 	if ( NextInstruction == NORMAL ) {
 		CPU_Message("  %X %s",CompilePC,RSPOpcodeName(RSPOpC.Hex,CompilePC));
@@ -1455,8 +1460,9 @@ void Compile_Special_SLTU ( void ) {
 }
 
 /********************** R4300i OpCodes: RegImm **********************/
-void Compile_RegImm_BLTZ ( void ) {
-	static BOOL bDelayAffect;
+void Compile_RegImm_BLTZ(void)
+{
+    static Boolean bDelayAffect;
 
 	if ( NextInstruction == NORMAL ) {
 		CPU_Message("  %X %s",CompilePC,RSPOpcodeName(RSPOpC.Hex,CompilePC));
@@ -1498,8 +1504,9 @@ void Compile_RegImm_BLTZ ( void ) {
 	}
 }
 
-void Compile_RegImm_BGEZ ( void ) {
-	static BOOL bDelayAffect;
+void Compile_RegImm_BGEZ(void)
+{
+    static Boolean bDelayAffect;
 
 	if ( NextInstruction == NORMAL ) {
 		CPU_Message("  %X %s",CompilePC,RSPOpcodeName(RSPOpC.Hex,CompilePC));
@@ -1576,8 +1583,9 @@ void Compile_RegImm_BLTZAL ( void ) {
 	}
 }
 
-void Compile_RegImm_BGEZAL ( void ) {
-	static BOOL bDelayAffect;
+void Compile_RegImm_BGEZAL(void)
+{
+    static Boolean bDelayAffect;
 
 	if ( NextInstruction == NORMAL ) {
 		CPU_Message("  %X %s",CompilePC,RSPOpcodeName(RSPOpC.Hex,CompilePC));
@@ -2109,7 +2117,8 @@ void RSP_MultiElement2Mmx(int MmxReg1, int MmxReg2) {
 	}
 }
 
-BOOL Compile_Vector_VMULF_MMX ( void ) {
+Boolean Compile_Vector_VMULF_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -2161,9 +2170,9 @@ void Compile_Vector_VMULF ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmulf
 	Cheat_r4300iOpcode(RSP_Vector_VMULF,"RSP_Vector_VMULF"); return;
@@ -2236,7 +2245,8 @@ void Compile_Vector_VMULU ( void ) {
 	Cheat_r4300iOpcode(RSP_Vector_VMULU,"RSP_Vector_VMULU");
 }
 
-BOOL Compile_Vector_VMUDL_MMX ( void ) {
+Boolean Compile_Vector_VMUDL_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -2287,10 +2297,10 @@ BOOL Compile_Vector_VMUDL_MMX ( void ) {
 void Compile_Vector_VMUDL ( void ) {
 	char Reg[256];
 	int count, el, del;
-	
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
+
+	Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+	Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+	Boolean bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
 
 	#ifndef CompileVmudl
 	Cheat_r4300iOpcode(RSP_Vector_VMUDL,"RSP_Vector_VMUDL"); return;
@@ -2342,7 +2352,8 @@ void Compile_Vector_VMUDL ( void ) {
 	}
 }
 
-BOOL Compile_Vector_VMUDM_MMX ( void ) {
+Boolean Compile_Vector_VMUDM_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -2428,9 +2439,9 @@ void Compile_Vector_VMUDM ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
+    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
 
 	#ifndef CompileVmudm
 	Cheat_r4300iOpcode(RSP_Vector_VMUDM,"RSP_Vector_VMUDM"); return;
@@ -2508,7 +2519,8 @@ void Compile_Vector_VMUDM ( void ) {
 	Pop(x86_EBP);
 }
 
-BOOL Compile_Vector_VMUDN_MMX ( void ) {
+Boolean Compile_Vector_VMUDN_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -2551,10 +2563,10 @@ BOOL Compile_Vector_VMUDN_MMX ( void ) {
 void Compile_Vector_VMUDN ( void ) {
 	char Reg[256];
 	int count, el, del;
-	
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
+
+    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
 
 	#ifndef CompileVmudn
 	Cheat_r4300iOpcode(RSP_Vector_VMUDN,"RSP_Vector_VMUDN"); return;
@@ -2611,7 +2623,8 @@ void Compile_Vector_VMUDN ( void ) {
 	Pop(x86_EBP);
 }
 
-BOOL Compile_Vector_VMUDH_MMX ( void ) {
+Boolean Compile_Vector_VMUDH_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -2690,9 +2703,9 @@ void Compile_Vector_VMUDH ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
+    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
 
 	#ifndef CompileVmudh
 	Cheat_r4300iOpcode(RSP_Vector_VMUDH,"RSP_Vector_VMUDH"); return;
@@ -2823,8 +2836,8 @@ void Compile_Vector_VMACF ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmacf
 	Cheat_r4300iOpcode(RSP_Vector_VMACF,"RSP_Vector_VMACF"); return;
@@ -2894,8 +2907,8 @@ void Compile_Vector_VMADL ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmadl
 	Cheat_r4300iOpcode(RSP_Vector_VMADL,"RSP_Vector_VMADL"); return;
@@ -2963,8 +2976,8 @@ void Compile_Vector_VMADM ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmadm
 	Cheat_r4300iOpcode(RSP_Vector_VMADM,"RSP_Vector_VMADM"); return;
@@ -3045,9 +3058,9 @@ void Compile_Vector_VMADM ( void ) {
 void Compile_Vector_VMADN ( void ) {
 	char Reg[256];
 	int count, el, del;
-	
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+
+    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmadn
 	Cheat_r4300iOpcode(RSP_Vector_VMADN,"RSP_Vector_VMADN"); return;
@@ -3120,8 +3133,8 @@ void Compile_Vector_VMADH ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmadh
 	Cheat_r4300iOpcode(RSP_Vector_VMADH,"RSP_Vector_VMADH"); return;
@@ -3245,7 +3258,8 @@ void Compile_Vector_VMADH ( void ) {
 	}
 }
 
-BOOL Compile_Vector_VADD_MMX ( void ) {
+Boolean Compile_Vector_VADD_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -3295,11 +3309,10 @@ void Compile_Vector_VADD ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bElement = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
-	BOOL bFlagUseage = UseRspFlags(CompilePC);
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bFlagUseage = UseRspFlags(CompilePC);
 
 	#ifndef CompileVadd
 	Cheat_r4300iOpcode(RSP_Vector_VADD,"RSP_Vector_VADD"); return;
@@ -3367,7 +3380,8 @@ void Compile_Vector_VADD ( void ) {
 	Pop(x86_EBP);
 }
 
-BOOL Compile_Vector_VSUB_MMX ( void ) {
+Boolean Compile_Vector_VSUB_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -3416,10 +3430,10 @@ void Compile_Vector_VSUB ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bOptimize = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
-	BOOL bFlagUseage = UseRspFlags(CompilePC);
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bFlagUseage = UseRspFlags(CompilePC);
 
 	#ifndef CompileVsub
 	Cheat_r4300iOpcode(RSP_Vector_VSUB,"RSP_Vector_VSUB"); return;
@@ -3489,7 +3503,8 @@ void Compile_Vector_VSUB ( void ) {
 	Pop(x86_EBP);
 }
 
-BOOL Compile_Vector_VABS_MMX ( void ) {
+Boolean Compile_Vector_VABS_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -3568,9 +3583,9 @@ BOOL Compile_Vector_VABS_MMX ( void ) {
 void Compile_Vector_VABS ( void ) {
 	int count, el, del;
 	char Reg[256];
-	
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 	#ifndef CompileVabs
 	Cheat_r4300iOpcode(RSP_Vector_VABS,"RSP_Vector_VABS"); return;
@@ -3665,10 +3680,10 @@ void Compile_Vector_VADDC ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
-	BOOL bElement = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+
 	#ifndef CompileVaddc
 	Cheat_r4300iOpcode(RSP_Vector_VADDC,"RSP_Vector_VADDC"); return;
 	#endif
@@ -3730,10 +3745,10 @@ void Compile_Vector_VSUBC ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
-	BOOL bElement = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+
 	#ifndef CompileVsubc
 	Cheat_r4300iOpcode(RSP_Vector_VSUBC,"RSP_Vector_VSUBC"); return;
 	#endif
@@ -3841,9 +3856,10 @@ void Compile_Vector_VSAW ( void ) {
 	MoveX86regToVariable(x86_EDX, &RSP_Vect[RSPOpC.sa].HW[6], Reg);
 }
 
-void Compile_Vector_VLT ( void ) {
-	BOOL bWriteToDest  = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+void Compile_Vector_VLT(void)
+{
+    Boolean bWriteToDest  = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 	BYTE *jump[3];
 	DWORD flag;
 	char Reg[256];
@@ -3932,9 +3948,10 @@ void Compile_Vector_VLT ( void ) {
 	}
 }
 
-void Compile_Vector_VEQ ( void ) {
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+void Compile_Vector_VEQ(void)
+{
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 	DWORD flag;
 	char Reg[256];
 	int count, el, del, last = -1;
@@ -3998,9 +4015,10 @@ void Compile_Vector_VEQ ( void ) {
 	}
 }
 
-void Compile_Vector_VNE ( void ) {
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+void Compile_Vector_VNE(void)
+{
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 	DWORD flag;
 	char Reg[256];
 	int el, del, last = -1;
@@ -4058,7 +4076,8 @@ void Compile_Vector_VNE ( void ) {
 	}
 }
 
-BOOL Compile_Vector_VGE_MMX ( void ) {
+Boolean Compile_Vector_VGE_MMX(void)
+{
 	char Reg[256];
 
 	if ((RSPOpC.rs & 0xF) >= 2 && (RSPOpC.rs & 0xF) <= 7 && IsMmx2Enabled == FALSE)
@@ -4099,8 +4118,9 @@ BOOL Compile_Vector_VGE_MMX ( void ) {
 	return TRUE;
 }
 
-void Compile_Vector_VGE ( void ) {
-/*	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+void Compile_Vector_VGE(void)
+{ /*
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 	/* FIXME: works ok, but needs careful flag analysis */
 /*	#if defined (DLIST)
@@ -4109,8 +4129,8 @@ void Compile_Vector_VGE ( void ) {
 	}
 	#endif
 */
-	BOOL bWriteToDest  = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bWriteToDest  = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 	BYTE *jump[3];
 	DWORD flag;
 	char Reg[256];
@@ -4217,7 +4237,7 @@ void Compile_Vector_VCR ( void ) {
 void Compile_Vector_VMRG ( void ) {
 	char Reg[256];
 	int count, el, del;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 	#ifndef CompileVmrg
 	Cheat_r4300iOpcode(RSP_Vector_VMRG,"RSP_Vector_VMRG"); return;
@@ -4249,7 +4269,8 @@ void Compile_Vector_VMRG ( void ) {
 	}
 }
 
-BOOL Compile_Vector_VAND_MMX ( void ) {
+Boolean Compile_Vector_VAND_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -4289,12 +4310,13 @@ BOOL Compile_Vector_VAND_MMX ( void ) {
 	return TRUE;
 }
 
-void Compile_Vector_VAND ( void ) {
+void Compile_Vector_VAND(void)
+{
 	char Reg[256];
 	int el, del, count;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bElement = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 	#ifndef CompileVand
 	Cheat_r4300iOpcode(RSP_Vector_VAND,"RSP_Vector_VAND"); return;
@@ -4341,7 +4363,8 @@ void Compile_Vector_VAND ( void ) {
 	}
 }
 
-BOOL Compile_Vector_VNAND_MMX ( void ) {
+Boolean Compile_Vector_VNAND_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -4387,9 +4410,9 @@ BOOL Compile_Vector_VNAND_MMX ( void ) {
 void Compile_Vector_VNAND ( void ) {
 	char Reg[256];
 	int el, del, count;
-	BOOL bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-	BOOL bElement = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
+    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 #ifndef CompileVnand
 	Cheat_r4300iOpcode(RSP_Vector_VNAND, "RSP_Vector_VNAND"); return;
@@ -4438,7 +4461,8 @@ void Compile_Vector_VNAND ( void ) {
 	}
 }
 
-BOOL Compile_Vector_VOR_MMX ( void ) {
+Boolean Compile_Vector_VOR_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -4483,8 +4507,8 @@ BOOL Compile_Vector_VOR_MMX ( void ) {
 void Compile_Vector_VOR ( void ) {
 	char Reg[256];
 	int el, del, count;
-	BOOL bElement = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 #ifndef CompileVor
 	Cheat_r4300iOpcode(RSP_Vector_VOR, "RSP_Vector_VOR"); return;
@@ -4528,7 +4552,8 @@ void Compile_Vector_VOR ( void ) {
 	}
 }
 
-BOOL Compile_Vector_VNOR_MMX ( void ) {
+Boolean Compile_Vector_VNOR_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -4574,8 +4599,8 @@ BOOL Compile_Vector_VNOR_MMX ( void ) {
 void Compile_Vector_VNOR ( void ) {
 	char Reg[256];
 	int el, del, count;
-	BOOL bElement = ((RSPOpC.rs & 0x0f) >= 8) ? TRUE : FALSE;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 #ifndef CompileVnor
 	Cheat_r4300iOpcode(RSP_Vector_VNOR, "RSP_Vector_VNOR"); return;
@@ -4621,7 +4646,8 @@ void Compile_Vector_VNOR ( void ) {
 	}
 }
 
-BOOL Compile_Vector_VXOR_MMX ( void ) {
+Boolean Compile_Vector_VXOR_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -4675,11 +4701,12 @@ BOOL Compile_Vector_VXOR_MMX ( void ) {
 	return TRUE;
 }
 
-void Compile_Vector_VXOR ( void ) {
-	#ifdef CompileVxor
-		char Reg[256];
-		DWORD count;
-		BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+void Compile_Vector_VXOR(void)
+{
+#ifdef CompileVxor
+    char Reg[256];
+    DWORD count;
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 		CPU_Message("  %X %s", CompilePC, RSPOpcodeName(RSPOpC.Hex, CompilePC));
 
@@ -4700,7 +4727,8 @@ void Compile_Vector_VXOR ( void ) {
 	Cheat_r4300iOpcodeNoMessage(RSP_Vector_VXOR, "RSP_Vector_VXOR");
 }
 
-BOOL Compile_Vector_VNXOR_MMX ( void ) {
+Boolean Compile_Vector_VNXOR_MMX(void)
+{
 	char Reg[256];
 
 	/* Do our MMX checks here */
@@ -4757,11 +4785,12 @@ BOOL Compile_Vector_VNXOR_MMX ( void ) {
 	return TRUE;
 }
 
-void Compile_Vector_VNXOR ( void ) {
-	#ifdef CompileVnxor
-		char Reg[256];
-		DWORD count;
-		BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+void Compile_Vector_VNXOR(void)
+{
+#ifdef CompileVnxor
+    char Reg[256];
+    DWORD count;
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 		CPU_Message("  %X %s", CompilePC, RSPOpcodeName(RSPOpC.Hex, CompilePC));
 
@@ -4785,9 +4814,9 @@ void Compile_Vector_VNXOR ( void ) {
 void Compile_Vector_VRCP ( void ) {
 	char Reg[256];
 	int count, el, last;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 	DWORD *end = NULL;
-	
+
 #ifndef CompileVrcp
 	Cheat_r4300iOpcode(RSP_Vector_VRCP,"RSP_Vector_VRCP");
 	return;
@@ -4851,7 +4880,7 @@ void Compile_Vector_VRCP ( void ) {
 void Compile_Vector_VRCPL ( void ) {
 	char Reg[256];
 	int count, el, last;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 	DWORD *end = NULL;
 
 #ifndef CompileVrcpl
@@ -4924,7 +4953,7 @@ void Compile_Vector_VRCPL ( void ) {
 void Compile_Vector_VRCPH ( void ) {
 	char Reg[256];
 	int count, el, last;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 	#ifndef CompileVrcph
 	Cheat_r4300iOpcode(RSP_Vector_VRCPH,"RSP_Vector_VRCPH"); return;
@@ -4963,7 +4992,7 @@ void Compile_Vector_VRCPH ( void ) {
 void Compile_Vector_VMOV ( void ) {
 	char Reg[256];
 	int el, count;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 #ifndef CompileVmov
 	Cheat_r4300iOpcode(RSP_Vector_VMOV, "RSP_Vector_VMOV"); return;
 #endif
@@ -5003,7 +5032,7 @@ void Compile_Vector_VRSQL ( void ) {
 void Compile_Vector_VRSQH ( void ) {
 	char Reg[256];
 	int count, el, last;
-	BOOL bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
+    Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 	#ifndef CompileVrsqh
 	Cheat_r4300iOpcode(RSP_Vector_VRSQH,"RSP_Vector_VRSQH"); return;

--- a/Source/RSP/Recompiler Sections.c
+++ b/Source/RSP/Recompiler Sections.c
@@ -26,6 +26,7 @@
 
 #include <windows.h>
 #include <stdio.h>
+
 #include "Rsp.h"
 #include "CPU.h"
 #include "Recompiler CPU.h"
@@ -35,6 +36,7 @@
 #include "dma.h"
 #include "log.h"
 #include "x86.h"
+#include "Types.h"
 
 #pragma warning(disable : 4152) // nonstandard extension, function/data pointer conversion in expression
 
@@ -750,7 +752,8 @@ void RSP_Sections_VMACF ( OPCODE RspOp, DWORD AccumStyle ) {
 
 static DWORD Section_000_VMADN; /* Yah i know, but leave it */
 
-BOOL Check_Section_000(void) {
+Boolean Check_Section_000(void)
+{
 	DWORD i;
 	OPCODE op0, op1;
 
@@ -854,7 +857,8 @@ void Compile_Section_000(void) {
 
 static DWORD Section_001_VMACF;
 
-BOOL Check_Section_001(void) {
+Boolean Check_Section_001(void)
+{
 	DWORD i;
 	OPCODE op0, op1;
 
@@ -944,7 +948,8 @@ void Compile_Section_001(void) {
 	MmxEmptyMultimediaState();
 }
 
-BOOL Check_Section_002 ( void ) {
+Boolean Check_Section_002(void)
+{
 	DWORD Count;
 	OPCODE op[0x0C];
 
@@ -1049,7 +1054,8 @@ void Compile_Section_002 ( void ) {
 	CompilePC += 12 * sizeof(OPCODE);
 }
 
-BOOL Check_Section_003 ( void ) {
+Boolean Check_Section_003(void)
+{
 	DWORD Count;
 	OPCODE op[4];
 
@@ -1117,7 +1123,8 @@ void Compile_Section_003 ( void ) {
 	CompilePC += 4 * sizeof(OPCODE);
 }
 
-BOOL RSP_DoSections(void) {
+Boolean RSP_DoSections(void)
+{
 	if (TRUE == Check_Section_000()) {
 		Compile_Section_000();
 		return TRUE;

--- a/Source/RSP/Rsp.h
+++ b/Source/RSP/Rsp.h
@@ -46,8 +46,6 @@ extern "C" {
 #define Default_ShowErrors			FALSE
 #define Default_AudioHle			FALSE
 
-/* Note: BOOL, BYTE, WORD, DWORD, TRUE, FALSE are defined in windows.h */
-
 #define PLUGIN_TYPE_RSP				1
 #define PLUGIN_TYPE_GFX				2
 #define PLUGIN_TYPE_AUDIO			3

--- a/Source/RSP/Types.h
+++ b/Source/RSP/Types.h
@@ -45,6 +45,10 @@ typedef void(*p_func)(void);
  * Until then, a simple type definition will help emphasize true/false logic.
  */
 typedef int Boolean;
+#if !defined(FALSE) && !defined(TRUE)
+#define FALSE           0
+#define TRUE            1
+#endif
 
 typedef union tagUWORD {
     int32_t     W;

--- a/Source/RSP/X86.c
+++ b/Source/RSP/X86.c
@@ -26,11 +26,13 @@
 
 #include <windows.h>
 #include <stdio.h>
+
 #include "Rsp.h"
 #include "x86.h"
 #include "memory.h"
 #include "RSP registers.h"
 #include "log.h"
+#include "Types.h"
 
 #pragma warning(disable : 4152) // nonstandard extension, function/data pointer conversion in expression
 
@@ -55,7 +57,7 @@ char * x86_HalfStrings[8] = {
 	"si", "di", "bp", "sp"
 };
 
-extern BOOL ConditionalMove;
+extern Boolean ConditionalMove;
 
 #define x86Byte_Name(Reg) (x86_ByteStrings[(Reg)])
 #define x86Half_Name(Reg) (x86_HalfStrings[(Reg)])


### PR DESCRIPTION
Ctrl+F find all instances of `BOOL` in every .c, .cpp and .h file.  Manually type in "Boolean" instead, hopefully without making any typos.  (Was too lazy to Ctrl+C so I could just Ctrl+V instead. :P)  If any instances of BOOL were found and replaced, then make sure `#include "Types.h"` was added to the file just to be absolutely sure that it was.  (Though some sub-header probably included it...should look at adding #pragma once more often to some of these headers.)

The exception was WIN32-specific operating system code, like framework GUI and things like that in Main.cpp that I left saying BOOL in its own commit, simply wrapping that out under #ifdef _WIN32.

Needless to say I did the usual spacing/style adjustments along the way for any lines changed.

Since WIN32 typedef's BOOL to `int`, and I typedef Boolean to `int` as well, I don't think that will cause any compile errors to ensue on the Windows end of compiling this plugin.  At least not cause of that.

At the end of the day, I saw a few errors about undefined TRUE and FALSE.  These macros historically were independent of `<windows.h>` before, so I think they should be #define'd.