### PR TITLE
[RDB] Save type fixes

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -206,7 +206,6 @@ Internal Name=ÐÝÅÃÞÀÏºÞ¯ÁÜ°ÙÄÞ
 Status=Issues (plugin)
 Plugin Note=[video] HLE incorrect sprites
 Counter Factor=1
-Save Type=FlashRam
 
 [36F22FBF-318912F2-C:4A]
 Good Name=64 Hanafuda - Tenshi no Yakusoku (J)
@@ -2265,13 +2264,6 @@ Counter Factor=1
 Delay SI=Yes
 RDRAM Size=8
 
-[B57D4EB4-345E09E5-C:0]
-Counter Factor=1
-Good Name=Guru - Kuru Kuru Fever (J) [ALECK64]
-Status=Compatible
-RDRAM Size=8
-Save Type=4kbit Eeprom
-
 //================  H  ================
 [95A80114-E0B72A7F-C:4A]
 Good Name=Hamster Monogatari 64 (J)
@@ -2988,6 +2980,13 @@ Status=Compatible
 Culling=1
 RDRAM Size=8
 Save Type=16kbit Eeprom
+
+[4248BA87-99BE605D-C:0]
+Counter Factor=1
+Good Name=Kuru Kuru Fever (J) [ALECK64]
+Status=Compatible
+RDRAM Size=8
+Save Type=4kbit Eeprom
 
 [0837F87A-D1436FF8-C:4A]
 Good Name=Kyojin no Doshin 1 (J) [CART HACK]
@@ -3839,7 +3838,6 @@ Status=Issues (core)
 Core Note=Speed/timing issues
 Audio Signal=Yes
 Counter Factor=1
-Save Type=FlashRam
 ViRefresh=500
 
 [147E0EDB-36C5B12C-C:4A]
@@ -6003,13 +6001,11 @@ Counter Factor=1
 Good Name=Tom and Jerry in Fists of Furry (E) (M6)
 Internal Name=TOM AND JERRY
 Status=Compatible
-Save Type=FlashRam
 
 [63E7391C-E6CCEA33-C:45]
 Good Name=Tom and Jerry in Fists of Furry (U)
 Internal Name=TOM AND JERRY
 Status=Compatible
-Save Type=FlashRam
 
 [4875AF3D-9A66D3A2-C:50]
 Good Name=Tom Clancy's Rainbow Six (E)

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -364,6 +364,7 @@ Status=Compatible
 Culling=1
 Primary Frame Buffer=1
 RDRAM Size=8
+Save Type=16kbit Eeprom
 
 [A5533106-B9F25E5B-C:4A]
 Good Name=Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (J)
@@ -372,6 +373,7 @@ Status=Compatible
 Culling=1
 Primary Frame Buffer=1
 RDRAM Size=8
+Save Type=16kbit Eeprom
 
 [DFD784AD-AE426603-C:50]
 Good Name=All Star Tennis '99 (E) (M5)

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -6606,6 +6606,7 @@ Internal Name=Waialae Country Club
 Status=Compatible
 Culling=1
 Primary Frame Buffer=1
+Save Type=Sram
 
 [0C5057AD-046E126E-C:50]
 Good Name=Waialae Country Club - True Golf Classics (E) (M4) (V1.1)
@@ -6613,6 +6614,7 @@ Internal Name=Waialae Country Club
 Status=Compatible
 Culling=1
 Primary Frame Buffer=1
+Save Type=Sram
 
 [8066D58A-C3DECAC1-C:45]
 Good Name=Waialae Country Club - True Golf Classics (U) (V1.0)
@@ -6620,6 +6622,7 @@ Internal Name=Waialae Country Club
 Status=Compatible
 Culling=1
 Primary Frame Buffer=1
+Save Type=Sram
 
 [DD318CE2-B73798BA-C:45]
 Good Name=Waialae Country Club - True Golf Classics (U) (V1.1)
@@ -6627,6 +6630,7 @@ Internal Name=Waialae Country Club
 Status=Compatible
 Culling=1
 Primary Frame Buffer=1
+Save Type=Sram
 
 [D715CC70-271CF5D6-C:50]
 Good Name=War Gods (E)

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1110,6 +1110,7 @@ Status=Compatible
 Counter Factor=1
 Delay SI=Yes
 RDRAM Size=8
+Save Type=16kbit Eeprom
 
 [FA5A3DFF-B4C9CDB9-C:45]
 Good Name=Clay Fighter - Sculptor's Cut (U)
@@ -2257,6 +2258,7 @@ Status=Compatible
 Counter Factor=1
 Delay SI=Yes
 RDRAM Size=8
+Save Type=16kbit Eeprom
 
 [C49ADCA2-F1501B62-C:45]
 Good Name=GT 64 - Championship Edition (U)
@@ -2265,6 +2267,7 @@ Status=Compatible
 Counter Factor=1
 Delay SI=Yes
 RDRAM Size=8
+Save Type=16kbit Eeprom
 
 //================  H  ================
 [95A80114-E0B72A7F-C:4A]


### PR DESCRIPTION
I checked each of these games and none of them save with FlashRam. NBA Showtime uses the Controller Pak, and the other games use 4kbit Eeprom.

I also fixed Kuru Kuru Fever's CRC1/2 and title.