### PR TITLE
Fix Exception in main.cpp

### DIFF
--- a/Source/Common/path.cpp
+++ b/Source/Common/path.cpp
@@ -587,6 +587,11 @@ void CPath::SetComponents(const char * lpszDrive, const char * lpszDirectory, co
     char buff_fullname[MAX_PATH];
 
     memset(buff_fullname, 0, sizeof(buff_fullname));
+    if (lpszDirectory == NULL || strlen(lpszDirectory) == 0)
+    {
+        static char empty_dir[] = { DIRECTORY_DELIMITER, '\0' };
+        lpszDirectory = empty_dir;
+    }
 
     _makepath(buff_fullname, lpszDrive, lpszDirectory, lpszName, lpszExtension);
     m_strPath.erase();


### PR DESCRIPTION
If Project64 is run from C:\Project64, we get an exception in main.cpp.

![permissionerror](https://cloud.githubusercontent.com/assets/11056843/17838500/fa916d18-67c6-11e6-98ef-9ae4726b8d64.png)

This fixes that bug.