### PR TITLE
Fix Project64.sln mappings for Android projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ Thumbs.db
 /Config/Project64.sc3
 /Config/Project64.zcache
 /ipch
+/Plugin/Audio/AndroidAudio.dll
+/Plugin/Audio/AndroidAudio_d.dll
 /Plugin/GFX/lib
 /Plugin/GFX/map
 /Plugin/GFX/pdb
@@ -39,6 +41,8 @@ Thumbs.db
 /Plugin/Input/lib
 /Plugin/Input/map
 /Plugin/Input/pdb
+/Plugin/Input/AndroidInput.dll
+/Plugin/Input/AndroidInput_d.dll
 /Plugin/Input/PJ64_NRage.dll
 /Plugin/Input/PJ64_NRage_d.dll
 /Plugin/RSP/lib
@@ -46,6 +50,10 @@ Thumbs.db
 /Plugin/RSP/pdb
 /Plugin/RSP/RSP 1.7.dll
 /Plugin/RSP/RSP_d 1.7.dll
+/Plugin/RSP/RSP-HLE.dll
+/Plugin/RSP/RSP-HLE_d.dll
+/Plugin64/Audio/AndroidAudio.dll
+/Plugin64/Audio/AndroidAudio_d.dll
 /Plugin64/GFX/lib
 /Plugin64/GFX/map
 /Plugin64/GFX/pdb
@@ -54,6 +62,8 @@ Thumbs.db
 /Plugin64/Input/lib
 /Plugin64/Input/map
 /Plugin64/Input/pdb
+/Plugin64/Input/AndroidInput.dll
+/Plugin64/Input/AndroidInput_d.dll
 /Plugin64/Input/PJ64_NRage.dll
 /Plugin64/Input/PJ64_NRage_d.dll
 /Plugin64/RSP/lib

--- a/Project64.sln
+++ b/Project64.sln
@@ -1,7 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 2010 or lager
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "3rd Party", "3rd Party", "{AA8F7F8E-5377-4911-859D-8A8817B0DB26}"
 EndProject
@@ -63,11 +62,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginRSP", "Source\Android
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "JniBridge", "Source\Android\Bridge\Bridge.vcxproj", "{593B00E6-1987-415D-A62C-26533FC3E95C}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginAudio", "..\project64-console\Source\Android\PluginAudio\PluginAudio.vcxproj", "{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginAudio", "Source\Android\PluginAudio\PluginAudio.vcxproj", "{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginInput", "..\project64-console\Source\Android\PluginInput\PluginInput.vcxproj", "{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PluginInput", "Source\Android\PluginInput\PluginInput.vcxproj", "{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "JniBridge", "..\project64-console\Source\Android\Bridge\Bridge.vcxproj", "{2607037A-ADEE-4C8D-9761-17E7823A9E61}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "JniBridge", "Source\Android\Bridge\Bridge.vcxproj", "{2607037A-ADEE-4C8D-9761-17E7823A9E61}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -133,11 +132,8 @@ Global
 		{731BD205-2826-4631-B7AF-117658E88DBC}.Release|Win32.Build.0 = Release|Win32
 		{731BD205-2826-4631-B7AF-117658E88DBC}.Release|x64.ActiveCfg = Release|x64
 		{731BD205-2826-4631-B7AF-117658E88DBC}.Release|x64.Build.0 = Release|x64
-		{360A34F3-3172-4B09-8BC9-B3FBEE677863}.Debug|Win32.ActiveCfg = Debug|Win32
-		{360A34F3-3172-4B09-8BC9-B3FBEE677863}.Debug|x64.ActiveCfg = Debug|Win32
 		{360A34F3-3172-4B09-8BC9-B3FBEE677863}.Release|Win32.ActiveCfg = Release|Win32
 		{360A34F3-3172-4B09-8BC9-B3FBEE677863}.Release|Win32.Build.0 = Release|Win32
-		{360A34F3-3172-4B09-8BC9-B3FBEE677863}.Release|x64.ActiveCfg = Release|Win32
 		{A4D13408-A794-4199-8FC7-4A9A32505005}.Debug|Win32.ActiveCfg = Debug|Win32
 		{A4D13408-A794-4199-8FC7-4A9A32505005}.Debug|Win32.Build.0 = Debug|Win32
 		{A4D13408-A794-4199-8FC7-4A9A32505005}.Debug|x64.ActiveCfg = Debug|x64
