### PR TITLE
[GlideHQ] undefined symbol:  fxt1_encode()

### DIFF
--- a/Source/GlideHQ/TxUtil.h
+++ b/Source/GlideHQ/TxUtil.h
@@ -31,9 +31,6 @@
 #include <string>
 
 #ifndef DXTN_DLL
-#ifdef __cplusplus
-extern "C"{
-#endif
 void tx_compress_dxtn(int srccomps, int width, int height,
                       const void *source, int destformat, void *dest,
                       int destRowStride);
@@ -41,9 +38,6 @@ void tx_compress_dxtn(int srccomps, int width, int height,
 int fxt1_encode(int width, int height, int comps,
                 const void *source, int srcRowStride,
                 void *dest, int destRowStride);
-#ifdef __cplusplus
-}
-#endif
 #endif /* DXTN_DLL */
 
 typedef void (*dxtCompressTexFuncExt)(int srccomps, int width,


### PR DESCRIPTION
I'm assuming there must have been some reason why the `extern "C"` was there.

Somebody on Windows try testing this commit before it gets merged, because I don't know if it will cause any linkage to break on there or not.  All I know is right now, with GNU it solves this run-time link fault:
```
bash-4.2$ ./mupen64
Couldn't load plugin './plugins/PJ64Glide64.so': ./plugins/PJ64Glide64.so: undefined symbol: fxt1_encode
```

Again, maybe it fixes for one platform and breaks on another.  This C-to-C++ namespace mess is rather hard to do a time-efficient investigation of, so if anyone understands a better solution, do say.