### PR TITLE
Sync Plugin64 rename to PJ64Video to 32-bit plugin dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,8 @@ Thumbs.db
 /Plugin64/GFX/lib
 /Plugin64/GFX/map
 /Plugin64/GFX/pdb
-/Plugin64/GFX/PJ64Glide64.dll
-/Plugin64/GFX/PJ64Glide64_d.dll
+/Plugin64/GFX/Project64-Video.dll
+/Plugin64/GFX/Project64-Video_d.dll
 /Plugin64/Input/lib
 /Plugin64/Input/map
 /Plugin64/Input/pdb


### PR DESCRIPTION
I thought maybe we could keep PJ64Glide64 ignored instead of replacing it (maybe some users will have PJ64Glide64.dll as well as Project64-Video.dll in their plugin folders for archival or testing reasons), but in keeping consistent with the 32-bit plugin folder I think it makes more sense to just replace it entirely.