### PR TITLE
s/not exists/not exist

### DIFF
--- a/Source/Common/FileClass.cpp
+++ b/Source/Common/FileClass.cpp
@@ -127,10 +127,10 @@ bool CFile::Open(const char * lpszFileName, uint32_t nOpenFlags)
 
     if ((nOpenFlags & CFileBase::modeCreate) != CFileBase::modeCreate)
     {
-        printf("Checking if %s exists\n",lpszFileName);
+        printf("Checking if %s exists...\n",lpszFileName);
         if (!CPath(lpszFileName).Exists())
         {
-            printf("%s does not exists\n",lpszFileName);
+            printf("%s does not exist.\n",lpszFileName);
             return false;
         }
     }

--- a/Source/Common/path.cpp
+++ b/Source/Common/path.cpp
@@ -985,7 +985,7 @@ bool CPath::Delete(bool bEvenIfReadOnly) const
     uint32_t dwAttr = ::GetFileAttributes(m_strPath.c_str());
     if (dwAttr == (uint32_t)-1)
     {
-        // File does not exists
+        // File does not exist.
         return false;
     }
 

--- a/Source/Project64-core/Settings/SettingType/SettingsType-Application.cpp
+++ b/Source/Project64-core/Settings/SettingType/SettingsType-Application.cpp
@@ -69,7 +69,7 @@ void CSettingTypeApplication::Initialize(const char * /*AppName*/)
     CPath BaseDir(g_Settings->LoadStringVal(Cmd_BaseDirectory).c_str(), "");
     if (!BaseDir.DirectoryExists())
     {
-        WriteTrace(TraceAppInit, TraceDebug, "BaseDir does not exists, doing nothing");
+        WriteTrace(TraceAppInit, TraceDebug, "BaseDir does not exist.  Doing nothing.");
         WriteTrace(TraceAppInit, TraceDebug, "Done");
         return;
     }


### PR DESCRIPTION
Somehow, I find this to be rather distracting.

```
bash-4.2$ ./project64 
Project64:  version 2.3.0.9999

**ERROR**:  (g_ModuleLogLevel == NULL) in WriteTrace()
**ERROR**:  (g_ModuleLogLevel == NULL) in WriteTrace()
**ERROR**:  (g_ModuleLogLevel == NULL) in WriteTrace()
**ERROR**:  (g_ModuleLogLevel == NULL) in WriteTrace()
*base_directory:  ~/project64/Source/Script/Unix/Project64-CLI/.
./../../CLI/notify.cpp:  line 36

Checking if //Config/Project64.rdb exists
//Config/Project64.rdb does not exists
Checking if //Config/Project64.rdb exists
//Config/Project64.rdb does not exists
Checking if //Config/Glide64.rdb exists
//Config/Glide64.rdb does not exists
Checking if //Config/Glide64.rdb exists
//Config/Glide64.rdb does not exists
Checking if //Config/Project64.cht exists
//Config/Project64.cht does not exists
Checking if //Config/Project64.cht exists
//Config/Project64.cht does not exists
Segmentation fault
```

_Complete_ sentences always end with a period, so it should be "[...] does not exist."