### PR TITLE
[Common] gettid() not declared in this scope

### DIFF
--- a/Source/Common/Thread.cpp
+++ b/Source/Common/Thread.cpp
@@ -3,6 +3,7 @@
 #ifndef _WIN32
 #include <unistd.h>
 #include <pthread.h>
+#include <sys/syscall.h>
 #endif
 
 CThread::CThread(CTHREAD_START_ROUTINE lpStartAddress) :
@@ -125,6 +126,8 @@ uint32_t CThread::GetCurrentThreadId(void)
 {
 #ifdef _WIN32
     return ::GetCurrentThreadId();
+#elif defined(SYS_gettid) || defined(__NR_gettid)
+    return syscall(__NR_gettid); /* GLIBC has no implementation of gettid(). */
 #else
     return gettid();
 #endif


### PR DESCRIPTION
This is the only error I had while compiling and linking the current Project64/Common sources.
```
Compiling common library sources for Project64...
./../../Common/Thread.cpp: In static member function 'static uint32_t CThread::GetCurrentThreadId()':
./../../Common/Thread.cpp:129:19: error: 'gettid' was not declared in this scope
     return gettid();
                   ^
Assembling common library sources...
```

It basically means that many C library implementations (evidently such as my own) do not provide this function; you have to access it through a SYSCALL--either `SYS_gettid` or `__NR_gettid`.