### PR TITLE
Do not force C++ compilation of C code.

### DIFF
--- a/Source/Script/Unix/glidehq.sh
+++ b/Source/Script/Unix/glidehq.sh
@@ -15,7 +15,7 @@ FLAGS_x86="\
 
 C_FLAGS=$FLAGS_x86
 
-CC=g++
+CC=cc
 AS=as
 
 echo Compiling GlideHQ library sources for Glide64...


### PR DESCRIPTION
Invoke compilation via `cc`, not `g++`.  This fixes both the remaining run-time linkage resolution conflicts on Linux as well as several C++ compilation warnings that did not apply to compiling with C rules.