### PR TITLE
[Glide64] [Glitch64] fixed non-WIN32 regressions from 52aea87

### DIFF
--- a/Source/Glide64/GlideExtensions.h
+++ b/Source/Glide64/GlideExtensions.h
@@ -44,20 +44,31 @@ typedef FxU32 GrCombineMode_t;
 
 #define GR_TEXTURE_UMA_EXT                0x06
 //wrapper specific
-#ifdef _WIN32
-FX_ENTRY void FX_CALL grConfigWrapperExt(FxI32, FxI32, FxBool, FxBool);
-#else
-FX_ENTRY void FX_CALL grConfigWrapperExt(FxI32, FxBool, FxBool);
+FX_ENTRY void FX_CALL grConfigWrapperExt(
+#ifndef ANDROID
+    FxI32, /* resolution parameter not supported on Android */
 #endif
+    FxI32,
+    FxBool,
+    FxBool
+);
 FX_ENTRY GrScreenResolution_t FX_CALL grWrapperFullScreenResolutionExt(FxU32*, FxU32*);
 FX_ENTRY char ** FX_CALL grQueryResolutionsExt(int32_t*);
 FX_ENTRY FxBool FX_CALL grKeyPressedExt(FxU32 key);
 FX_ENTRY void FX_CALL grGetGammaTableExt(FxU32, FxU32*, FxU32*, FxU32*);
 
-#ifdef _WIN32
-FX_ENTRY GrContext_t FX_CALL grSstWinOpenExt(HWND hWnd, GrScreenResolution_t screen_resolution, GrScreenRefresh_t refresh_rate, GrColorFormat_t color_format, GrOriginLocation_t origin_location, GrPixelFormat_t pixelformat, int nColBuffers, int nAuxBuffers);
-#else
-FX_ENTRY GrContext_t FX_CALL grSstWinOpenExt(GrScreenRefresh_t refresh_rate, GrColorFormat_t color_format, GrOriginLocation_t origin_location, GrPixelFormat_t pixelformat, int nColBuffers, int nAuxBuffers);
+FX_ENTRY GrContext_t FX_CALL grSstWinOpenExt(
+#ifndef ANDROID
+    HWND hWnd,
+    GrScreenResolution_t screen_resolution,
+#endif
+    GrScreenRefresh_t refresh_rate,
+    GrColorFormat_t color_format,
+    GrOriginLocation_t origin_location,
+    GrPixelFormat_t pixelformat,
+    int nColBuffers,
+    int nAuxBuffers
+);
 #endif
 
 //color combiner

--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -281,11 +281,13 @@ void ChangeSize()
 
 void ConfigWrapper()
 {
-#ifdef _WIN32
-    grConfigWrapperExt(g_settings->wrpResolution, g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic);
+    grConfigWrapperExt(
+#ifdef ANDROID
+        g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic
 #else
-    grConfigWrapperExt(g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic);
+        g_settings->wrpResolution, g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic
 #endif
+    );
 }
 
 void UseUnregisteredSetting(int /*SettingID*/)
@@ -859,6 +861,10 @@ int InitGfx()
     }
     //*/
 
+/*
+ * 2016.03.27 cxd4 -- to do:  #ifdef _WIN32 or #ifndef _ANDROID?
+ * Can't tell which one is correct here, but I think the latter.
+ */
 #ifdef _WIN32
     uint32_t res_data = g_settings->res_data;
     if (ev_fullscreen)
@@ -1401,7 +1407,7 @@ int CALL InitiateGFX(GFX_INFO Gfx_Info)
     ReadSettings();
     char name[21] = "DEFAULT";
     ReadSpecialSettings(name);
-#ifdef _WIN32
+#ifndef ANDROID
     g_settings->res_data_org = g_settings->res_data;
 #endif
 
@@ -1430,11 +1436,13 @@ int CALL InitiateGFX(GFX_INFO Gfx_Info)
     if (fb_depth_render_enabled)
         ZLUT_init();
 
+    grConfigWrapperExt(
 #ifdef _WIN32
-    grConfigWrapperExt(g_settings->wrpResolution, g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic);
+        g_settings->wrpResolution, g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic
 #else
-    grConfigWrapperExt(g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic);
+        g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic
 #endif
+    );
 
     grGlideInit();
     grSstSelect(0);

--- a/Source/Glide64/Settings.cpp
+++ b/Source/Glide64/Settings.cpp
@@ -6,7 +6,7 @@ res_x(640),
 scr_res_x(640),
 res_y(480),
 scr_res_y(480),
-#ifdef _WIN32
+#ifndef ANDROID
 res_data(GR_RESOLUTION_640x480),
 res_data_org(GR_RESOLUTION_640x480),
 #endif
@@ -94,7 +94,7 @@ n64_z_scale(0), //scale vertex z value before writing to depth buffer, as N64 do
 hacks(0),
 
 //wrapper settings
-#ifdef _WIN32
+#ifndef ANDROID
 wrpResolution(0),
 #endif
 wrpVRAM(0),

--- a/Source/Glide64/Settings.h
+++ b/Source/Glide64/Settings.h
@@ -9,7 +9,7 @@ public:
 
     uint32_t res_x, scr_res_x;
     uint32_t res_y, scr_res_y;
-#ifdef _WIN32
+#ifndef ANDROID
     uint32_t res_data, res_data_org;
 #endif
 
