### PR TITLE
Exclude OGLESwrappers.cpp also from x64 build.

### DIFF
--- a/Source/Glitch64/Glitch64.vcxproj
+++ b/Source/Glitch64/Glitch64.vcxproj
@@ -55,7 +55,7 @@
       <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="OGLESwrappers.cpp">
-      <ExcludedFromBuild Condition="'$(Platform)'=='Win32'">true</ExcludedFromBuild>
+      <ExcludedFromBuild>true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="OGLgeometry.cpp" />
     <ClCompile Include="OGLglitchmain.cpp" />


### PR DESCRIPTION
Currently, OGLESwrappers.cpp is excluded from build only on the Win32 platform.
This change removes the contidion, making Windows64 build again.