### PR TITLE
GetLength must be multiple of 8

### DIFF
--- a/Source/Project64-core/N64System/Mips/Audio.cpp
+++ b/Source/Project64-core/N64System/Mips/Audio.cpp
@@ -38,10 +38,10 @@ uint32_t CAudio::GetLength()
     uint32_t TimeLeft = g_SystemTimer->GetTimer(CSystemTimer::AiTimerInterrupt), Res = 0;
     if (TimeLeft > 0)
     {
-        Res = (TimeLeft / m_CountsPerByte);
+        Res = (TimeLeft / m_CountsPerByte)&~7;
     }
     WriteTrace(TraceAudio, TraceDebug, "Done (res = %d, TimeLeft = %d)", Res, TimeLeft);
-    return (Res + 3)&~3;
+    return Res;
 }
 
 uint32_t CAudio::GetStatus()


### PR DESCRIPTION
According to LaC's n64 hardware dox, the AI_LEN_REG must be a multiple of 8 not 4.