### PR TITLE
[Glide64] port winback hack from GLideN64

### DIFF
--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -445,6 +445,8 @@ void ReadSpecialSettings(const char * name)
         g_settings->hacks |= hack_GoldenEye;
     else if (strstr(name, (const char *)"PUZZLE LEAGUE"))
         g_settings->hacks |= hack_PPL;
+	else if (strstr(name, (const char *)"WIN BACK") || strstr(name, (const char *)"OPERATION WINBACK"))
+		g_settings->hacks |= hack_Winback;
 
     g_settings->alt_tex_size = GetSetting(Set_alt_tex_size);
     g_settings->use_sts1_only = GetSetting(Set_use_sts1_only);

--- a/Source/Glide64/Settings.h
+++ b/Source/Glide64/Settings.h
@@ -151,9 +151,10 @@ public:
 #define  hack_TGR         (1<<24)  //Top Gear Rally
 #define  hack_TGR2        (1<<25)  //Top Gear Rally 2
 #define  hack_Tonic       (1<<26)  //tonic trouble
-#define  hack_Yoshi       (1<<27)  //Yoshi Story
-#define  hack_Zelda       (1<<28)  //zeldas hacks
-#define  hack_OoT         (1<<29)  //zelda OoT hacks
+#define  hack_Winback     (1<<27)  //WinBack - Covert Operations
+#define  hack_Yoshi       (1<<28)  //Yoshi Story
+#define  hack_Zelda       (1<<29)  //zeldas hacks
+#define  hack_OoT         (1<<30)  //zelda OoT hacks
     uint32_t hacks;
 
     //wrapper settings

--- a/Source/Glide64/rdp.cpp
+++ b/Source/Glide64/rdp.cpp
@@ -929,11 +929,16 @@ static void rdp_texrect()
         else
         {
             //gDPTextureRectangle
-            if (g_settings->hacks&hack_ASB)
+			if (g_settings->hacks&hack_ASB || g_settings->hacks&hack_Winback)
                 rdp.cmd2 = 0;
             else
                 rdp.cmd2 = ((uint32_t*)gfx.RDRAM)[a + 0];
-            rdp.cmd3 = ((uint32_t*)gfx.RDRAM)[a + 1];
+
+			if (g_settings->hacks&hack_Winback)
+				rdp.cmd3 = 0;
+			else
+				rdp.cmd3 = ((uint32_t*)gfx.RDRAM)[a + 1];
+
             rdp.pc[rdp.pc_i] += 8;
         }
     }
@@ -943,7 +948,7 @@ static void rdp_texrect()
         return;
     }
 
-    if (rdp.skip_drawing || (!fb_emulation_enabled && (rdp.cimg == rdp.zimg)))
+	if (rdp.skip_drawing || (!fb_emulation_enabled && (rdp.cimg == rdp.zimg)) || rdp.cmd3 == 0)
     {
         if ((g_settings->hacks&hack_PMario) && rdp.ci_status == ci_useless)
         {


### PR DESCRIPTION
This fixes the moving gray square bug in WinBack - Covert Operations
This is a HLE bug, so a hack might be the best solution
see https://github.com/gonetz/GLideN64/issues/63 for more details