### PR TITLE
[64DD] Make sure at boot that the disk is inserted

### DIFF
--- a/Source/Project64-core/N64System/Mips/Disk.cpp
+++ b/Source/Project64-core/N64System/Mips/Disk.cpp
@@ -83,6 +83,10 @@ void DiskCommand()
         //Unset Reset Bit
         g_Reg->ASIC_STATUS &= ~DD_STATUS_RST_STATE;
         g_Reg->ASIC_STATUS &= ~DD_STATUS_DISK_CHNG;
+        //F-Zero X + Expansion Kit fix so it doesn't enable "swapping" at boot
+        dd_swapdelay = 0;
+        if (g_Disk != NULL)
+            g_Reg->ASIC_STATUS |= DD_STATUS_DISK_PRES;
         break;
     case 0x00120000:
         //RTC Get Year & Month


### PR DESCRIPTION
Fixes F-Zero X Expansion Kit loading too late.

Also, I wanna talk about RDB:
Should I remove "Fixed audio timing" for F-Zero X? I found out that's the thing preventing F-Zero X Expansion Kit to work properly on Recompiler.