@@ -188,46 +184,60 @@ Global
 		{17836496-31B0-46F2-B1B1-366D7DF6F04C}.Release|x64.Build.0 = Release|x64
 		{D233025A-231F-4A43-92B6-E87193C60ACC}.Debug|Win32.ActiveCfg = Debug|Win32
 		{D233025A-231F-4A43-92B6-E87193C60ACC}.Debug|Win32.Build.0 = Debug|Win32
-		{D233025A-231F-4A43-92B6-E87193C60ACC}.Debug|x64.ActiveCfg = Debug|Win32
+		{D233025A-231F-4A43-92B6-E87193C60ACC}.Debug|x64.ActiveCfg = Debug|x64
+		{D233025A-231F-4A43-92B6-E87193C60ACC}.Debug|x64.Build.0 = Debug|x64
 		{D233025A-231F-4A43-92B6-E87193C60ACC}.Release|Win32.ActiveCfg = Release|Win32
 		{D233025A-231F-4A43-92B6-E87193C60ACC}.Release|Win32.Build.0 = Release|Win32
-		{D233025A-231F-4A43-92B6-E87193C60ACC}.Release|x64.ActiveCfg = Release|Win32
+		{D233025A-231F-4A43-92B6-E87193C60ACC}.Release|x64.ActiveCfg = Release|x64
+		{D233025A-231F-4A43-92B6-E87193C60ACC}.Release|x64.Build.0 = Release|x64
 		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Debug|Win32.ActiveCfg = Debug|Win32
 		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Debug|Win32.Build.0 = Debug|Win32
-		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Debug|x64.ActiveCfg = Debug|Win32
+		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Debug|x64.ActiveCfg = Debug|x64
+		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Debug|x64.Build.0 = Debug|x64
 		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Release|Win32.ActiveCfg = Release|Win32
 		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Release|Win32.Build.0 = Release|Win32
-		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Release|x64.ActiveCfg = Release|Win32
+		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Release|x64.ActiveCfg = Release|x64
+		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Release|x64.Build.0 = Release|x64
 		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Debug|Win32.ActiveCfg = Debug|Win32
 		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Debug|Win32.Build.0 = Debug|Win32
-		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Debug|x64.ActiveCfg = Debug|Win32
+		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Debug|x64.ActiveCfg = Debug|x64
+		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Debug|x64.Build.0 = Debug|x64
 		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Release|Win32.ActiveCfg = Release|Win32
 		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Release|Win32.Build.0 = Release|Win32
-		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Release|x64.ActiveCfg = Release|Win32
+		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Release|x64.ActiveCfg = Release|x64
+		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Release|x64.Build.0 = Release|x64
 		{593B00E6-1987-415D-A62C-26533FC3E95C}.Debug|Win32.ActiveCfg = Debug|Win32
 		{593B00E6-1987-415D-A62C-26533FC3E95C}.Debug|Win32.Build.0 = Debug|Win32
-		{593B00E6-1987-415D-A62C-26533FC3E95C}.Debug|x64.ActiveCfg = Debug|Win32
+		{593B00E6-1987-415D-A62C-26533FC3E95C}.Debug|x64.ActiveCfg = Debug|x64
+		{593B00E6-1987-415D-A62C-26533FC3E95C}.Debug|x64.Build.0 = Debug|x64
 		{593B00E6-1987-415D-A62C-26533FC3E95C}.Release|Win32.ActiveCfg = Release|Win32
 		{593B00E6-1987-415D-A62C-26533FC3E95C}.Release|Win32.Build.0 = Release|Win32
-		{593B00E6-1987-415D-A62C-26533FC3E95C}.Release|x64.ActiveCfg = Release|Win32
+		{593B00E6-1987-415D-A62C-26533FC3E95C}.Release|x64.ActiveCfg = Release|x64
+		{593B00E6-1987-415D-A62C-26533FC3E95C}.Release|x64.Build.0 = Release|x64
 		{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}.Debug|Win32.ActiveCfg = Debug|Win32
 		{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}.Debug|Win32.Build.0 = Debug|Win32
