### PR TITLE
va_list undeclared

### DIFF
--- a/Source/Common/LogClass.h
+++ b/Source/Common/LogClass.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdarg.h>
 #include <string>
 #include "FileClass.h"
 


### PR DESCRIPTION
```
Compiling Glide64 plugin sources...
In file included from ./../../Glide64/../Common/Trace.h:2:0,
                 from ./../../Glide64/trace.h:3,
                 from ./../../Glide64/trace.cpp:1:
./../../Glide64/../Common/LogClass.h:22:40: error: 'va_list' has not been declared
     void LogArgs(const char * Message, va_list & args);
                                        ^
```