### PR TITLE
Port @Gonetz Bomberman 2 blend mode to Glide64.

### DIFF
--- a/Source/Glide64/Combine.cpp
+++ b/Source/Glide64/Combine.cpp
@@ -15867,6 +15867,10 @@ void CombineBlender()
         case 0x5000: /* Vigilante 8 explosions */
             A_BLEND(GR_BLEND_ONE_MINUS_SRC_ALPHA, GR_BLEND_SRC_ALPHA);
             break;
+            
+            case 0xFA00: // Bomberman second attack
+				A_BLEND(GR_BLEND_ONE, GR_BLEND_ZERO);
+				break;
 
         default:
             A_BLEND(GR_BLEND_SRC_ALPHA, GR_BLEND_ONE_MINUS_SRC_ALPHA);


### PR DESCRIPTION
I haven't tested this personally, since I can't load the save states because PJ64 has broken save state loading. But it should work. I personally want to see Glide64 replaced as soon as possible, but there's no harm porting such an obvious bug fix.