### PR TITLE
Change Z_BUFSIZE to fix zlib behavior on Windows XP.

### DIFF
--- a/Source/3rdParty/zlib/zlib.vcxproj
+++ b/Source/3rdParty/zlib/zlib.vcxproj
@@ -36,6 +36,9 @@
       <PrecompiledHeader />
       <WarningLevel>Level4</WarningLevel>
       <DisableSpecificWarnings>4100;4127;4131;4189;4244;4701;4703;4996</DisableSpecificWarnings>
+
+      <!-- Fix for later VC versions on XP: 45KB + 436 -->
+      <PreprocessorDefinitions>Z_BUFSIZE=46516;$(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
Project64 failed to save states on Windows XP when built with Visual Studio 2010 or later.
This is likely a compiler issue related to memory layout.

To work around it, changed the value of `Z_BUFSIZE` in ZLib's makefile (zlib.vcxproj) to a lower one (from `64KB` to about `45KB`).