### PR TITLE
forgot to pass @LuigiBlood's 64DD stuff to the linker

### DIFF
--- a/Source/Script/Unix/project64-core.sh
+++ b/Source/Script/Unix/project64-core.sh
@@ -122,6 +122,7 @@ $AS -o $obj/N64System/interp/CPU.o      $obj/N64System/interp/CPU.asm
 $AS -o $obj/N64System/interp/Ops.o      $obj/N64System/interp/Ops.asm
 $AS -o $obj/N64System/interp/Ops32.o    $obj/N64System/interp/Ops32.asm
 $AS -o $obj/N64System/Mips/Audio.o      $obj/N64System/Mips/Audio.asm
+$AS -o $obj/N64System/Mips/Disk.o       $obj/N64System/Mips/Disk.asm
 $AS -o $obj/N64System/Mips/Dma.o        $obj/N64System/Mips/Dma.asm
 $AS -o $obj/N64System/Mips/Eeprom.o     $obj/N64System/Mips/Eeprom.asm
 $AS -o $obj/N64System/Mips/FlashRam.o   $obj/N64System/Mips/FlashRam.asm
@@ -136,6 +137,7 @@ $AS -o $obj/N64System/Mips/SyEvents.o   $obj/N64System/Mips/SyEvents.asm
 $AS -o $obj/N64System/Mips/SyTiming.o   $obj/N64System/Mips/SyTiming.asm
 $AS -o $obj/N64System/Mips/TLBclass.o   $obj/N64System/Mips/TLBclass.asm
 $AS -o $obj/N64System/N64Class.o        $obj/N64System/N64Class.asm
+$AS -o $obj/N64System/N64DiskClass.o    $obj/N64System/N64DiskClass.asm
 $AS -o $obj/N64System/N64RomClass.o     $obj/N64System/N64RomClass.asm
 $AS -o $obj/N64System/ProfileClass.o    $obj/N64System/ProfileClass.asm
 $AS -o $obj/N64System/dynarec/Block.o   $obj/N64System/dynarec/Block.asm
@@ -197,6 +199,7 @@ $obj/N64System/interp/CPU.o \
 $obj/N64System/interp/Ops.o \
 $obj/N64System/interp/Ops32.o \
 $obj/N64System/Mips/Audio.o \
+$obj/N64System/Mips/Disk.o \
 $obj/N64System/Mips/Dma.o \
 $obj/N64System/Mips/Eeprom.o \
 $obj/N64System/Mips/FlashRam.o \
@@ -211,6 +214,7 @@ $obj/N64System/Mips/SyEvents.o \
 $obj/N64System/Mips/SyTiming.o \
 $obj/N64System/Mips/TLBclass.o \
 $obj/N64System/N64Class.o \
+$obj/N64System/N64DiskClass.o \
 $obj/N64System/N64RomClass.o \
 $obj/N64System/ProfileClass.o \
 $obj/N64System/dynarec/Block.o \


### PR DESCRIPTION
This fixes a few unresolved references while building the CLI executable frontend to the core.

