### PR TITLE
Update French.pj.Lang

### DIFF
--- a/Lang/French.pj.Lang
+++ b/Lang/French.pj.Lang
@@ -541,7 +541,7 @@
 #3016#  "Project64 pour Android"
 #3017#  "Licence"
 #3018#  "Révision"
-#3019#  "Project64 pour Android\u2122 est un port de la version Windows de project64. La version\u2122 Android peut lancer la plupart des jeux N64."
+#3019#  "Project64 pour Android\u2122 est un port de la version Windows de project64. La version Android\u2122 peut lancer la plupart des jeux N64."
 #3020#  "Auteurs de Project64."
 
 //In game menu


### PR DESCRIPTION
Last fix. It seems "La version Android\u2122" is now correct.