### PR TITLE
[Glide64] Fix #1224

### DIFF
--- a/Source/Glide64/Main.cpp
+++ b/Source/Glide64/Main.cpp
@@ -2054,7 +2054,7 @@ void newSwapBuffers()
             g_settings->frame_buffer ^= fb_ref;
         }
     }
-    if (g_settings->buff_clear && (hotkey_info.hk_ref || hotkey_info.hk_motionblur || hotkey_info.hk_filtering))
+    if (hotkey_info.hk_ref || hotkey_info.hk_motionblur || hotkey_info.hk_filtering)
     {
         set_message_combiner();
         char buf[256];


### PR DESCRIPTION
Fix text display not showing if clear buffer on every frame is off.

This text display is mixed up with hotkey_info..  Which is used as timer for display.