### PR TITLE
Ignore VS2017 metadata folder.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,0 @@
-[*]
-indent_style = tab
-indent_size = 4
-end_of_line = lf
-insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.o
 
 Thumbs.db
+/.vs
 /Bin/Debug
 /Bin/Debug64
 /Bin/Package


### PR DESCRIPTION
Adds `.vs` to the ignored folders list.