### PR TITLE
Move to cfile

### DIFF
--- a/Source/Project64-core/N64System/Mips/Mempak.H
+++ b/Source/Project64-core/N64System/Mips/Mempak.H
@@ -14,8 +14,9 @@ class Mempak
 {
 public:
     static uint8_t CalculateCrc(uint8_t * DataToCrc);
-    static void Load(int32_t Control);
-    static void Format(int32_t Control);
     static void ReadFrom(int32_t Control, uint32_t address, uint8_t * data);
     static void WriteTo(int32_t Control, uint32_t address, uint8_t * data);
+private:
+    static void LoadMempak(int32_t Control);
+    static void Format(int32_t Control);
 };

--- a/Source/Project64-core/N64System/Mips/Mempak.cpp
+++ b/Source/Project64-core/N64System/Mips/Mempak.cpp
@@ -15,33 +15,37 @@
 #include <Common/path.h>
 
 uint8_t Mempaks[4][128 * 256]; /* [CONTROLLERS][PAGES][BYTES_PER_PAGE] */
-CPath MempakNames[4];
+CFile MempakHandle[4];
 
-void Mempak::Load(int32_t Control)
+void Mempak::LoadMempak(int32_t Control)
 {
     stdstr MempakName;
-
     MempakName.Format("%s_Cont_%d", g_Settings->LoadStringVal(Game_GameName).c_str(), Control + 1);
 
-    MempakNames[Control] = CPath(g_Settings->LoadStringVal(Directory_NativeSave).c_str(), stdstr_f("%s.mpk",MempakName.c_str()).c_str());
+    CPath MempakPath(g_Settings->LoadStringVal(Directory_NativeSave).c_str(), stdstr_f("%s.mpk",MempakName.c_str()).c_str());
+
     if (g_Settings->LoadBool(Setting_UniqueSaveDir))
     {
-        MempakNames[Control].AppendDirectory(g_Settings->LoadStringVal(Game_UniqueSaveDir).c_str());
+        MempakPath.AppendDirectory(g_Settings->LoadStringVal(Game_UniqueSaveDir).c_str());
     }
-    if (!MempakNames[Control].DirectoryExists())
+    if (!MempakPath.DirectoryExists())
     {
-        MempakNames[Control].DirectoryCreate();
+        MempakPath.DirectoryCreate();
     }
 
-    if (MempakNames[Control].Exists())
+    bool formatMempak = !MempakPath.Exists();
+
+    MempakHandle[Control].Open(MempakPath, CFileBase::modeReadWrite | CFileBase::modeNoTruncate | CFileBase::modeCreate);
+    MempakHandle[Control].SeekToBegin();
+
+    if (formatMempak)
     {
-        FILE *mempak = fopen(MempakNames[Control], "rb");
-        fread(Mempaks[Control], 1, 0x8000, mempak);
-        fclose(mempak);
+        Mempak::Format(Control);
+        MempakHandle[Control].Write(Mempaks[Control], 0x8000);
     }
     else
     {
-        Mempak::Format(Control);
+        MempakHandle[Control].Read(Mempaks[Control], 0x8000);
     }
 }
 
@@ -113,6 +117,11 @@ void Mempak::ReadFrom(int32_t Control, uint32_t address, uint8_t * data)
 {
     if (address < 0x8000)
     {
+        if (!MempakHandle[Control].IsOpen())
+        {
+            LoadMempak(Control);
+        }
+
         memcpy(data, &Mempaks[Control][address], 0x20);
     }
     else
@@ -126,11 +135,16 @@ void Mempak::WriteTo(int32_t Control, uint32_t address, uint8_t * data)
 {
     if (address < 0x8000)
     {
+        if (!MempakHandle[Control].IsOpen())
+        {
+            LoadMempak(Control);
+        }
+
         memcpy(&Mempaks[Control][address], data, 0x20);
 
-        FILE* mempak = fopen(MempakNames[Control], "wb");
-        fwrite(Mempaks[Control], 1, 0x8000, mempak);
-        fclose(mempak);
+        MempakHandle[Control].Seek(address, CFile::begin);
+        MempakHandle[Control].Write(data, 0x20);
+        MempakHandle[Control].Flush();
     }
     else
     {

--- a/Source/Project64-core/N64System/Mips/Transferpak.cpp
+++ b/Source/Project64-core/N64System/Mips/Transferpak.cpp
@@ -32,13 +32,22 @@ void Transferpak::Init()
 
 void Transferpak::Release()
 {
-    GBCart::release_gb_cart(&tpak.gb_cart);
+    if (tpak.gb_cart.rom != NULL)
+    {
+        GBCart::release_gb_cart(&tpak.gb_cart);
+    }
 }
 
 void Transferpak::ReadFrom(uint16_t address, uint8_t * data)
 {
 	if ((address >= 0x8000) && (address <= 0x8FFF))
 	{
+        //Ensure we actually have a ROM loaded in first.
+        if (tpak.gb_cart.rom == NULL)
+        {
+            Init();
+        }
+
 		//Get whether the GB cart is enabled or disabled
 		uint8_t value = (tpak.enabled) ? 0x84 : 0x00;
 
@@ -71,8 +80,15 @@ void Transferpak::ReadFrom(uint16_t address, uint8_t * data)
 
 void Transferpak::WriteTo(uint16_t address, uint8_t * data)
 {
+
     if ((address >= 0x8000) && (address <= 0x8FFF))
     {
+        //Ensure we actually have a ROM loaded in first.
+        if (tpak.gb_cart.rom == NULL)
+        {
+            Init();
+        }
+
         //Set whether the gb cart is enabled or disabled.
         switch (*data)
         {

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -699,9 +699,6 @@ bool CN64System::SetActiveSystem(bool bActive)
                     case PLUGIN_TANSFER_PAK:
                         Transferpak::Init();
                         break;
-                    case PLUGIN_MEMPAK:
-                        Mempak::Load(i);
-                        break;
                     }
                 }
             }

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -687,22 +687,6 @@ bool CN64System::SetActiveSystem(bool bActive)
         {
             WriteTrace(TraceN64System, TraceError, "g_Plugins->Initiate Failed");
         }
-        else
-        {
-            CONTROL * Controllers = g_Plugins->Control()->PluginControllers();
-            for (int i = 0; i < 3; i++)
-            {
-                if (Controllers[i].Present)
-                {
-                    switch (Controllers[i].Plugin)
-                    {
-                    case PLUGIN_TANSFER_PAK:
-                        Transferpak::Init();
-                        break;
-                    }
-                }
-            }
-        }
     }
 
     if (bReset)


### PR DESCRIPTION
Move mempak to using the CFile class, and also change its behavior slightly so we only load mempak in when there has been a read or a write to the mempak itself, rather then doing it on load. We also only now write the bytes that have been changes to the mempak file rather then writing the whole lot everytime a write has been performed.

Also made a slight change to the transferpak so that now only loads when there has been a read or a write to the transferpak, rather then on load.