### PR TITLE
[64DD] Avoid Disk save disappearing when crashing during save

### DIFF
--- a/Source/Project64-core/N64System/N64DiskClass.cpp
+++ b/Source/Project64-core/N64System/N64DiskClass.cpp
@@ -76,7 +76,7 @@ bool CN64Disk::SaveDiskImage()
 
     WriteTrace(TraceN64System, TraceDebug, "Trying to open %s (Shadow File)", ShadowFile.c_str());
     m_DiskFile.Close();
-    if (!m_DiskFile.Open(ShadowFile.c_str(), CFileBase::modeWrite | CFileBase::modeCreate))
+    if (!m_DiskFile.Open(ShadowFile.c_str(), CFileBase::modeWrite | CFileBase::modeCreate | CFileBase::modeNoTruncate))
     {
         WriteTrace(TraceN64System, TraceError, "Failed to open %s (Shadow File)", ShadowFile.c_str());
         return false;


### PR DESCRIPTION
I had that problem myself several times, it's maybe time to stop being lazy and actually fix this :D