### PR TITLE
[GlideHQ] undeclared stuff from stdlib and string

### DIFF
--- a/Source/GlideHQ/TxCache.cpp
+++ b/Source/GlideHQ/TxCache.cpp
@@ -26,6 +26,7 @@
 #endif
 
 #include <string.h> /* memcpy, memset */
+#include <stdlib.h> /* malloc, free */
 
 #include "TxCache.h"
 #include "TxDbg.h"

--- a/Source/GlideHQ/TxCache.cpp
+++ b/Source/GlideHQ/TxCache.cpp
@@ -25,6 +25,8 @@
 #pragma warning(disable: 4786)
 #endif
 
+#include <string.h> /* memcpy, memset */
+
 #include "TxCache.h"
 #include "TxDbg.h"
 #include <zlib/zlib.h>


### PR DESCRIPTION
```
./../../GlideHQ/TxCache.cpp: In member function 'boolean TxCache::add(uint64, GHQTexInfo*, int)':
./../../GlideHQ/TxCache.cpp:133:52: error: 'free' was not declared in this scope
                     free((*itMap).second->info.data);
                                                    ^
./../../GlideHQ/TxCache.cpp:152:45: error: 'malloc' was not declared in this scope
     uint8 *tmpdata = (uint8*)malloc(dataSize);
                                             ^
./../../GlideHQ/TxCache.cpp:161:43: error: 'memcpy' was not declared in this scope
             memcpy(tmpdata, dest, dataSize);
                                           ^
./../../GlideHQ/TxCache.cpp:207:21: error: 'free' was not declared in this scope
         free(tmpdata);
                     ^
./../../GlideHQ/TxCache.cpp: In member function 'boolean TxCache::get(uint64, GHQTexInfo*)':
./../../GlideHQ/TxCache.cpp:223:68: error: 'memcpy' was not declared in this scope
         memcpy(info, &(((*itMap).second)->info), sizeof(GHQTexInfo));
                                                                    ^
./../../GlideHQ/TxCache.cpp: In member function 'boolean TxCache::load(const char*, const char*, int)':
./../../GlideHQ/TxCache.cpp:346:55: error: 'memset' was not declared in this scope
                 memset(&tmpInfo, 0, sizeof(GHQTexInfo));
                                                       ^
./../../GlideHQ/TxCache.cpp:366:55: error: 'malloc' was not declared in this scope
                 tmpInfo.data = (uint8*)malloc(dataSize);
                                                       ^
./../../GlideHQ/TxCache.cpp:374:38: error: 'free' was not declared in this scope
                     free(tmpInfo.data);
                                      ^
./../../GlideHQ/TxCache.cpp: In member function 'boolean TxCache::del(uint64)':
./../../GlideHQ/TxCache.cpp:402:40: error: 'free' was not declared in this scope
         free((*itMap).second->info.data);
                                        ^
./../../GlideHQ/TxCache.cpp: In member function 'void TxCache::clear()':
./../../GlideHQ/TxCache.cpp:430:44: error: 'free' was not declared in this scope
             free((*itMap).second->info.data);
                                            ^
```