### PR TITLE
Fix unresolved g_RecompPos to name m_RecompPos.

### DIFF
--- a/Source/Project64-core/N64System/Recompiler/x86/x86ops.cpp
+++ b/Source/Project64-core/N64System/Recompiler/x86/x86ops.cpp
@@ -216,7 +216,7 @@ void CX86Ops::Call_Direct(void * FunctAddress, const char * FunctName)
 {
     CPU_Message("      call offset %s", FunctName);
     AddCode8(0xE8);
-    AddCode32((uint32_t)FunctAddress - (uint32_t)*g_RecompPos - 4);
+    AddCode32((uint32_t)FunctAddress - (uint32_t)*m_RecompPos - 4);
 }
 
 void CX86Ops::Call_Indirect(void * FunctAddress, const char * FunctName)


### PR DESCRIPTION
Fixes a compile error regression introduced when attempting to build on Windows or Linux after commit https://github.com/project64/project64/commit/1e2cc8eb90150b3daadb02a8ce18bb6f45f26008 .