### PR TITLE
[Cheats UI] leftover references to std::strtoul

### DIFF
--- a/Source/Project64/UserInterface/CheatClassUI.cpp
+++ b/Source/Project64/UserInterface/CheatClassUI.cpp
@@ -854,7 +854,7 @@ int CALLBACK CCheatsUI::CheatsCodeQuantProc(HWND hDlg, uint32_t uMsg, uint32_t w
                 TCHAR szTmp[10], szTmp2[10];
                 uint32_t Value;
                 GetDlgItemText(hDlg, IDC_VALUE, szTmp, sizeof(szTmp));
-                Value = szTmp[0] == '$' ? strtoul(&szTmp[1], 0, 16) : std::strtoul(szTmp, 0, 16);
+                Value = szTmp[0] == '$' ? strtoul(&szTmp[1], 0, 16) : strtoul(&szTmp[0], 0, 16);
                 if (Value > Stop)  { Value = Stop; }
                 if (Value < Start) { Value = Start; }
                 sprintf(szTmp2, "$%X", Value);
@@ -887,7 +887,7 @@ int CALLBACK CCheatsUI::CheatsCodeQuantProc(HWND hDlg, uint32_t uMsg, uint32_t w
             uint32_t Value;
 
             GetDlgItemText(hDlg, IDC_VALUE, szTmp, sizeof(szTmp));
-            Value = szTmp[0] == '$' ? std::strtol(&szTmp[1], 0, 16) : std::strtol(szTmp, 0, 16);
+            Value = szTmp[0] == '$' ? strtol(&szTmp[1], 0, 16) : strtol(&szTmp[0], 0, 16);
             if (Value > Stop) { Value = Stop; }
             if (Value < Start) { Value = Start; }
             sprintf(CheatExten, "$%X", Value);


### PR DESCRIPTION
There were some remaining references to the `std::` version left after this commit:
https://github.com/project64/project64/commit/13cfd8b728ff4ffa0611cbf18db2a2433d715b7e

By the way, based on the pattern observable here, I think it would be cleaner code to say:
```c
 /* Value = szTmp[0] == '$' ? strtoul(&szTmp[1], 0, 16) : std::strtoul(szTmp, 0, 16); */
    Value = strtoul(&szTmp[(szTmp[0] == '$') ? 1 : 0], 0, 16);
```