### PR TITLE
minor fix 64 for Densha de GO! 64

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1304,7 +1304,9 @@ Status=Compatible
 [17C54A61-4A83F2E7-C:4A]
 Good Name=Densha de GO! 64 (J)
 Internal Name=ÃÞÝ¼¬ÃÞGO!64
+Save Type=16kbit Eeprom
 Status=Compatible
+Counter Factor=1
 
 [A5F667E1-DA1FBD1F-C:4A]
 Good Name=Derby Stallion 64 (J)


### PR DESCRIPTION
save type needs to be 16kbit EEPROM otherwise the game will never load or save; setting counter factor to 1 makes the game speed more accurate to other DdGO games (tested side-by-side) and fixes audio issues