-		{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}.Debug|x64.ActiveCfg = Debug|Win32
+		{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}.Debug|x64.ActiveCfg = Debug|x64
+		{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}.Debug|x64.Build.0 = Debug|x64
 		{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}.Release|Win32.ActiveCfg = Release|Win32
 		{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}.Release|Win32.Build.0 = Release|Win32
-		{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}.Release|x64.ActiveCfg = Release|Win32
+		{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}.Release|x64.ActiveCfg = Release|x64
+		{FEEA1071-2F0A-4436-A698-D0AF8CF79CFE}.Release|x64.Build.0 = Release|x64
 		{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}.Debug|Win32.ActiveCfg = Debug|Win32
 		{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}.Debug|Win32.Build.0 = Debug|Win32
-		{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}.Debug|x64.ActiveCfg = Debug|Win32
+		{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}.Debug|x64.ActiveCfg = Debug|x64
+		{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}.Debug|x64.Build.0 = Debug|x64
 		{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}.Release|Win32.ActiveCfg = Release|Win32
 		{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}.Release|Win32.Build.0 = Release|Win32
-		{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}.Release|x64.ActiveCfg = Release|Win32
+		{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}.Release|x64.ActiveCfg = Release|x64
+		{694F79A3-70F8-49F5-9287-8C38E1C8B6B1}.Release|x64.Build.0 = Release|x64
 		{2607037A-ADEE-4C8D-9761-17E7823A9E61}.Debug|Win32.ActiveCfg = Debug|Win32
 		{2607037A-ADEE-4C8D-9761-17E7823A9E61}.Debug|Win32.Build.0 = Debug|Win32
-		{2607037A-ADEE-4C8D-9761-17E7823A9E61}.Debug|x64.ActiveCfg = Debug|Win32
+		{2607037A-ADEE-4C8D-9761-17E7823A9E61}.Debug|x64.ActiveCfg = Debug|x64
+		{2607037A-ADEE-4C8D-9761-17E7823A9E61}.Debug|x64.Build.0 = Debug|x64
 		{2607037A-ADEE-4C8D-9761-17E7823A9E61}.Release|Win32.ActiveCfg = Release|Win32
 		{2607037A-ADEE-4C8D-9761-17E7823A9E61}.Release|Win32.Build.0 = Release|Win32
-		{2607037A-ADEE-4C8D-9761-17E7823A9E61}.Release|x64.ActiveCfg = Release|Win32
+		{2607037A-ADEE-4C8D-9761-17E7823A9E61}.Release|x64.ActiveCfg = Release|x64
+		{2607037A-ADEE-4C8D-9761-17E7823A9E61}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Android/Bridge/Bridge.vcxproj
+++ b/Source/Android/Bridge/Bridge.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Source/Android/PluginAudio/PluginAudio.vcxproj
+++ b/Source/Android/PluginAudio/PluginAudio.vcxproj
@@ -1,15 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Debug|Win32">
+			<Configuration>Debug</Configuration>
+			<Platform>Win32</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Debug|x64">
+			<Configuration>Debug</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|Win32">
+			<Configuration>Release</Configuration>
+			<Platform>Win32</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{D233025A-231F-4A43-92B6-E87193C60ACC}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>

--- a/Source/Android/PluginInput/PluginInput.vcxproj
+++ b/Source/Android/PluginInput/PluginInput.vcxproj
@@ -5,9 +5,17 @@
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Source/Android/PluginRSP/PluginRSP.vcxproj
+++ b/Source/Android/PluginRSP/PluginRSP.vcxproj
@@ -1,15 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Debug|Win32">
+			<Configuration>Debug</Configuration>
+			<Platform>Win32</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Debug|x64">
+			<Configuration>Debug</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|Win32">
+			<Configuration>Release</Configuration>
+			<Platform>Win32</Platform>
+		</ProjectConfiguration>
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>


### PR DESCRIPTION
Win32 is failing to build, and x64 is not correctly mapped.
All config,platform combinations work fine now.