### PR TITLE
[Glitch64] Fix missing GL extension prototypes on non-ES, non-WIN32 systems.

### DIFF
--- a/Source/Glitch64/OGLtextures.cpp
+++ b/Source/Glitch64/OGLtextures.cpp
@@ -50,7 +50,7 @@ typedef struct _texlist
 static int nbTex = 0;
 static texlist *list = NULL;
 
-#ifdef _WIN32
+#if !defined(__ANDROID__) && !defined(ANDROID)
 extern PFNGLDELETERENDERBUFFERSEXTPROC glDeleteRenderbuffersEXT;
 extern PFNGLDELETEFRAMEBUFFERSEXTPROC glDeleteFramebuffersEXT;
 extern PFNGLCOMPRESSEDTEXIMAGE2DARBPROC glCompressedTexImage2DARB;

--- a/Source/Glitch64/glitchmain.h
+++ b/Source/Glitch64/glitchmain.h
@@ -46,6 +46,14 @@ extern int buffer_cleared; // mark that the buffer has been cleared, used to che
 
 #ifdef _WIN32
 #include <windows.h>
+typedef const char * (WINAPI * PFNWGLGETEXTENSIONSSTRINGARBPROC)(HDC hdc);
+#else
+#include <stdio.h>
+#endif
+
+#if defined(__ANDROID__) || defined(ANDROID)
+#include "OGLESwrappers.h"
+#else
 #include "opengl.h"
 
 extern "C" {
@@ -78,12 +86,9 @@ extern "C" {
     extern PFNGLUNIFORM4FARBPROC glUniform4fARB;
     extern PFNGLUSEPROGRAMOBJECTARBPROC glUseProgramObjectARB;
     extern PFNGLGETHANDLEARBPROC glGetHandleARB;
-    typedef const char * (WINAPI * PFNWGLGETEXTENSIONSSTRINGARBPROC) (HDC hdc);
 }
-#else
-#include <stdio.h>
-#include "OGLESwrappers.h"
-#endif // _WIN32
+#endif
+
 #include "glide.h"
 
 void init_geometry();

--- a/Source/Glitch64/glitchmain.h
+++ b/Source/Glitch64/glitchmain.h
@@ -57,7 +57,10 @@ typedef const char * (WINAPI * PFNWGLGETEXTENSIONSSTRINGARBPROC)(HDC hdc);
 #include "opengl.h"
 
 extern "C" {
+#ifndef GL_VERSION_1_3
     extern PFNGLACTIVETEXTUREARBPROC glActiveTextureARB;
+    extern PFNGLMULTITEXCOORD2FARBPROC glMultiTexCoord2fARB;
+#endif
     extern PFNGLATTACHOBJECTARBPROC glAttachObjectARB;
     extern PFNGLBINDFRAMEBUFFEREXTPROC glBindFramebufferEXT;
     extern PFNGLBINDRENDERBUFFEREXTPROC glBindRenderbufferEXT;
@@ -77,7 +80,6 @@ extern "C" {
     extern PFNGLGETOBJECTPARAMETERIVARBPROC glGetObjectParameterivARB;
     extern PFNGLGETUNIFORMLOCATIONARBPROC glGetUniformLocationARB;
     extern PFNGLLINKPROGRAMARBPROC glLinkProgramARB;
-    extern PFNGLMULTITEXCOORD2FARBPROC glMultiTexCoord2fARB;
     extern PFNGLRENDERBUFFERSTORAGEEXTPROC glRenderbufferStorageEXT;
     extern PFNGLSECONDARYCOLOR3FPROC glSecondaryColor3f;
     extern PFNGLSHADERSOURCEARBPROC glShaderSourceARB;


### PR DESCRIPTION
Don't use #ifdef _WIN32 unless it really is WIN32-specific code.
Anything taken from the extensions list applies to any version of desktop OpenGL.

Also, the following prototypes:
```c
extern PFNGLACTIVETEXTUREARBPROC glActiveTextureARB;
extern PFNGLMULTITEXCOORD2FARBPROC glMultiTexCoord2fARB;
```

Those features are **core** to OpenGL 1.3, which Linux natively supports, so declaring those extern's results in conflicting definitions.  (Windows on the other hand has GL 1.1 only for core implementation, in which those names were never defined anyway.)  It's correct to use #ifndef GL_VERSION_1_3 preprocessor logic here to see whether the implementation of `#include <GL/gl.h>` has less than GL 1.3 core support in it, which may be the case with Windows but not with Mac or Linux.