@@ -157,7 +157,7 @@ public:
     uint32_t hacks;
 
     //wrapper settings
-#ifdef _WIN32
+#ifndef ANDROID
     int wrpResolution;
 #endif
     int wrpVRAM;

--- a/Source/Glitch64/glitchmain.h
+++ b/Source/Glitch64/glitchmain.h
@@ -17,7 +17,7 @@ extern int dumping;
 
 typedef struct _wrapper_config
 {
-#ifdef _WIN32
+#ifndef ANDROID
     int res;
 #endif
     int fbo;
@@ -178,11 +178,14 @@ void disable_textureSizes();
 
 // config functions
 
-#ifdef _WIN32
-FX_ENTRY void FX_CALL grConfigWrapperExt(FxI32, FxI32, FxBool, FxBool);
-#else
-FX_ENTRY void FX_CALL grConfigWrapperExt(FxI32, FxBool, FxBool);
+FX_ENTRY void FX_CALL grConfigWrapperExt(
+#ifndef ANDROID
+    FxI32, /* resolution parameter not supported on Android build */
 #endif
+    FxI32,
+    FxBool,
+    FxBool
+);
 FX_ENTRY GrScreenResolution_t FX_CALL grWrapperFullScreenResolutionExt(FxU32*, FxU32*);
 FX_ENTRY char ** FX_CALL grQueryResolutionsExt(int32_t*);
 FX_ENTRY FxBool FX_CALL grKeyPressedExt(FxU32 key);

--- a/Source/Glitch64/inc/glide.h
+++ b/Source/Glitch64/inc/glide.h
@@ -623,11 +623,13 @@ grFinish(void);
 FX_ENTRY void FX_CALL 
 grFlush(void);
 
-#ifdef _WIN32
-FX_ENTRY GrContext_t FX_CALL grSstWinOpen( HWND hWnd, GrScreenResolution_t screen_resolution, GrScreenRefresh_t refresh_rate, GrColorFormat_t color_format, GrOriginLocation_t origin_location, int  nColBuffers, int nAuxBuffers);
+FX_ENTRY GrContext_t FX_CALL grSstWinOpen(
+#ifdef ANDROID
+    GrScreenRefresh_t refresh_rate, GrColorFormat_t color_format, GrOriginLocation_t origin_location, int  nColBuffers, int nAuxBuffers
 #else
-FX_ENTRY GrContext_t FX_CALL grSstWinOpen( GrScreenRefresh_t refresh_rate, GrColorFormat_t color_format, GrOriginLocation_t origin_location, int  nColBuffers, int nAuxBuffers);
+    HWND hWnd, GrScreenResolution_t screen_resolution, GrScreenRefresh_t refresh_rate, GrColorFormat_t color_format, GrOriginLocation_t origin_location, int  nColBuffers, int nAuxBuffers
 #endif
+);
 
 FX_ENTRY FxBool FX_CALL
 grSstWinClose( GrContext_t context );


### PR DESCRIPTION
Going over this commit:
https://github.com/project64/project64/commit/52aea8738fcec816c7946576b6cf4d3eb6fa8ee0

Git Blame on GitHub told me about a few of the added `#ifdef _WIN32` instances that further contributed to regressions and new compile errors for non-Windows platforms that use desktop OpenGL (which Android does not).

Anything that said ifdef _WIN32 or ifdef WIN32 before zilmar committed anything to that I left alone.

A few compile errors still remain for Glitch64 on the Linux build due to one other commit that caused regressions besides this one.  I will take a look at that later after if and when this can get merged.

The exact errors remaining are:
```
Compiling Glitch64 library sources for Glide64...
./../../Glitch64/OGLglitchmain.cpp:511:8: error: 'SDL_Surface' does not name a type
 static SDL_Surface *m_pScreen;
        ^
./../../Glitch64/OGLglitchmain.cpp: In function 'GrContext_t grSstWinOpen(HWND, GrScreenResolution_t, GrScreenRefresh_t, GrColorFormat_t, GrOriginLocation_t, int, int)':
./../../Glitch64/OGLglitchmain.cpp:1135:36: error: 'width' was not declared in this scope
     glViewport(0, viewport_offset, width, height);
                                    ^
./../../Glitch64/OGLglitchmain.cpp:1135:43: error: 'height' was not declared in this scope
     glViewport(0, viewport_offset, width, height);
                                           ^
./../../Glitch64/OGLglitchmain.cpp: In function 'FxBool grSstWinClose(GrContext_t)':
./../../Glitch64/OGLglitchmain.cpp:1282:5: error: 'm_pScreen' was not declared in this scope
     m_pScreen = NULL;
     ^
./../../Glitch64/OGLglitchmain.cpp: In function 'void CorrectGamma(const FxU16 (*)[256])':
./../../Glitch64/OGLglitchmain.cpp:2803:71: error: 'SDL_SetGammaRamp' was not declared in this scope
     res = SDL_SetGammaRamp(aGammaRamp[0], aGammaRamp[1], aGammaRamp[2]);
                                                                       ^
./../../Glitch64/OGLglitchmain.cpp: In function 'void grGetGammaTableExt(FxU32, FxU32*, FxU32*, FxU32*)':
./../../Glitch64/OGLglitchmain.cpp:2838:69: error: 'SDL_GetGammaRamp' was not declared in this scope
     if (SDL_GetGammaRamp(aGammaRamp[0], aGammaRamp[1], aGammaRamp[2]) != -1)
                                                                     ^
```