### PR TITLE
[Glide64] correct Winback hack

### DIFF
--- a/Source/Glide64/rdp.cpp
+++ b/Source/Glide64/rdp.cpp
@@ -929,16 +929,17 @@ static void rdp_texrect()
         else
         {
             //gDPTextureRectangle
-			if (g_settings->hacks&hack_ASB || g_settings->hacks&hack_Winback)
+			if (g_settings->hacks&hack_Winback) {
+				rdp.pc[rdp.pc_i] += 8;
+				return;
+			}
+
+			if (g_settings->hacks&hack_ASB)
                 rdp.cmd2 = 0;
             else
                 rdp.cmd2 = ((uint32_t*)gfx.RDRAM)[a + 0];
 
-			if (g_settings->hacks&hack_Winback)
-				rdp.cmd3 = 0;
-			else
-				rdp.cmd3 = ((uint32_t*)gfx.RDRAM)[a + 1];
-
+			rdp.cmd3 = ((uint32_t*)gfx.RDRAM)[a + 1];
             rdp.pc[rdp.pc_i] += 8;
         }
     }
@@ -948,7 +949,7 @@ static void rdp_texrect()
         return;
     }
 
-	if (rdp.skip_drawing || (!fb_emulation_enabled && (rdp.cimg == rdp.zimg)) || rdp.cmd3 == 0)
+	if (rdp.skip_drawing || (!fb_emulation_enabled && (rdp.cimg == rdp.zimg)))
     {
         if ((g_settings->hacks&hack_PMario) && rdp.ci_status == ci_useless)
         {


### PR DESCRIPTION
I made a mistake and ported a wrong version of the hack.
This fixed regressions in triple play 2000