### PR TITLE
SigmaVirus Linking=off fix to PAL Shadows of the Empire

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -5318,6 +5318,7 @@ Good Name=Star Wars - Shadows of the Empire (E)
 Internal Name=Shadow of the Empire
 Status=Compatible
 Core Note=Swoop bike speed issue
+Linking=Off
 RDRAM Size=8
 
 [264D7E5C-18874622-C:45]


### PR DESCRIPTION
This should fix #1014 - Level select is freezing on Star Wars - Shadows of the Empire at least for the PAL/Europe version.