### PR TITLE
unresolved vsprintf()

### DIFF
--- a/Source/Project64-core/N64System/Recompiler/x86CodeLog.h
+++ b/Source/Project64-core/N64System/Recompiler/x86CodeLog.h
@@ -10,6 +10,10 @@
 ****************************************************************************/
 #pragma once
 
+/* vsprintf() needs to have both of these included. */
+#include <stdio.h>
+#include <stdarg.h>
+
 #define CPU_Message(Message,... )  if (bX86Logging) { x86_Log_Message(Message,## __VA_ARGS__); }
 
 void x86_Log_Message (const char * Message, ...);


### PR DESCRIPTION
```
./../../Project64-core/N64System/Recompiler/x86CodeLog.cpp: In function 'void x86_Log_Message(const char*, ...)':
./../../Project64-core/N64System/Recompiler/x86CodeLog.cpp:29:41: error: 'vsprintf' was not declared in this scope
         vsprintf(buffer, strFormat, args);
                                         ^
```