Of course, a few are in progress:
```
Linking executable UI for Project64...
./Project64-CLI/../Project64-core/libproject64-core.a(AppInit.o): In function `AppInit(CNotification*, char const*, int, char**)':
AppInit.cpp:(.text+0xfd0): undefined reference to `CMipsMemoryVM::SetupSegvHandler()'
./Project64-CLI/../Project64-core/libproject64-core.a(PifRam.o): In function `CPifRam::ProcessControllerCommand(int, unsigned char*)':
PifRam.cpp:(.text+0xa26): undefined reference to `Transferpak::ReadFrom(unsigned short, unsigned char*)'
PifRam.cpp:(.text+0xb27): undefined reference to `Transferpak::WriteTo(unsigned short, unsigned char*)'
./Project64-CLI/../Project64-core/libproject64-core.a(SyTiming.o): In function `CSystemTimer::SaveData(void*&) const':
SystemTiming.cpp:(.text+0x5ae): undefined reference to `zipWriteInFileInZip'
SystemTiming.cpp:(.text+0x5c0): undefined reference to `zipWriteInFileInZip'
SystemTiming.cpp:(.text+0x5d0): undefined reference to `zipWriteInFileInZip'
SystemTiming.cpp:(.text+0x5e4): undefined reference to `zipWriteInFileInZip'
SystemTiming.cpp:(.text+0x5f8): undefined reference to `zipWriteInFileInZip'
./Project64-CLI/../Project64-core/libproject64-core.a(SyTiming.o):SystemTiming.cpp:(.text+0x60c): more undefined references to `zipWriteInFileInZip' follow
./Project64-CLI/../Project64-core/libproject64-core.a(SyTiming.o): In function `CSystemTimer::LoadData(void*&)':
SystemTiming.cpp:(.text+0x6cc): undefined reference to `unzReadCurrentFile'
SystemTiming.cpp:(.text+0x6de): undefined reference to `unzReadCurrentFile'
SystemTiming.cpp:(.text+0x726): undefined reference to `unzReadCurrentFile'
SystemTiming.cpp:(.text+0x73a): undefined reference to `unzReadCurrentFile'
SystemTiming.cpp:(.text+0x74e): undefined reference to `unzReadCurrentFile'
./Project64-CLI/../Project64-core/libproject64-core.a(SyTiming.o):SystemTiming.cpp:(.text+0x762): more undefined references to `unzReadCurrentFile' follow
./Project64-CLI/../Project64-core/libproject64-core.a(N64Class.o): In function `CN64System::~CN64System()':
N64Class.cpp:(.text+0x2d44): undefined reference to `Transferpak::Release()'
./Project64-CLI/../Project64-core/libproject64-core.a(N64Class.o): In function `CN64System::SaveState()':
N64Class.cpp:(.text+0x417b): undefined reference to `zipOpen'
N64Class.cpp:(.text+0x41d7): undefined reference to `zipOpenNewFileInZip'
N64Class.cpp:(.text+0x41fb): undefined reference to `zipWriteInFileInZip'
N64Class.cpp:(.text+0x4212): undefined reference to `zipWriteInFileInZip'
N64Class.cpp:(.text+0x422f): undefined reference to `zipWriteInFileInZip'
N64Class.cpp:(.text+0x4246): undefined reference to `zipWriteInFileInZip'
N64Class.cpp:(.text+0x425f): undefined reference to `zipWriteInFileInZip'
./Project64-CLI/../Project64-core/libproject64-core.a(N64Class.o):N64Class.cpp:(.text+0x4278): more undefined references to `zipWriteInFileInZip' follow
./Project64-CLI/../Project64-core/libproject64-core.a(N64Class.o): In function `CN64System::SaveState()':
N64Class.cpp:(.text+0x447a): undefined reference to `zipCloseFileInZip'
N64Class.cpp:(.text+0x44ce): undefined reference to `zipOpenNewFileInZip'
N64Class.cpp:(.text+0x44f2): undefined reference to `zipWriteInFileInZip'
N64Class.cpp:(.text+0x450f): undefined reference to `zipCloseFileInZip'
N64Class.cpp:(.text+0x4521): undefined reference to `zipClose'
./Project64-CLI/../Project64-core/libproject64-core.a(N64Class.o): In function `CN64System::LoadState(char const*)':
N64Class.cpp:(.text+0x4d14): undefined reference to `unzOpen'
N64Class.cpp:(.text+0x4d30): undefined reference to `unzGoToFirstFile'
N64Class.cpp:(.text+0x4d63): undefined reference to `unzGetCurrentFileInfo'
N64Class.cpp:(.text+0x4d7a): undefined reference to `unzLocateFile'
N64Class.cpp:(.text+0x4d8c): undefined reference to `unzOpenCurrentFile'
N64Class.cpp:(.text+0x4da8): undefined reference to `unzReadCurrentFile'
N64Class.cpp:(.text+0x4ddf): undefined reference to `unzReadCurrentFile'
N64Class.cpp:(.text+0x4df6): undefined reference to `unzReadCurrentFile'
N64Class.cpp:(.text+0x4e91): undefined reference to `unzReadCurrentFile'
N64Class.cpp:(.text+0x4ea7): undefined reference to `unzReadCurrentFile'
./Project64-CLI/../Project64-core/libproject64-core.a(N64Class.o):N64Class.cpp:(.text+0x4ebd): more undefined references to `unzReadCurrentFile' follow
./Project64-CLI/../Project64-core/libproject64-core.a(N64Class.o): In function `CN64System::LoadState(char const*)':
N64Class.cpp:(.text+0x5087): undefined reference to `unzCloseCurrentFile'
N64Class.cpp:(.text+0x5091): undefined reference to `unzGoToFirstFile'
N64Class.cpp:(.text+0x50ab): undefined reference to `unzClose'
N64Class.cpp:(.text+0x50ce): undefined reference to `unzCloseCurrentFile'
N64Class.cpp:(.text+0x5125): undefined reference to `unzGoToNextFile'
N64Class.cpp:(.text+0x512f): undefined reference to `unzClose'
./Project64-CLI/../Project64-core/libproject64-core.a(N64RomClass.o): In function `CN64Rom::AllocateAndLoadZipImage(char const*, bool)':
N64RomClass.cpp:(.text+0x82f): undefined reference to `unzOpen'
N64RomClass.cpp:(.text+0x846): undefined reference to `unzGoToFirstFile'
N64RomClass.cpp:(.text+0x888): undefined reference to `unzGetCurrentFileInfo'
N64RomClass.cpp:(.text+0x89d): undefined reference to `unzLocateFile'
N64RomClass.cpp:(.text+0x8a9): undefined reference to `unzOpenCurrentFile'
N64RomClass.cpp:(.text+0x8cb): undefined reference to `unzReadCurrentFile'
N64RomClass.cpp:(.text+0x961): undefined reference to `unzReadCurrentFile'
N64RomClass.cpp:(.text+0x974): undefined reference to `unzCloseCurrentFile'
N64RomClass.cpp:(.text+0xa19): undefined reference to `unzCloseCurrentFile'
N64RomClass.cpp:(.text+0xa7b): undefined reference to `unzCloseCurrentFile'
N64RomClass.cpp:(.text+0xa8e): undefined reference to `unzGoToNextFile'
N64RomClass.cpp:(.text+0xaa1): undefined reference to `unzClose'
collect2: error: ld returned 1 exit status
```