### PR TITLE
Improve alist_resample

### DIFF
--- a/Source/Android/PluginRSP/alist.cpp
+++ b/Source/Android/PluginRSP/alist.cpp
@@ -633,11 +633,11 @@ void alist_resample( CHle * hle, bool init, bool flag2, uint16_t dmemo, uint16_t
     {
         const int16_t* lut = RESAMPLE_LUT + ((pitch_accu & 0xfc00) >> 8);
 
-        *sample(hle, opos++) = clamp_s16(
-            ((*sample(hle, ipos) * lut[0]) >> 15) +
-            ((*sample(hle, ipos + 1) * lut[1]) >> 15) +
-            ((*sample(hle, ipos + 2) * lut[2]) >> 15) +
-            ((*sample(hle, ipos + 3) * lut[3]) >> 15));
+        *sample(hle, opos++) = clamp_s16( (
+            (*sample(hle, ipos    ) * lut[0]) +
+            (*sample(hle, ipos + 1) * lut[1]) +
+            (*sample(hle, ipos + 2) * lut[2]) +
+            (*sample(hle, ipos + 3) * lut[3]) ) >> 15);
 
         pitch_accu += pitch;
         ipos += (pitch_accu >> 16);


### PR DESCRIPTION
New algorithm is faster and more accurate

I tested Super Smash Bros and looked at the first 32 bytes written to DMEM from Resample and got the following results

old algorithm
0000 0000 0000 0000 0000 0000 0000 0000
FFDA FFFF 0082 FFE3 0296 01B9 0065 0200

new algorithm
0000 0000 0000 0000 0000 0000 0000 0000
FFDA FFFF 0084 FFE4 0297 01BB 0066 0202

Project64 RSP Interpreter
0000 0000 0000 0000 0000 0000 0000 0000
FFDB FFFF 0084 FFE4 0297 01BB 0066 0202