### PR TITLE
Revert "Fix Mario 64 texture wobble"

### DIFF
--- a/Source/Glide64/Util.cpp
+++ b/Source/Glide64/Util.cpp
@@ -698,7 +698,7 @@ static void clip_w(int interpolate_colors)
                 rdp.vtxbuf[index].x = Vi.x + (Vj.x - Vi.x) * percent;
                 rdp.vtxbuf[index].y = Vi.y + (Vj.y - Vi.y) * percent;
                 rdp.vtxbuf[index].z = Vi.z + (Vj.z - Vi.z) * percent;
-                rdp.vtxbuf[index].w = 1.00f;
+                rdp.vtxbuf[index].w = 0.01f;
                 rdp.vtxbuf[index].u0 = Vi.u0 + (Vj.u0 - Vi.u0) * percent;
                 rdp.vtxbuf[index].v0 = Vi.v0 + (Vj.v0 - Vi.v0) * percent;
                 rdp.vtxbuf[index].u1 = Vi.u1 + (Vj.u1 - Vi.u1) * percent;
@@ -719,7 +719,7 @@ static void clip_w(int interpolate_colors)
                 rdp.vtxbuf[index].x = Vj.x + (Vi.x - Vj.x) * percent;
                 rdp.vtxbuf[index].y = Vj.y + (Vi.y - Vj.y) * percent;
                 rdp.vtxbuf[index].z = Vj.z + (Vi.z - Vj.z) * percent;
-                rdp.vtxbuf[index].w = 1.00f;
+                rdp.vtxbuf[index].w = 0.01f;
                 rdp.vtxbuf[index].u0 = Vj.u0 + (Vi.u0 - Vj.u0) * percent;
                 rdp.vtxbuf[index].v0 = Vj.v0 + (Vi.v0 - Vj.v0) * percent;
                 rdp.vtxbuf[index].u1 = Vj.u1 + (Vi.u1 - Vj.u1) * percent;


### PR DESCRIPTION
Commit https://github.com/project64/project64/commit/5b82ca80da2386b962a8744001c0f6209e116365 causes too many side effects for too little gain.

This should fix https://github.com/project64/project64/issues/1149