### PR TITLE
Set CF=1 for the Ganbare Goemon games

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -2020,12 +2020,14 @@ RDRAM Size=8
 Good Name=Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J)
 Internal Name=GOEMON2 DERODERO
 Status=Compatible
+Counter Factor=1
 
 [832C168B-56A2CDAE-C:4A]
 Good Name=Ganbare Goemon - Neo Momoyama Bakufu no Odori (J)
 Internal Name=GANBAKE GOEMON
 Status=Compatible
 Culling=1
+Counter Factor=1
 RDRAM Size=8
 
 [21FFFD0A-FA0D1D98-C:4A]
@@ -2125,6 +2127,7 @@ Status=Compatible
 Good Name=Goemon's Great Adventure (U)
 Internal Name=GOEMONS GREAT ADV
 Status=Compatible
+Counter Factor=1
 
 [4690FB1C-4CD56D44-C:45]
 Good Name=Golden Nugget 64 (U)
@@ -3602,17 +3605,22 @@ Good Name=Mystical Ninja 2 Starring Goemon (E) (M3)
 Internal Name=MYSTICAL NINJA2 SG
 Status=Compatible
 Counter Factor=1
+Culling=1
 
 [F5360FBE-2BF1691D-C:50]
 Good Name=Mystical Ninja Starring Goemon (E)
 Internal Name=MYSTICAL NINJA
 Status=Compatible
+Counter Factor=1
+Culling=1
 RDRAM Size=8
 
 [FCBCCB21-72903C6B-C:45]
 Good Name=Mystical Ninja Starring Goemon (U)
 Internal Name=MYSTICAL NINJA
 Status=Compatible
+Counter Factor=1
+Culling=1
 RDRAM Size=8
 
 //================  N  ================

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -2128,6 +2128,7 @@ Good Name=Goemon's Great Adventure (U)
 Internal Name=GOEMONS GREAT ADV
 Status=Compatible
 Counter Factor=1
+Culling=1
 
 [4690FB1C-4CD56D44-C:45]
 Good Name=Golden Nugget 64 (U)

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -2021,13 +2021,14 @@ Good Name=Ganbare Goemon - Derodero Douchuu Obake Tenkomori (J)
 Internal Name=GOEMON2 DERODERO
 Status=Compatible
 Counter Factor=1
+Culling=1
 
 [832C168B-56A2CDAE-C:4A]
 Good Name=Ganbare Goemon - Neo Momoyama Bakufu no Odori (J)
 Internal Name=GANBAKE GOEMON
 Status=Compatible
-Culling=1
 Counter Factor=1
+Culling=1
 RDRAM Size=8
 
 [21FFFD0A-FA0D1D98-C:4A]


### PR DESCRIPTION
Fixes the out-of-sync intro
Compared against a real N64

Also made Culling=1 consistent across all the games that support it for small speedup using Jabo's D3D8