### PR TITLE
Add working Glide64 and Glitch64 shell scripts.

### DIFF
--- a/Source/Script/Unix/glide64.sh
+++ b/Source/Script/Unix/glide64.sh
@@ -6,17 +6,12 @@ mkdir -p $obj
 FLAGS_x86="\
  -I$src/.. \
  -I$src/../3rdParty \
- -I$src/../3rdParty/wx/include \
- -I$src/../3rdParty/wx/lib/vc_lib/msw \
  -I$src/../Glitch64/inc \
- -I$src/../3rdParty/sdl/include \
  -S \
  -fPIC \
  -masm=intel \
  -march=native \
  -Os"
-# -I$src/../3rdParty/wx/include/msvc \
-# -I$src/../3rdParty/wx/include/wx \
 
 C_FLAGS=$FLAGS_x86
 

--- a/Source/Script/Unix/glide64.sh
+++ b/Source/Script/Unix/glide64.sh
@@ -1,0 +1,84 @@
+src=./../../Glide64
+obj=./Glide64
+
+mkdir -p $obj
+
+FLAGS_x86="\
+ -I$src/.. \
+ -I$src/../3rdParty \
+ -I$src/../3rdParty/wx/include \
+ -I$src/../3rdParty/wx/lib/vc_lib/msw \
+ -I$src/../Glitch64/inc \
+ -I$src/../3rdParty/sdl/include \
+ -S \
+ -fPIC \
+ -masm=intel \
+ -march=native \
+ -Os"
+# -I$src/../3rdParty/wx/include/msvc \
+# -I$src/../3rdParty/wx/include/wx \
+
+C_FLAGS=$FLAGS_x86
+
+CC=g++
+AS=as
+
+echo Compiling Glide64 plugin sources...
+$CC -o $obj/Main.asm                    $src/Main.cpp $C_FLAGS
+$CC -o $obj/FBtoScreen.asm              $src/FBtoScreen.cpp $C_FLAGS
+$CC -o $obj/rdp.asm                     $src/rdp.cpp $C_FLAGS
+$CC -o $obj/Keys.asm                    $src/Keys.cpp $C_FLAGS
+$CC -o $obj/CRC.asm                     $src/CRC.cpp $C_FLAGS
+$CC -o $obj/Debugger.asm                $src/Debugger.cpp $C_FLAGS
+$CC -o $obj/Util.asm                    $src/Util.cpp $C_FLAGS
+$CC -o $obj/TexCache.asm                $src/TexCache.cpp $C_FLAGS
+$CC -o $obj/3dmath.asm                  $src/3dmath.cpp $C_FLAGS
+$CC -o $obj/Combine.asm                 $src/Combine.cpp $C_FLAGS
+$CC -o $obj/DepthBufferRender.asm       $src/DepthBufferRender.cpp $C_FLAGS
+$CC -o $obj/Ext_TxFilter.asm            $src/Ext_TxFilter.cpp $C_FLAGS
+$CC -o $obj/TexBuffer.asm               $src/TexBuffer.cpp $C_FLAGS
+$CC -o $obj/trace.asm                   $src/trace.cpp $C_FLAGS
+$CC -o $obj/Settings.asm                $src/Settings.cpp $C_FLAGS
+$CC -o $obj/Config.asm                  $src/Config.cpp $C_FLAGS
+
+echo Assembling Glide64 sources...
+$AS -o $obj/Main.o                      $obj/Main.asm
+$AS -o $obj/FBtoScreen.o                $obj/FBtoScreen.asm
+$AS -o $obj/rdp.o                       $obj/rdp.asm
+$AS -o $obj/Keys.o                      $obj/Keys.asm
+$AS -o $obj/CRC.o                       $obj/CRC.asm
+$AS -o $obj/Debugger.o                  $obj/Debugger.asm
+$AS -o $obj/Util.o                      $obj/Util.asm
+$AS -o $obj/TexCache.o                  $obj/TexCache.asm
+$AS -o $obj/3dmath.o                    $obj/3dmath.asm
+$AS -o $obj/Combine.o                   $obj/Combine.asm
+$AS -o $obj/DepthBufferRender.o         $obj/DepthBufferRender.asm
+$AS -o $obj/Ext_TxFilter.o              $obj/Ext_TxFilter.asm
+$AS -o $obj/TexBuffer.o                 $obj/TexBuffer.asm
+$AS -o $obj/trace.o                     $obj/trace.asm
+$AS -o $obj/Settings.o                  $obj/Settings.asm
+$AS -o $obj/Config.o                    $obj/Config.asm
+
+OBJ_LIST="\
+ $obj/Config.o \
+ $obj/Settings.o \
+ $obj/trace.o \
+ $obj/TexBuffer.o \
+ $obj/Ext_TxFilter.o \
+ $obj/DepthBufferRender.o \
+ $obj/Combine.o \
+ $obj/3dmath.o \
+ $obj/TexCache.o \
+ $obj/Util.o \
+ $obj/Debugger.o \
+ $obj/CRC.o \
+ $obj/Keys.o \
+ $obj/rdp.o \
+ $obj/FBtoScreen.o \
+ $obj/Main.o \
+ -L$obj/../Glitch64 \
+ -L$obj/../Common \
+ -L$obj/../Settings"
+
+echo Linking PJGlide64 objects...
+g++ -o $obj/PJ64Glide64.so $OBJ_LIST -lglitch64 -lcommon -lsettings -shared -shared-libgcc

