### PR TITLE
Update core linkage output.

### DIFF
--- a/Source/Project64-core/N64System/Mips/MemoryVirtualMem.h
+++ b/Source/Project64-core/N64System/Mips/MemoryVirtualMem.h
@@ -22,6 +22,11 @@
 #include <sys/ucontext.h>
 #endif
 
+#ifndef _WIN32
+#include <signal.h>
+/* siginfo_t */
+#endif
+
 /*
 * 64-bit Windows exception recovery facilities will expect to interact with
 * the 64-bit registers of the Intel architecture (e.g., rax instead of eax).
@@ -101,7 +106,7 @@ public:
     int32_t   MemoryFilter(uint32_t dwExptCode, void * lpExceptionPointer);
     void  UpdateFieldSerration(uint32_t interlaced);
 #ifndef _WIN32
-    static bool SetupSegvHandler (void);
+    static bool SetupSegvHandler(void);
     static void segv_handler(int signal, siginfo_t *siginfo, void *sigcontext);
 #endif
 

--- a/Source/Script/Unix/project64-core.sh
+++ b/Source/Script/Unix/project64-core.sh
@@ -261,4 +261,4 @@ $obj/Settings/type/TmpNumber.o \
 $obj/Settings/type/TmpString.o"
 
 echo Linking static library objects for Project64-core...
-ar rcs $obj/project64-core.a $OBJ_LIST
+ar rcs $obj/libproject64-core.a $OBJ_LIST


### PR DESCRIPTION
Seems I forgot to prefix the static library's output file name with a "lib-".
Not that this was a mistake or anything, but not conventional.

Since a very recent commit, the UI also did not compile because `siginfo_t` was used undeclared in one of the core header files.  The location of where the type is used is marked by a junk whitespace change I added on to the commit.