### PR TITLE
Use sizeof() to eliminate respecification of array bounds.

### DIFF
--- a/Source/Project64-core/N64System/Mips/FlashRam.cpp
+++ b/Source/Project64-core/N64System/Mips/FlashRam.cpp
@@ -29,7 +29,8 @@ CFlashram::~CFlashram()
 
 void CFlashram::DmaFromFlashram(uint8_t * dest, int32_t StartOffset, int32_t len)
 {
-    uint8_t FlipBuffer[1 << 16];
+    uint8_t FlipBuffer[0x10000];
+
     switch (m_FlashFlag)
     {
     case FLASHRAM_MODE_READ:


### PR DESCRIPTION
I really just noticed this so far in `FlashRam.cpp` only.  There might be others to apply this to.