### PR TITLE
[RDB] Fix freeze in Wonder Project J2

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -6794,12 +6794,12 @@ RDRAM Size=8
 Good Name=Wonder Project J2 - Corlo no Mori no Josette (J)
 Internal Name=WONDER PROJECT J2
 Status=Compatible
-Core Note=Intro hang? skip to avoid
+Counter Factor=1
 
 [4F1E88F7-4A5A3F96-C:4A]
 Good Name=Wonder Project J2 [T]
 Status=Compatible
-Core Note=Intro hang? skip to avoid
+Counter Factor=1
 
 [F9FC3090-FF014EC2-C:50]
 Good Name=World Cup 98 (E) (M8)


### PR DESCRIPTION
The translation always freezed after the letter scene, but the Japanese rom did not freeze every time.
I managed to make a save state where it will always freeze if you don't press the Z button.
Interpreter + cxd4 RSP also freeze. CF=1 fixes the freeze in all cases.

[Wonder Project J2 - Corlo no Mori no Josette (J).pj.zip](https://github.com/project64/project64/files/673430/Wonder.Project.J2.-.Corlo.no.Mori.no.Josette.J.pj.zip)
