### PR TITLE
fixed undefined type error in flash pre-buffer aliasing

### DIFF
--- a/Source/Project64-core/N64System/Mips/FlashRam.cpp
+++ b/Source/Project64-core/N64System/Mips/FlashRam.cpp
@@ -175,10 +175,7 @@ void CFlashram::WriteToFlashCommand(uint32_t FlashRAM_Command)
                 uint8_t * FlashRamPointer = m_FlashRamPointer;
 
                 memset(FlipBuffer, 0, sizeof(FlipBuffer));
-                for (edx = 0; edx < 128; edx += 1)
-                {
-                    FlipBuffer[edx] = FlashRamPointer[edx ^ 0];
-                } /* To do:  Have controllable XOR mask to correct flash RAM. */
+                memcpy(&FlipBuffer[0], FlashRamPointer, 128);
 
                 m_File.Seek(m_FlashRAM_Offset, CFile::begin);
                 m_File.Write(FlipBuffer, 128);

--- a/Source/Project64-core/N64System/Mips/FlashRam.cpp
+++ b/Source/Project64-core/N64System/Mips/FlashRam.cpp
@@ -175,10 +175,10 @@ void CFlashram::WriteToFlashCommand(uint32_t FlashRAM_Command)
                 uint8_t * FlashRamPointer = m_FlashRamPointer;
 
                 memset(FlipBuffer, 0, sizeof(FlipBuffer));
-                for (edx = 0; edx < 128; edx += 4)
+                for (edx = 0; edx < 128; edx += 1)
                 {
-                    *(unsigned __int32 *)(FlipBuffer + edx) = *(unsigned __int32 *)&FlashRamPointer[edx];
-                }
+                    FlipBuffer[edx] = FlashRamPointer[edx ^ 0];
+                } /* To do:  Have controllable XOR mask to correct flash RAM. */
 
                 m_File.Seek(m_FlashRAM_Offset, CFile::begin);
                 m_File.Write(FlipBuffer, 128);


### PR DESCRIPTION
`__int32` is compiler-specific.  Standard types like `long` or custom type names like `int32_t` are better.

Except in this case, we're working with memory.  Casting pointers for aliasing like this is not good practice and has no well-defined result in the C standard.  Using `unsigned char` or `memcpy()` is better.