### PR TITLE
vsprintf() needs stdio and stdarg.

### DIFF
--- a/Source/Project64-core/N64System/Recompiler/RecompilerCodeLog.cpp
+++ b/Source/Project64-core/N64System/Recompiler/RecompilerCodeLog.cpp
@@ -13,6 +13,10 @@
 #include <Common/path.h>
 #include <Common/Platform.h>
 
+/* vsprintf() */
+#include <stdio.h>
+#include <stdarg.h>
+
 static CLog * g_CPULogFile = NULL;
 
 void Recompiler_Log_Message(const char * strFormat, ...)


### PR DESCRIPTION
...Unless, of course, some other header like <windows.h> includes those.