### PR TITLE
[Glide64] got it compiling on Linux

### DIFF
--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -861,11 +861,7 @@ int InitGfx()
     }
     //*/
 
-/*
- * 2016.03.27 cxd4 -- to do:  #ifdef _WIN32 or #ifndef _ANDROID?
- * Can't tell which one is correct here, but I think the latter.
- */
-#ifdef _WIN32
+#ifndef ANDROID
     uint32_t res_data = g_settings->res_data;
     if (ev_fullscreen)
     {
@@ -886,7 +882,11 @@ int InitGfx()
     gfx_context = grSstWinOpen(gfx.hWnd, res_data, GR_REFRESH_60Hz, GR_COLORFORMAT_RGBA, GR_ORIGIN_UPPER_LEFT, 2, 1);
     if (!gfx_context)
     {
+#ifdef _WIN32
         MessageBox(gfx.hWnd, "Error setting display mode", "Error", MB_OK | MB_ICONEXCLAMATION);
+#else
+        fprintf(stderr, "Error setting display mode\n");
+#endif
         grGlideShutdown();
         return FALSE;
     }
@@ -1437,10 +1437,10 @@ int CALL InitiateGFX(GFX_INFO Gfx_Info)
         ZLUT_init();
 
     grConfigWrapperExt(
-#ifdef _WIN32
-        g_settings->wrpResolution, g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic
-#else
+#ifdef ANDROID
         g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic
+#else
+        g_settings->wrpResolution, g_settings->wrpVRAM * 1024 * 1024, g_settings->wrpFBO, g_settings->wrpAnisotropic
 #endif
     );
 


### PR DESCRIPTION
Just a couple WIN32-isms I missed/was unsure of along the way.

So now it compiles without warnings, but we do have link errors:
```
bash-4.2$ ./glide64.sh 
Compiling Glide64 plugin sources...
Assembling Glide64 sources...
Linking PJGlide64 objects...
./Glide64/Config.o: In function `DllConfig':
Config.cpp:(.text+0x0): multiple definition of `DllConfig'
./Glide64/Config.o:Config.cpp:(.text+0x0): first defined here
./Glide64/Config.o: In function `CloseConfig()':
Config.cpp:(.text+0x3c): multiple definition of `CloseConfig()'
./Glide64/Config.o:Config.cpp:(.text+0x3c): first defined here
./Glide64/Config.o: In function `DllAbout':
Config.cpp:(.text+0x77): multiple definition of `DllAbout'
./Glide64/Config.o:Config.cpp:(.text+0x77): first defined here
./Glide64/Config.o: In function `general_setting(short, char const*, unsigned int)':
Config.cpp:(.text+0x78): multiple definition of `general_setting(short, char const*, unsigned int)'
./Glide64/Config.o:Config.cpp:(.text+0x78): first defined here
./Glide64/Config.o: In function `game_setting(short, char const*, unsigned int)':
Config.cpp:(.text+0x8d): multiple definition of `game_setting(short, char const*, unsigned int)'
./Glide64/Config.o:Config.cpp:(.text+0x8d): first defined here
./Glide64/Config.o: In function `game_setting_default(short, char const*, short)':
Config.cpp:(.text+0xa5): multiple definition of `game_setting_default(short, char const*, short)'
./Glide64/Config.o:Config.cpp:(.text+0xa5): first defined here
./Glide64/Config.o:(.data+0x0): multiple definition of `texhirs'
./Glide64/Config.o:(.data+0x0): first defined here
./Glide64/Config.o:(.data+0x8): multiple definition of `texcmpr'
./Glide64/Config.o:(.data+0x8): first defined here
./Glide64/Config.o:(.data+0x10): multiple definition of `texenht'
./Glide64/Config.o:(.data+0x10): first defined here
./Glide64/Config.o:(.data+0x40): multiple definition of `texfltr'
./Glide64/Config.o:(.data+0x40): first defined here
./Glide64/Config.o:(.bss+0x0): multiple definition of `Set_log_flush'
./Glide64/Config.o:(.bss+0x0): first defined here
./Glide64/Config.o:(.bss+0x2): multiple definition of `Set_log_dir'
./Glide64/Config.o:(.bss+0x2): first defined here
./Glide64/Config.o:(.bss+0x4): multiple definition of `Set_texture_dir'
./Glide64/Config.o:(.bss+0x4): first defined here
./Glide64/Config.o:(.bss+0x6): multiple definition of `Set_basic_mode'
./Glide64/Config.o:(.bss+0x6): first defined here
/usr/lib64/gcc/x86_64-slackware-linux/4.8.2/../../../../x86_64-slackware-linux/bin/ld: cannot find -lcommon
collect2: error: ld returned 1 exit status
```
That -lcommon error all the way at the bottom I think is because I need to restore the branch I had where zilmar ported the Common sources to Android, which in upstream has not yet been pushed.  The rest of the errors are within Glide64 somehow, and I will have to figure them out later.