### PR TITLE
Skip Android modules on Windows builds.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-
   <PropertyGroup>
-    <Platform Condition="'$(Platform)' == ''">Win32</Platform>
+    <Platform      Condition="'$(Platform)'      == ''">Win32</Platform>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <SolutionDir Condition="'$(SolutionDir)' == ''">$(MSBuildThisFileDirectory)</SolutionDir>
+    <SolutionDir   Condition="'$(SolutionDir)'   == ''">$(MSBuildThisFileDirectory)</SolutionDir>
   </PropertyGroup>
-
 </Project>

--- a/Project64.sln
+++ b/Project64.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26430.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "3rd Party", "3rd Party", "{AA8F7F8E-5377-4911-859D-8A8817B0DB26}"
 EndProject
@@ -55,6 +55,11 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "JniBridge", "Source\Android\Bridge\Bridge.vcxproj", "{593B00E6-1987-415D-A62C-26533FC3E95C}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Project64-video", "Source\Project64-video\Project64-video.vcxproj", "{A4D13408-A794-4199-8FC7-4A9A32505005}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C2390A06-21BB-4B32-88D7-AC83867720C6}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -120,7 +125,7 @@ Global
 		{731BD205-2826-4631-B7AF-117658E88DBC}.Release|Win32.Build.0 = Release|Win32
 		{731BD205-2826-4631-B7AF-117658E88DBC}.Release|x64.ActiveCfg = Release|x64
 		{731BD205-2826-4631-B7AF-117658E88DBC}.Release|x64.Build.0 = Release|x64
-		{360A34F3-3172-4B09-8BC9-B3FBEE677863}.Debug|Win32.ActiveCfg = Release|Win32
+		{360A34F3-3172-4B09-8BC9-B3FBEE677863}.Debug|Win32.ActiveCfg = Debug|Win32
 		{360A34F3-3172-4B09-8BC9-B3FBEE677863}.Debug|x64.ActiveCfg = Release|Win32
 		{360A34F3-3172-4B09-8BC9-B3FBEE677863}.Release|Win32.ActiveCfg = Release|Win32
 		{360A34F3-3172-4B09-8BC9-B3FBEE677863}.Release|Win32.Build.0 = Release|Win32
@@ -150,28 +155,20 @@ Global
 		{17836496-31B0-46F2-B1B1-366D7DF6F04C}.Release|x64.ActiveCfg = Release|x64
 		{17836496-31B0-46F2-B1B1-366D7DF6F04C}.Release|x64.Build.0 = Release|x64
 		{D233025A-231F-4A43-92B6-E87193C60ACC}.Debug|Win32.ActiveCfg = Debug|Win32
-		{D233025A-231F-4A43-92B6-E87193C60ACC}.Debug|Win32.Build.0 = Debug|Win32
 		{D233025A-231F-4A43-92B6-E87193C60ACC}.Debug|x64.ActiveCfg = Debug|Win32
 		{D233025A-231F-4A43-92B6-E87193C60ACC}.Release|Win32.ActiveCfg = Release|Win32
-		{D233025A-231F-4A43-92B6-E87193C60ACC}.Release|Win32.Build.0 = Release|Win32
 		{D233025A-231F-4A43-92B6-E87193C60ACC}.Release|x64.ActiveCfg = Release|Win32
 		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Debug|Win32.ActiveCfg = Debug|Win32
-		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Debug|Win32.Build.0 = Debug|Win32
 		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Debug|x64.ActiveCfg = Debug|Win32
 		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Release|Win32.ActiveCfg = Release|Win32
-		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Release|Win32.Build.0 = Release|Win32
 		{1133A1CC-A9E5-4026-B20D-6A2987130D4E}.Release|x64.ActiveCfg = Release|Win32
 		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Debug|Win32.ActiveCfg = Debug|Win32
-		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Debug|Win32.Build.0 = Debug|Win32
 		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Debug|x64.ActiveCfg = Debug|Win32
 		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Release|Win32.ActiveCfg = Release|Win32
-		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Release|Win32.Build.0 = Release|Win32
 		{B685BB34-D700-4FCC-8503-9B6AA1A0C95D}.Release|x64.ActiveCfg = Release|Win32
 		{593B00E6-1987-415D-A62C-26533FC3E95C}.Debug|Win32.ActiveCfg = Debug|Win32
-		{593B00E6-1987-415D-A62C-26533FC3E95C}.Debug|Win32.Build.0 = Debug|Win32
 		{593B00E6-1987-415D-A62C-26533FC3E95C}.Debug|x64.ActiveCfg = Debug|Win32
 		{593B00E6-1987-415D-A62C-26533FC3E95C}.Release|Win32.ActiveCfg = Release|Win32
-		{593B00E6-1987-415D-A62C-26533FC3E95C}.Release|Win32.Build.0 = Release|Win32
 		{593B00E6-1987-415D-A62C-26533FC3E95C}.Release|x64.ActiveCfg = Release|Win32
 		{A4D13408-A794-4199-8FC7-4A9A32505005}.Debug|Win32.ActiveCfg = Debug|Win32
 		{A4D13408-A794-4199-8FC7-4A9A32505005}.Debug|Win32.Build.0 = Debug|Win32

--- a/Project64.sln
+++ b/Project64.sln
@@ -1,6 +1,4 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "3rd Party", "3rd Party", "{AA8F7F8E-5377-4911-859D-8A8817B0DB26}"
 EndProject


### PR DESCRIPTION
Currently, doing a full Windows build also compiles Android plugins, unnecessarily increasing build time.

This change excludes those projects when building for Windows x86 or x64.