### PR TITLE
[RDB] Use best possible settings for Super Mario 64

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -5541,24 +5541,44 @@ Plugin Note=[Glide64] splitscreen/picture in picture problem
 Good Name=Super Mario 64 (E) (M3)
 Internal Name=SUPER MARIO 64
 Status=Compatible
+Counter Factor=1
+SMM-Cache=0
+SMM-FUNC=0
+SMM-PI DMA=0
+SMM-TLB=0
 Culling=1
 
 [4EAA3D0E-74757C24-C:4A]
 Good Name=Super Mario 64 (J)
 Internal Name=SUPER MARIO 64
 Status=Compatible
+Counter Factor=1
+SMM-Cache=0
+SMM-FUNC=0
+SMM-PI DMA=0
+SMM-TLB=0
 Culling=1
 
 [635A2BFF-8B022326-C:45]
 Good Name=Super Mario 64 (U)
 Internal Name=SUPER MARIO 64
 Status=Compatible
+Counter Factor=1
+SMM-Cache=0
+SMM-FUNC=0
+SMM-PI DMA=0
+SMM-TLB=0
 Culling=1
 
 [D6FBA4A8-6326AA2C-C:4A]
 Good Name=Super Mario 64 - Shindou Edition (J)
 Internal Name=SUPERMARIO64
 Status=Compatible
+Counter Factor=1
+SMM-Cache=0
+SMM-FUNC=0
+SMM-PI DMA=0
+SMM-TLB=0
 Culling=1
 
 [66572080-28E348E1-C:4A]


### PR DESCRIPTION
Starting work on the RDB. First things first: Super Mario 64. This is like the most popular game for the console, and probably what most people will first play on the emulator, so it should run as good as possible. Explanation of these settings:

1. Set Counter Factor to 1. Makes the title screen with Mario's disembodied head far smoother (runs at a steady 30 DL/s NTSC/25 DL/s PAL), and should prevent any slowdowns. Also makes transitions between maps slightly quicker.
2. Disabled all Self-Modifying Code Methods. 99% certain this game doesn't need them. Should increase core speed, not that this game is resource-intensive but it doesn't hurt to optimize.

Tested these settings very thoroughly with the (U) ROM (collected all 120 stars, did about every action possible, even tried the hidden level select and debug displays), and fairly extensively with the (E), (J) and Shindou Edition ROMs.

I was tempted to disable Advanced Block Linking (also tested fairly extensively with it Off) to prevent microstuttering, but I think that's something that should be considered on a more global level.