### PR TITLE
Fix Glitch64 build.

### DIFF
--- a/Source/Glitch64/OGLgeometry.cpp
+++ b/Source/Glitch64/OGLgeometry.cpp
@@ -22,6 +22,7 @@ static int st1_off;
 static int st1_en;
 static int fog_ext_off;
 static int fog_ext_en;
+static int fog_enabled;
 
 int w_buffer_mode;
 int inverted_culling;


### PR DESCRIPTION
`fog_enabled` was removed from glitchman.h. This caused build errors:
```
Source\Glitch64\OGLgeometry.cpp(383):Source\Glitch64\OGLgeometry.cpp(383,0): Error C2065: 'fog_enabled': undeclared identifier
Source\Glitch64\OGLgeometry.cpp(385):Source\Glitch64\OGLgeometry.cpp(385,0): Error C2065: 'fog_enabled': undeclared identifier
...
```

because it is stil used in OGLgeometry.
Added the variable statically.