### PR TITLE
Fix Namco Museum Galaga freeze.

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -3681,7 +3681,6 @@ Good Name=Namco Museum 64 (U)
 Internal Name=NAMCOMUSEUM64
 Status=Compatible
 32bit=No
-Culling=1
 RDRAM Size=8
 
 [DF331A18-5FD4E044-C:45]

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -3680,6 +3680,7 @@ Status=Compatible
 Good Name=Namco Museum 64 (U)
 Internal Name=NAMCOMUSEUM64
 Status=Compatible
+32bit=No
 Culling=1
 RDRAM Size=8
 


### PR DESCRIPTION
Reported in http://forum.pj64-emu.com/showthread.php?t=7594.

Disabling 32-bit engine fixes the freezing in Galaga.