### PR TITLE
[Installer] Fix permissions - desktop icon option

### DIFF
--- a/Source/Installer/Installer.iss
+++ b/Source/Installer/Installer.iss
@@ -40,6 +40,7 @@ Name: "{app}\Logs"; Permissions: everyone-full
 Name: "{app}\Save"; Permissions: everyone-full
 Name: "{app}\Screenshots"; Permissions: everyone-full
 Name: "{app}\Textures"; Permissions: everyone-full
+Name: "{app}"; Permissions: everyone-full
 
 [Icons]
 Name: "{commondesktop}\Project64"; Filename: "{app}\Project64.exe"; Tasks: desktopicon

--- a/Source/Installer/Installer.iss
+++ b/Source/Installer/Installer.iss
@@ -5,7 +5,7 @@
 AppId={{BEB5FB69-4080-466F-96C4-F15DF271718B}
 AppName=Project64
 AppVersion={#AppVersion}
-DefaultDirName={pf}\Project64 2.3
+DefaultDirName={pf32}\Project64 2.3
 VersionInfoVersion={#AppVersion}
 OutputDir={#BaseDir}\Bin\{#Configuration}
 OutputBaseFilename=Setup Project64 2.3
@@ -35,11 +35,11 @@ Source: "{#BaseDir}\Plugin\Input\PJ64_NRage.dll"; DestDir: "{app}\Plugin\Input"
 Source: "{#BaseDir}\Plugin\RSP\RSP 1.7.dll"; DestDir: "{app}\Plugin\RSP"
 
 [Dirs]
-Name: "{app}\Config"; Permissions: users-modify
-Name: "{app}\Logs"; Permissions: users-modify
-Name: "{app}\Save"; Permissions: users-modify
-Name: "{app}\Screenshots"; Permissions: users-modify
-Name: "{app}\Textures"; Permissions: users-modify
+Name: "{app}\Config"; Permissions: everyone-full
+Name: "{app}\Logs"; Permissions: everyone-full
+Name: "{app}\Save"; Permissions: everyone-full
+Name: "{app}\Screenshots"; Permissions: everyone-full
+Name: "{app}\Textures"; Permissions: everyone-full
 
 [Icons]
 Name: "{commonprograms}\Project64 2.3\Project64"; Filename: "{app}\Project64.exe"

--- a/Source/Installer/Installer.iss
+++ b/Source/Installer/Installer.iss
@@ -42,7 +42,10 @@ Name: "{app}\Screenshots"; Permissions: everyone-full
 Name: "{app}\Textures"; Permissions: everyone-full
 
 [Icons]
+Name: "{commondesktop}\Project64"; Filename: "{app}\Project64.exe"; Tasks: desktopicon
 Name: "{commonprograms}\Project64 2.3\Project64"; Filename: "{app}\Project64.exe"
 Name: "{commonprograms}\Project64 2.3\Uninstall Project64 2.3"; Filename: "{uninstallexe}"; Parameters: "/LOG"
 Name: "{commonprograms}\Project64 2.3\Support"; Filename: "http://forum.pj64-emu.com"
 
+[Tasks]
+Name: desktopicon; Description: "Create a &desktop icon"


### PR DESCRIPTION
Fixes permissions for Windows 7/8/10.  And correct Program Files (x86) folder when running on 64bit windows.