### PR TITLE
[Glitch64] compiles now on Linux w/o warnings or errors

### DIFF
--- a/Source/Glitch64/OGLglitchmain.cpp
+++ b/Source/Glitch64/OGLglitchmain.cpp
@@ -1126,7 +1126,7 @@ int                  nAuxBuffers)
         glCompressedTexImage2DARB = (PFNGLCOMPRESSEDTEXIMAGE2DPROC)dummy_glCompressedTexImage2D;
 #endif
 
-#ifdef _WIN32
+#ifndef ANDROID
     glViewport(0, viewport_offset, g_width, g_height);
     viewport_width = g_width;
     viewport_height = g_height;

--- a/Source/Glitch64/OGLglitchmain.cpp
+++ b/Source/Glitch64/OGLglitchmain.cpp
@@ -29,6 +29,21 @@
  */
 #include <Settings/Settings.h>
 
+#if !defined(_WIN32) && !defined(__ANDROID__) && !defined(ANDROID)
+/*
+ * Do not include <SDL.h> for Windows or Android builds.
+ * Most other platforms tend to include it by default, though.
+ *
+ * Just a few dependencies to SDL remain in the code:
+ *     1.  SDL_SetGammaRamp(), in CorrectGamma()
+ *     2.  SDL_SetGammaRamp(), in grGetGammaTableExt()
+ *     3.  SDL_Surface* m_pScreen = SDL_SetVideoMode(...), to create context
+ * Context creation can be done fine without SDL, and eventually it will be
+ * nice to remove it.  However, Mac & modern Linux tends to come with SDL.
+ */
+#include <SDL.h>
+#endif
+
 struct ResolutionInfo
 {
     unsigned int dwW, dwH, dwF;

--- a/Source/Glitch64/OGLglitchmain.cpp
+++ b/Source/Glitch64/OGLglitchmain.cpp
@@ -29,21 +29,6 @@
  */
 #include <Settings/Settings.h>
 
-#if !defined(_WIN32) && !defined(__ANDROID__) && !defined(ANDROID)
-/*
- * Do not include <SDL.h> for Windows or Android builds.
- * Most other platforms tend to include it by default, though.
- *
- * Just a few dependencies to SDL remain in the code:
- *     1.  SDL_SetGammaRamp(), in CorrectGamma()
- *     2.  SDL_SetGammaRamp(), in grGetGammaTableExt()
- *     3.  SDL_Surface* m_pScreen = SDL_SetVideoMode(...), to create context
- * Context creation can be done fine without SDL, and eventually it will be
- * nice to remove it.  However, Mac & modern Linux tends to come with SDL.
- */
-#include <SDL.h>
-#endif
-
 struct ResolutionInfo
 {
     unsigned int dwW, dwH, dwF;
@@ -522,9 +507,6 @@ struct texbuf_t {
 static texbuf_t texbufs[NB_TEXBUFS];
 static int texbuf_i;
 
-#ifndef _WIN32
-static SDL_Surface *m_pScreen;
-#endif // _WIN32
 unsigned short frameBuffer[2048 * 2048];
 unsigned short depthBuffer[2048 * 2048];
 
@@ -1294,7 +1276,7 @@ grSstWinClose(GrContext_t context)
 #else
     //SDL_QuitSubSystem(SDL_INIT_VIDEO);
     //sleep(2);
-    m_pScreen = NULL;
+    //m_pScreen = NULL;
 #endif
     return FXTRUE;
 }
@@ -2815,7 +2797,9 @@ static void CorrectGamma(const FxU16 aGammaRamp[3][256])
 {
     int res;
 
-    res = SDL_SetGammaRamp(aGammaRamp[0], aGammaRamp[1], aGammaRamp[2]);
+ /* res = SDL_SetGammaRamp(aGammaRamp[0], aGammaRamp[1], aGammaRamp[2]); */
+    res = -1;
+    fputs("ERROR:  Replacement for SDL_SetGammaRamp unimplemented.\n", stderr);
     WriteTrace(TraceGlitch, TraceDebug, "SDL_SetGammaRamp returned %d\r\n", res);
 }
 #endif
@@ -2850,7 +2834,8 @@ grGetGammaTableExt(FxU32 /*nentries*/, FxU32 *red, FxU32 *green, FxU32 *blue)
     {
         ReleaseDC(NULL, hdc);
 #else
-    if (SDL_GetGammaRamp(aGammaRamp[0], aGammaRamp[1], aGammaRamp[2]) != -1)
+    fputs("ERROR:  Replacement for SDL_GetGammaRamp unimplemented.\n", stderr);
+ /* if (SDL_GetGammaRamp(aGammaRamp[0], aGammaRamp[1], aGammaRamp[2]) != -1) */
     {
 #endif
         for (int i = 0; i < 256; i++)

--- a/Source/Glitch64/OGLglitchmain.cpp
+++ b/Source/Glitch64/OGLglitchmain.cpp
@@ -699,7 +699,6 @@ int                  nAuxBuffers)
     depth_texture = free_texture++;
 
 #ifdef _WIN32
-
     PIXELFORMATDESCRIPTOR pfd;
     memset(&pfd, 0, sizeof(PIXELFORMATDESCRIPTOR));
     pfd.nSize = sizeof(PIXELFORMATDESCRIPTOR);
@@ -712,6 +711,8 @@ int                  nAuxBuffers)
     pfd.cAuxBuffers = 1;
 
     int pfm;
+#else
+    fputs("ERROR:  No GLX yet to start GL on [Free]BSD, Linux etc.\n", stderr);
 #endif // _WIN32
 
     WriteTrace(TraceGlitch, TraceDebug, "hWnd: %d, screen_resolution: %d, refresh_rate: %d, color_format: %d, origin_location: %d, nColBuffers: %d, nAuxBuffers: %d", hWnd, screen_resolution&~0x80000000, refresh_rate, color_format, origin_location, nColBuffers, nAuxBuffers);


### PR DESCRIPTION
Let me know if I did the first commit incorrectly.  I was confused by this particular case of `#ifdef WIN32` in that it appears to have predominantly placed there by the original authors before zilmar even forked the plugin, but also in that it applies whether to name height g_height or just height.

The second commit...I imagine I did not do incorrectly.  It just restores the `#include <SDL.h>` that zilmar removed for WIN32 builds and for ANDROID builds.  I am more than able to remove the Linux dependency on SDL in this plugin with context creation (not the gamma function though...not sure what's up with that), but I figure this is faster as a preface to the gradual process of removing it for there as well.  Besides, this way it can get the plugin compiling for Macintosh or whatever as well.