### PR TITLE
Add defaults file so MSBuild can be run from any subdirectory.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <PropertyGroup>
+    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)</SolutionDir>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This change adds `Directory.Build.props` (name and location mandatory by convention) to the root of the repository.

What it does:
Allows for `MSBuild` (when not running Visual Studio) to be run from any directory containing a VCXPROJ file, in order to build a specific project from the command line.

What it fixes:
Without it, running `MSBuild` from, for example, `Source\Common`,  yields the following error:
```
Common.vcxproj(30,5): error MSB4019: The imported project "Source\Common\PropertySheets\Platform.Debug.props" was not found.
 Confirm that the path in the <Import> declaration is correct, and that the file exists on disk.
```