### PR TITLE
[Common] Make WriteTrace() #define more stable #ifdef _DEBUG.

### DIFF
--- a/Source/Common/Trace.h
+++ b/Source/Common/Trace.h
@@ -37,9 +37,19 @@ private:
 };
 
 #ifdef _WIN32
-#define WriteTrace(m, s, format, ...) if(g_ModuleLogLevel[(m)] >= (s)) { WriteTraceFull((m), (s), __FILE__, __LINE__, __FUNCTION__, (format), ## __VA_ARGS__); }
+
+#define WriteTrace(m, s, format, ...) \
+if (g_ModuleLogLevel[(m)] >= (s)) {\
+    WriteTraceFull((m), (s), __FILE__, __LINE__, __FUNCTION__, (format), ## __VA_ARGS__);\
+}
+
 #else
-#define WriteTrace(m, s, format, ...) if(g_ModuleLogLevel[(m)] >= (s)) { WriteTraceFull((m), (s), __FILE__, __LINE__, __PRETTY_FUNCTION__, (format), ## __VA_ARGS__); }
+
+#define WriteTrace(m, s, format, ...) \
+if (g_ModuleLogLevel[(m)] >= (s)) {\
+    WriteTraceFull((m), (s), __FILE__, __LINE__, __PRETTY_FUNCTION__, (format), ## __VA_ARGS__);\
+}
+
 #endif
 
 CTraceModule * TraceAddModule(CTraceModule * TraceModule);

--- a/Source/Common/Trace.h
+++ b/Source/Common/Trace.h
@@ -38,17 +38,35 @@ private:
 
 #ifdef _WIN32
 
+#ifdef _DEBUG
+#define WriteTrace(m, s, format, ...) \
+if (g_ModuleLogLevel == NULL) {\
+    fputs("**ERROR**:  (g_ModuleLogLevel == NULL) in WriteTrace()", stderr);\
+} else if (g_ModuleLogLevel[(m)] >= (s)) {\
+    WriteTraceFull((m), (s), __FILE__, __LINE__, __FUNCTION__, (format), ## __VA_ARGS__);\
+}
+#else
 #define WriteTrace(m, s, format, ...) \
 if (g_ModuleLogLevel[(m)] >= (s)) {\
     WriteTraceFull((m), (s), __FILE__, __LINE__, __FUNCTION__, (format), ## __VA_ARGS__);\
 }
+#endif
 
 #else
 
+#ifdef _DEBUG
+#define WriteTrace(m, s, format, ...) \
+if (g_ModuleLogLevel == NULL) {\
+    fputs("**ERROR**:  (g_ModuleLogLevel == NULL) in WriteTrace()", stderr);\
+} else if (g_ModuleLogLevel[(m)] >= (s)) {\
+    WriteTraceFull((m), (s), __FILE__, __LINE__, __PRETTY_FUNCTION__, (format), ## __VA_ARGS__);\
+}
+#else
 #define WriteTrace(m, s, format, ...) \
 if (g_ModuleLogLevel[(m)] >= (s)) {\
     WriteTraceFull((m), (s), __FILE__, __LINE__, __PRETTY_FUNCTION__, (format), ## __VA_ARGS__);\
 }
+#endif
 
 #endif
 

--- a/Source/Common/Trace.h
+++ b/Source/Common/Trace.h
@@ -41,7 +41,7 @@ private:
 #ifdef _DEBUG
 #define WriteTrace(m, s, format, ...) \
 if (g_ModuleLogLevel == NULL) {\
-    fputs("**ERROR**:  (g_ModuleLogLevel == NULL) in WriteTrace()", stderr);\
+    fputs("**ERROR**:  (g_ModuleLogLevel == NULL) in WriteTrace()\n", stderr);\
 } else if (g_ModuleLogLevel[(m)] >= (s)) {\
     WriteTraceFull((m), (s), __FILE__, __LINE__, __FUNCTION__, (format), ## __VA_ARGS__);\
 }
@@ -57,7 +57,7 @@ if (g_ModuleLogLevel[(m)] >= (s)) {\
 #ifdef _DEBUG
 #define WriteTrace(m, s, format, ...) \
 if (g_ModuleLogLevel == NULL) {\
-    fputs("**ERROR**:  (g_ModuleLogLevel == NULL) in WriteTrace()", stderr);\
+    fputs("**ERROR**:  (g_ModuleLogLevel == NULL) in WriteTrace()\n", stderr);\
 } else if (g_ModuleLogLevel[(m)] >= (s)) {\
     WriteTraceFull((m), (s), __FILE__, __LINE__, __PRETTY_FUNCTION__, (format), ## __VA_ARGS__);\
 }

--- a/Source/Script/Unix/common.sh
+++ b/Source/Script/Unix/common.sh
@@ -7,6 +7,7 @@ FLAGS_x86="\
  -I$src/.. \
  -S \
  -fPIC \
+ -D_DEBUG \
  -masm=intel \
  -march=native \
  -Os"


### PR DESCRIPTION
With the high traffic in Project64's interface over the core, the state of my current working tree with local modifications to silently ignore/bypass each one just to wait until finding out what the real cause is has become rather overtaxing.  It becomes too difficult to keep local changes out of even my own master.

So why not have the macro fixed for _DEBUG compiles?