### PR TITLE
repaired compilation assumptions in Project64/Support.h

### DIFF
--- a/Source/Project64/Support.h
+++ b/Source/Project64/Support.h
@@ -1,4 +1,6 @@
+#if defined(_WIN32)
 #include <windows.h>
+#endif
 
 #include <Common/memtest.h>
 #include <Common/CriticalSection.h>

--- a/Source/Project64/Support.h
+++ b/Source/Project64/Support.h
@@ -2,7 +2,7 @@
 #include <windows.h>
 #endif
 
-#include <Common/memtest.h>
+#include <Common/MemTest.h>
 #include <Common/CriticalSection.h>
 #include <Common/StdString.h>
 #include <Common/FileClass.h>


### PR DESCRIPTION
Nothing which shall revise any of the actual Windows UI code to get along with any other operating systems, but for the purposes of furthered analysis it's a good idea to not have interference from this file.

For anyone curious, the next [heap of singularly and frequently repeated] error message is from:
```
In file included from ./../../Project64/UserInterface.h:19:0,
                 from ./../../Project64/stdafx.h:21,
                 from ./../../Project64/main.cpp:1:
./../../Project64/WTLApp.h:15:22: fatal error: shellapi.h: No such file or directory
 #include <shellapi.h>
                      ^
```