--- a/Source/Script/Unix/glitch64.sh
+++ b/Source/Script/Unix/glitch64.sh
@@ -1,0 +1,49 @@
+src=./../../Glitch64
+obj=./Glitch64
+
+mkdir -p $obj
+
+FLAGS_x86="\
+ -S \
+ -fPIC \
+ -I$src/inc \
+ -I/usr/include/SDL \
+ -I$src/.. \
+ -masm=intel \
+ -march=native \
+ -Os"
+
+C_FLAGS=$FLAGS_x86
+
+CC=g++
+AS=as
+
+echo Compiling Glitch64 library sources for Glide64...
+$CC -o $obj/OGLcombiner.asm             $src/OGLcombiner.cpp $C_FLAGS
+$CC -o $obj/OGLgeometry.asm             $src/OGLgeometry.cpp $C_FLAGS
+$CC -o $obj/OGLglitchmain.asm           $src/OGLglitchmain.cpp $C_FLAGS
+$CC -o $obj/OGLtextures.asm             $src/OGLtextures.cpp $C_FLAGS
+#$CC -o $obj/OGLEScombiner.asm           $src/OGLEScombiner.cpp $C_FLAGS
+#$CC -o $obj/OGLESgeometry.asm           $src/OGLESgeometry.cpp $C_FLAGS
+#$CC -o $obj/OGLESglitchmain.asm         $src/OGLESglitchmain.cpp $C_FLAGS
+#$CC -o $obj/OGLEStextures.asm           $src/OGLEStextures.cpp $C_FLAGS
+
+echo Assembling Glitch64 library sources...
+$AS -o $obj/OGLcombiner.o               $obj/OGLcombiner.asm
+$AS -o $obj/OGLgeometry.o               $obj/OGLgeometry.asm
+$AS -o $obj/OGLglitchmain.o             $obj/OGLglitchmain.asm
+$AS -o $obj/OGLtextures.o               $obj/OGLtextures.asm
+#$AS -o $obj/OGLEScombiner.o             $obj/OGLEScombiner.asm
+#$AS -o $obj/OGLESgeometry.o             $obj/OGLESgeometry.asm
+#$AS -o $obj/OGLESglitchmain.o           $obj/OGLESglitchmain.asm
+#$AS -o $obj/OGLEStextures.o             $obj/OGLEStextures.asm
+
+OBJ_LIST="\
+ $obj/OGLtextures.o \
+ $obj/OGLglitchmain.o \
+ $obj/OGLgeometry.o \
+ $obj/OGLcombiner.o"
+#$obj/OGLEStextures.o $obj/OGLESglitchmain.o $obj/OGLESgeometry.o $obj/OGLEScombiner.o"
+
+echo Linking static library objects for Glitch64...
+ar rcs $obj/libglitch64.a $OBJ_LIST

--- a/Source/Script/Unix/glitch64.sh
+++ b/Source/Script/Unix/glitch64.sh
@@ -7,7 +7,6 @@ FLAGS_x86="\
  -S \
  -fPIC \
  -I$src/inc \
- -I/usr/include/SDL \
  -I$src/.. \
  -masm=intel \
  -march=native \


### PR DESCRIPTION
I'm embarrassed to say that the linker errors I was having with Glide64 were caused by an overlooked copypasta failure of the form of specifying `$obj/Config.o` twice redundantly in the GNU link command.

The only remaining link error now is this:
```shell
./glitch64.sh 
Compiling Glitch64 library sources for Glide64...
Assembling Glitch64 library sources...
Linking static library objects for Glitch64...

./glide64.sh 
Compiling Glide64 plugin sources...
Assembling Glide64 sources...
Linking PJGlide64 objects...
/usr/lib64/gcc/x86_64-slackware-linux/4.8.2/../../../../x86_64-slackware-linux/bin/ld: cannot find -lcommon
collect2: error: ld returned 1 exit status
```
libcommon has locally been ported to Android by zilmar, but the branch has not yet been pushed to the public which is why it is not directly something exposed for me to have tested in each branch I make.

At any rate, the build goes far along enough now that I can push these two Unix script files.

They were sitting on my hard drive for probably months with no changes; I was just waiting to make sure the build would progress far enough along so that it would be worth uploading them here.