### PR TITLE
SigmaVirus CF=1 fix to PAL Super Smash Bros.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1,4 +1,4 @@
-﻿// ============ RDB for PJ64 v2.2. GoodN64 v321 =====================================
+// ============ RDB for PJ64 v2.2. GoodN64 v321 =====================================
 // PJ64 v2.2 Official RDB
 // Not for use with PJ64 v1.6 or previous
 //---- START OF RDB FILE HEADER ---------------------------------------------------------
@@ -5548,6 +5548,7 @@ ViRefresh=2200
 Good Name=Super Smash Bros. (E) (M3)
 Internal Name=SMASH BROTHERS
 Status=Compatible
+Counter Factor=1
 Culling=1
 SMM-Cache=0
 SMM-FUNC=0


### PR DESCRIPTION
He reported the PAL issue #1015 and his fix:  `Counter Factor=1`, which is all that is relevant to the specific issue here.  Though I was hoping he might have done this PR himself, I can do it if need be.

Sorry, no clue why line number 1 got changed here.
EDIT:  Looks like it's an auto-fix to https://github.com/project64/project64/commit/6d4cb1c2e3268a34bae7c5272533ec9c87de3474#diff-6ed817341fe13121d9cae89c071156ccL1