### PR TITLE
Fixed includes for FunctionMapClass.

### DIFF
--- a/Source/Project64-core/N64System/Recompiler/FunctionMapClass.h
+++ b/Source/Project64-core/N64System/Recompiler/FunctionMapClass.h
@@ -10,6 +10,7 @@
 ****************************************************************************/
 #pragma once
 #include <Project64-core/N64System/Recompiler/FunctionInfo.h>
+#include <Project64-core/Settings/GameSettings.h>
 
 class CFunctionMap :
     private CGameSettings


### PR DESCRIPTION
Attempting to build for x64 failed with this error:
```
Source\Project64-core\N64System\Recompiler\FunctionMapClass.h(16):Source\Project64-core\N64System\Recompiler\FunctionMapClass.h(16,0): Error C2504: 'CGameSettings': base class undefined
```

This was due to `x86RegInfo.h` including headers that `x64RegInfo` doesn't.