### PR TITLE
Fix install directory

### DIFF
--- a/Source/Installer/Installer.iss
+++ b/Source/Installer/Installer.iss
@@ -5,7 +5,7 @@
 AppId={{BEB5FB69-4080-466F-96C4-F15DF271718B}
 AppName=Project64
 AppVersion={#AppVersion}
-DefaultDirName={pf}\Project64 2.3
+DefaultDirName={userdocs}\..\Project64 2.3
 VersionInfoVersion={#AppVersion}
 OutputDir={#BaseDir}\Bin\{#Configuration}
 OutputBaseFilename=Setup Project64 2.3


### PR DESCRIPTION
This changes the default install directory to Users\USERNAME\Project64 2.3.

Windows 8, 8,1 and 10 don't have permission for programs to write files in the Program Files directory.

I tried to use OnlyBelowVersion and MiniVersion parameters, but couldn't get it to work for DefaultDirName.  I'm not sure which directory it will point at for XP or 7.  Needs to be tested on Windows 7/XP.