### PR TITLE
Monaco GP Counter Factor

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -3513,6 +3513,7 @@ Status=Compatible
 Good Name=Monaco Grand Prix (U)
 Internal Name=Monaco Grand Prix
 Status=Compatible
+Counter Factor=1
 Culling=1
 RDRAM Size=8
 
@@ -3521,6 +3522,7 @@ Good Name=Monaco Grand Prix - Racing Simulation 2 (E) (M4)
 Internal Name=Monaco GP Racing 2
 Status=Compatible
 Clear Frame=2
+Counter Factor=1
 Culling=1
 
 [5AC383E1-D712E387-C:45]


### PR DESCRIPTION
Analog control is impossible with counter factor 2.  It behaves like switched keyboard input.  This game needs Counter Factor 1.