### PR TITLE
Do not track static library output from pre-link components.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 *.opendb
 *.VC.db
 
+# static library output (MSVC, GCC--from core components like Common)
+*.lib
+*.a
+
 # compiler-generated sources (MSVC, GCC)
 *.asm
 *.s


### PR DESCRIPTION
Recently, I made a pull request that was pushed using `git add --all` as a shortcut, which mistakenly added some garbage library files to that PR that I did not mean to have and had to cancel the PR.

This mistake could have been prevented had files with the `*.a` extension been in the `.gitignore`.