### PR TITLE
[RSP] Optimize compiling scalar whole selections.

### DIFF
--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -2976,7 +2976,7 @@ void Compile_Vector_VMADM ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-    Boolean bOptimize = (SPOpC.rs & 8) ? TRUE : FALSE;
+    Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmadm

--- a/Source/RSP/Recompiler Ops.c
+++ b/Source/RSP/Recompiler Ops.c
@@ -2124,7 +2124,7 @@ Boolean Compile_Vector_VMULF_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	/* NOTE: Problem here is the lack of +/- 0x8000 rounding */
@@ -2143,7 +2143,7 @@ Boolean Compile_Vector_VMULF_MMX(void)
 			sprintf(Reg, "RSP_Vect[%i].UHW[4]", RSPOpC.rt);
 			MmxPmulhwRegToVariable(x86_MM1, &RSP_Vect[RSPOpC.rt].UHW[4], Reg);
 		}
-	} else if ((RSPOpC.rs & 0xF) >= 8) {
+	} else if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM2);
 		MmxPmulhwRegToReg(x86_MM0, x86_MM2);
 		MmxPmulhwRegToReg(x86_MM1, x86_MM2);
@@ -2170,7 +2170,7 @@ void Compile_Vector_VMULF ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
@@ -2273,7 +2273,7 @@ Boolean Compile_Vector_VMUDL_MMX(void)
 			MmxPmulhuwRegToReg(x86_MM0, x86_MM2);
 			MmxPmulhuwRegToReg(x86_MM1, x86_MM3);
 		}
-	} else if ((RSPOpC.rs & 0xF) >= 8) {
+	} else if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM2);
 		MmxPmulhuwRegToReg(x86_MM0, x86_MM2);
 		MmxPmulhuwRegToReg(x86_MM1, x86_MM2);
@@ -2298,7 +2298,7 @@ void Compile_Vector_VMUDL ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-	Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+	Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
 	Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 	Boolean bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
 
@@ -2386,7 +2386,7 @@ Boolean Compile_Vector_VMUDM_MMX(void)
 		MmxPsrawImmed(x86_MM3, 15);
 		MmxPmullwRegToReg(x86_MM2, x86_MM4);
 		MmxPmullwRegToReg(x86_MM3, x86_MM5);
-	} else if ((RSPOpC.rs & 0xF) >= 8) {
+	} else if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM4);
 
 		/* Copy the signed portion */
@@ -2439,7 +2439,7 @@ void Compile_Vector_VMUDM ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
     Boolean bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
 
@@ -2526,7 +2526,7 @@ Boolean Compile_Vector_VMUDN_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	sprintf(Reg, "RSP_Vect[%i].UHW[0]", RSPOpC.rd);
@@ -2539,7 +2539,7 @@ Boolean Compile_Vector_VMUDN_MMX(void)
 		MmxPmullwVariableToReg(x86_MM0, &RSP_Vect[RSPOpC.rt].UHW[0], Reg);
 		sprintf(Reg, "RSP_Vect[%i].UHW[4]", RSPOpC.rt);
 		MmxPmullwVariableToReg(x86_MM1, &RSP_Vect[RSPOpC.rt].UHW[4], Reg);
-	} else if ((RSPOpC.rs & 0xF) >= 8) {
+	} else if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM2);
 		MmxPmullwRegToReg(x86_MM0, x86_MM2);
 		MmxPmullwRegToReg(x86_MM1, x86_MM2);
@@ -2564,7 +2564,7 @@ void Compile_Vector_VMUDN ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
     Boolean bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
 
@@ -2630,7 +2630,7 @@ Boolean Compile_Vector_VMUDH_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	sprintf(Reg, "RSP_Vect[%i].HW[0]", RSPOpC.rd);
@@ -2659,7 +2659,7 @@ Boolean Compile_Vector_VMUDH_MMX(void)
 			MmxPmullwRegToReg(x86_MM1, x86_MM3);
 			MmxPmulhwRegToReg(x86_MM5, x86_MM3);
 		}
-	} else if ((RSPOpC.rs & 0x0f) >= 8) {
+	} else if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM2);
 
 		MmxPmullwRegToReg(x86_MM0, x86_MM2);
@@ -2703,7 +2703,7 @@ void Compile_Vector_VMUDH ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
     Boolean bWriteToAccum = WriteToAccum(EntireAccum, CompilePC);
 
