### PR TITLE
Wait for previous process to terminate

### DIFF
--- a/Source/Common/Util.cpp
+++ b/Source/Common/Util.cpp
@@ -107,6 +107,7 @@ bool pjutil::TerminatedExistingExe()
                     if (TerminateProcess(hHandle, 0))
                     {
                         bTerminated = true;
+                        WaitForSingleObject(hHandle, 30 * 1000);
                     }
                     else
                     {


### PR DESCRIPTION
The new process will not have read/write access to config files if it
does not wait until previous processes have been terminated.