### PR TITLE
Constrict window message initializers as ANDROID- and WIN32-only.

### DIFF
--- a/Source/Project64-core/Plugins/GFXPlugin.cpp
+++ b/Source/Project64-core/Plugins/GFXPlugin.cpp
@@ -173,13 +173,17 @@ bool CGfxPlugin::Initiate(CN64System * System, RenderWindow * Window)
     GFX_INFO Info = { 0 };
 
     Info.MemoryBswaped = true;
-#ifdef _WIN32
-    Info.hWnd = Window ? Window->GetWindowHandle() : NULL;
-    Info.hStatusBar = Window ? Window->GetStatusBar() : NULL;
-#else
+#if defined(ANDROID) || defined(__ANDROID__)
     Info.SwapBuffers = SwapBuffers;
+#endif
     Info.hWnd = NULL;
     Info.hStatusBar = NULL;
+#ifdef _WIN32
+    if (Window != NULL)
+    {
+        Info.hWnd       = Window->GetWindowHandle();
+        Info.hStatusBar = Window->GetStatusBar();
+    }
 #endif
     Info.CheckInterrupts = DummyCheckInterrupts;
 


### PR DESCRIPTION
```
./../../Project64-core/Plugins/GFXPlugin.cpp: In member function 'bool CGfxPlugin::Initiate(CN64System*, RenderWindow*)':
./../../Project64-core/Plugins/GFXPlugin.cpp:181:34: error: 'struct RenderWindow' has no member named 'GetWindowHandle'
     Info.hWnd = Window ? Window->GetWindowHandle() : NULL;
                                  ^
./../../Project64-core/Plugins/GFXPlugin.cpp:182:40: error: 'struct RenderWindow' has no member named 'GetStatusBar'
     Info.hStatusBar = Window ? Window->GetStatusBar() : NULL;
                                        ^
```