@@ -2836,7 +2836,7 @@ void Compile_Vector_VMACF ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmacf
@@ -2907,7 +2907,7 @@ void Compile_Vector_VMADL ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmadl
@@ -2976,7 +2976,7 @@ void Compile_Vector_VMADM ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bOptimize = (SPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmadm
@@ -3059,7 +3059,7 @@ void Compile_Vector_VMADN ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmadn
@@ -3133,7 +3133,7 @@ void Compile_Vector_VMADH ( void ) {
 	char Reg[256];
 	int count, el, del;
 
-    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
 
 	#ifndef CompileVmadh
@@ -3265,7 +3265,7 @@ Boolean Compile_Vector_VADD_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	sprintf(Reg, "RSP_Vect[%i].UHW[0]", RSPOpC.rd);
@@ -3273,7 +3273,7 @@ Boolean Compile_Vector_VADD_MMX(void)
 	sprintf(Reg, "RSP_Vect[%i].UHW[4]", RSPOpC.rd);
 	MmxMoveQwordVariableToReg(x86_MM1, &RSP_Vect[RSPOpC.rd].UHW[4], Reg);
 
-	if ((RSPOpC.rs & 15) >= 8) {
+	if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM2);
 		MmxPaddswRegToReg(x86_MM0, x86_MM2);
 		MmxPaddswRegToReg(x86_MM1, x86_MM2);
@@ -3310,7 +3310,7 @@ void Compile_Vector_VADD ( void ) {
 	int count, el, del;
 
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bElement = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
     Boolean bFlagUseage = UseRspFlags(CompilePC);
 
@@ -3387,7 +3387,7 @@ Boolean Compile_Vector_VSUB_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	sprintf(Reg, "RSP_Vect[%i].UHW[0]", RSPOpC.rd);
@@ -3431,7 +3431,7 @@ void Compile_Vector_VSUB ( void ) {
 	int count, el, del;
 
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-    Boolean bOptimize = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bOptimize = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
     Boolean bFlagUseage = UseRspFlags(CompilePC);
 
@@ -3510,7 +3510,7 @@ Boolean Compile_Vector_VABS_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	sprintf(Reg, "RSP_Vect[%i].UHW[0]", RSPOpC.rd);
@@ -3682,7 +3682,7 @@ void Compile_Vector_VADDC ( void ) {
 
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
     Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
-    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bElement = (RSPOpC.rs & 8) ? TRUE : FALSE;
 
 	#ifndef CompileVaddc
 	Cheat_r4300iOpcode(RSP_Vector_VADDC,"RSP_Vector_VADDC"); return;
@@ -3747,7 +3747,7 @@ void Compile_Vector_VSUBC ( void ) {
 
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
     Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
-    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bElement = (RSPOpC.rs & 8) ? TRUE : FALSE;
 
 	#ifndef CompileVsubc
 	Cheat_r4300iOpcode(RSP_Vector_VSUBC,"RSP_Vector_VSUBC"); return;
@@ -4080,7 +4080,7 @@ Boolean Compile_Vector_VGE_MMX(void)
 {
 	char Reg[256];
 
-	if ((RSPOpC.rs & 0xF) >= 2 && (RSPOpC.rs & 0xF) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0xF) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	CPU_Message("  %X %s",CompilePC,RSPOpcodeName(RSPOpC.Hex,CompilePC));
@@ -4098,19 +4098,19 @@ Boolean Compile_Vector_VGE_MMX(void)
 		MmxMoveQwordVariableToReg(x86_MM4, &RSP_Vect[RSPOpC.rt].HW[0], Reg);
 		sprintf(Reg, "RSP_Vect[%i].HW[4]", RSPOpC.rt);
 		MmxMoveQwordVariableToReg(x86_MM5, &RSP_Vect[RSPOpC.rt].HW[4], Reg);
-	} else if ((RSPOpC.rs & 0x0f) >= 8) {
+	} else if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM4);
 	} else {
 		RSP_MultiElement2Mmx(x86_MM4, x86_MM5);
 	}
 
 	MmxCompareGreaterWordRegToReg(x86_MM2, x86_MM4);
-	MmxCompareGreaterWordRegToReg(x86_MM3, ((RSPOpC.rs & 0x0f) >= 8) ? x86_MM4 : x86_MM5);
+	MmxCompareGreaterWordRegToReg(x86_MM3, (RSPOpC.rs & 8) ? x86_MM4 : x86_MM5);
 
 	MmxPandRegToReg(x86_MM0, x86_MM2);
 	MmxPandRegToReg(x86_MM1, x86_MM3);
 	MmxPandnRegToReg(x86_MM2, x86_MM4);
-	MmxPandnRegToReg(x86_MM3, ((RSPOpC.rs & 0x0f) >= 8) ? x86_MM4 : x86_MM5);
+	MmxPandnRegToReg(x86_MM3, (RSPOpC.rs & 8) ? x86_MM4 : x86_MM5);
 
 	MmxPorRegToReg(x86_MM0, x86_MM2);
 	MmxPorRegToReg(x86_MM1, x86_MM3);
@@ -4276,7 +4276,7 @@ Boolean Compile_Vector_VAND_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	sprintf(Reg, "RSP_Vect[%i].UHW[0]", RSPOpC.rd);
@@ -4284,7 +4284,7 @@ Boolean Compile_Vector_VAND_MMX(void)
 	sprintf(Reg, "RSP_Vect[%i].UHW[4]", RSPOpC.rd);
 	MmxMoveQwordVariableToReg(x86_MM1, &RSP_Vect[RSPOpC.rd].UHW[4], Reg);
 
-	if ((RSPOpC.rs & 0xF) >= 8) {
+	if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM2);
 		MmxPandRegToReg(x86_MM0, x86_MM2);
 		MmxPandRegToReg(x86_MM1, x86_MM2);
@@ -4315,7 +4315,7 @@ void Compile_Vector_VAND(void)
 	char Reg[256];
 	int el, del, count;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bElement = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 	#ifndef CompileVand
@@ -4370,7 +4370,7 @@ Boolean Compile_Vector_VNAND_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	sprintf(Reg, "RSP_Vect[%i].UHW[0]", RSPOpC.rd);
@@ -4379,7 +4379,7 @@ Boolean Compile_Vector_VNAND_MMX(void)
 	MmxMoveQwordVariableToReg(x86_MM1, &RSP_Vect[RSPOpC.rd].UHW[4], Reg);
 	MmxPcmpeqwRegToReg(x86_MM7, x86_MM7);
 
-	if ((RSPOpC.rs & 0xF) >= 8) {
+	if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM2);
 		MmxPandRegToReg(x86_MM0, x86_MM2);
 		MmxPandRegToReg(x86_MM1, x86_MM2);
@@ -4411,7 +4411,7 @@ void Compile_Vector_VNAND ( void ) {
 	char Reg[256];
 	int el, del, count;
     Boolean bWriteToDest = WriteToVectorDest(RSPOpC.sa, CompilePC);
-    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bElement = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 #ifndef CompileVnand
@@ -4468,7 +4468,7 @@ Boolean Compile_Vector_VOR_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	sprintf(Reg, "RSP_Vect[%i].UHW[0]", RSPOpC.rd);
@@ -4478,7 +4478,7 @@ Boolean Compile_Vector_VOR_MMX(void)
 
 	if ((RSPOpC.rs & 0xF) < 2 && (RSPOpC.rd == RSPOpC.rt)) {
 
-	} else if ((RSPOpC.rs & 0xF) >= 8) {
+	} else if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM2);
 		MmxPorRegToReg(x86_MM0, x86_MM2);
 		MmxPorRegToReg(x86_MM1, x86_MM2);
@@ -4507,7 +4507,7 @@ Boolean Compile_Vector_VOR_MMX(void)
 void Compile_Vector_VOR ( void ) {
 	char Reg[256];
 	int el, del, count;
-    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bElement = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 #ifndef CompileVor
@@ -4559,7 +4559,7 @@ Boolean Compile_Vector_VNOR_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	sprintf(Reg, "RSP_Vect[%i].UHW[0]", RSPOpC.rd);
@@ -4568,7 +4568,7 @@ Boolean Compile_Vector_VNOR_MMX(void)
 	MmxMoveQwordVariableToReg(x86_MM1, &RSP_Vect[RSPOpC.rd].UHW[4], Reg);
 	MmxPcmpeqwRegToReg(x86_MM7, x86_MM7);
 
-	if ((RSPOpC.rs & 0xF) >= 8) {
+	if (RSPOpC.rs & 8) {
 		RSP_Element2Mmx(x86_MM2);
 		MmxPorRegToReg(x86_MM0, x86_MM2);
 		MmxPorRegToReg(x86_MM1, x86_MM2);
@@ -4599,7 +4599,7 @@ Boolean Compile_Vector_VNOR_MMX(void)
 void Compile_Vector_VNOR ( void ) {
 	char Reg[256];
 	int el, del, count;
-    Boolean bElement = ((RSPOpC.rs & 0xF) >= 8) ? TRUE : FALSE;
+    Boolean bElement = (RSPOpC.rs & 8) ? TRUE : FALSE;
     Boolean bWriteToAccum = WriteToAccum(Low16BitAccum, CompilePC);
 
 #ifndef CompileVnor
@@ -4653,7 +4653,7 @@ Boolean Compile_Vector_VXOR_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	if ((RSPOpC.rs & 0xF) < 2 && (RSPOpC.rd == RSPOpC.rt)) {
@@ -4671,7 +4671,7 @@ Boolean Compile_Vector_VXOR_MMX(void)
 		sprintf(Reg, "RSP_Vect[%i].UHW[4]", RSPOpC.rd);
 		MmxMoveQwordVariableToReg(x86_MM1, &RSP_Vect[RSPOpC.rd].UHW[4], Reg);
 
-		if ((RSPOpC.rs & 0xF) >= 8) {
+		if (RSPOpC.rs & 8) {
 			RSP_Element2Mmx(x86_MM2);
 			MmxXorRegToReg(x86_MM0, x86_MM2);
 			MmxXorRegToReg(x86_MM1, x86_MM2);
@@ -4734,7 +4734,7 @@ Boolean Compile_Vector_VNXOR_MMX(void)
 	/* Do our MMX checks here */
 	if (IsMmxEnabled == FALSE)
 		return FALSE;
-	if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE)
+	if ((RSPOpC.rs & 0x0f) >= 2 && !(RSPOpC.rs & 8) && IsMmx2Enabled == FALSE)
 		return FALSE;
 
 	if ((RSPOpC.rs & 0xF) < 2 && (RSPOpC.rd == RSPOpC.rt)) {
@@ -4753,7 +4753,7 @@ Boolean Compile_Vector_VNXOR_MMX(void)
 		MmxMoveQwordVariableToReg(x86_MM1, &RSP_Vect[RSPOpC.rd].UHW[4], Reg);
 		MmxPcmpeqwRegToReg(x86_MM7, x86_MM7);
 
-		if ((RSPOpC.rs & 0xF) >= 8) {
+		if (RSPOpC.rs & 8) {
 			RSP_Element2Mmx(x86_MM2);
 			MmxXorRegToReg(x86_MM0, x86_MM2);
 			MmxXorRegToReg(x86_MM1, x86_MM2);


### PR DESCRIPTION
Not that I care or anything about this particular section, but as I was forced to look at this code while I was fixing the BOOL errors I felt inclined to simplify for size and fewer instructions.
```c
bool
f(unsigned x)
{
 // return ((x & 0xF) >= 0x8); # AND eax, 15; CMP eax, 7; SETG al;
    return ((x & 8) ? true : false); # SHR eax, 3; AND eax, 1;
} # .ident	"GCC: (GNU) 4.8.2"
```
There are way more optimizations (similar to this) that could be done throughout the rest of the RSP re-compiler translations.  I have had the pleasure of not being forced to look at those parts of the code.

I will give two examples though.  First:
```c
if ((RSPOpC.rs & 0x0f) >= 2 && (RSPOpC.rs & 0x0f) <= 7 && IsMmx2Enabled == FALSE) {
```
As `((x & 0xF) >= 0x2)` is identical to saying `!(x & ~0x1)`, we have 3 FALSE's.
```c
if NOT(!!(x & ~0x1) & !!(RSPOpC.rs & 0x8) & IsMmx2Enabled/*=true*/) {
```
(I prefer the double exclamation marks, `!!(x & y)`, as this is more compact than a ternary ? 1 : 0.  I personally think of !!(x & y) as the "is bit set?" operator.)

A related, second example of what can be optimized in the compiler:
```c
	if (bOptimize == TRUE) {
		del = (RSPOpC.rs & 0x07) ^ 7;
```
The whole point of `bOptimize` being true is that (rs & 0x8) is true, so we know that (rs ^ 0x8) is the same as doing (rs & ~0x8) in all of those cases.  Therefore, rewrite the & to a ^ for a combined XOR:
```c
if (bOptimize) {
    del = RSPOpC.rs ^ 0x1F; /* better yet, ~(RSPOpC.rs) */
```