### PR TITLE
[Glide64] Only ban Set_Resolution for Android?

### DIFF
--- a/Source/Glide64/Config.h
+++ b/Source/Glide64/Config.h
@@ -62,7 +62,7 @@ enum
     Set_ghq_cache_save, Set_ghq_cache_size, Set_ghq_hirs_let_texartists_fly,
     Set_ghq_hirs_dump,
 
-#ifdef _WIN32
+#ifndef ANDROID
     Set_Resolution, Set_wrpResolution,
 #endif
 


### PR DESCRIPTION
https://github.com/project64/project64/commit/19913f206b73b74837dc207496c73e51cd01a88b

Did we mean to make this Windows-only or just desktop-OpenGL-only (i.e. no Android, iOS)?
If somehow it's a Windows-only thing then I guess just close this PR/cancel it.

Fixes the compile errors:
```
./../../Glide64/Main.cpp: In function 'void ReadSettings()':
./../../Glide64/Main.cpp:310:49: error: 'Set_Resolution' was not declared in this scope
     g_settings->res_data = (uint32_t)GetSetting(Set_Resolution);
                                                 ^
./../../Glide64/Main.cpp:314:44: error: 'Set_wrpResolution' was not declared in this scope
     g_settings->wrpResolution = GetSetting(Set_wrpResolution);
                                            ^
```