### PR TITLE
Added UpdateVersion PowerShell script.

### DIFF
--- a/Source/Script/UpdateVersion.ps1
+++ b/Source/Script/UpdateVersion.ps1
@@ -1,22 +1,22 @@
 Param
 (
-	$SolutionDir = $(Get-Location),
+	$SolutionDir = (Split-path (Split-Path ($PSScriptRoot))),
 	[Parameter(Mandatory=$true)]
 	[string] $Version,
 	[string[]] $Files = (
-		'Source\Project64-core\version.h',
-		'Source\nragev20\version.h',
-		'Source\RSP\version.h',
-		'Source\Project64-video\version.h'
+		"$SolutionDir\Source\Project64-core\version.h",
+		"$SolutionDir\Source\nragev20\version.h",
+		"$SolutionDir\Source\RSP\version.h",
+		"$SolutionDir\Source\Project64-video\version.h"
 	)
 )
 
 $versionArr = $Version.Split('.')
 foreach ($file in $Files) {
-	(Get-Content "$SolutionDir\$file") `
+	(Get-Content $file) `
 		-replace '(#define\s+VERSION_MAJOR\s+)\d+',    "`${1}$($versionArr[0])" `
 		-replace '(#define\s+VERSION_MINOR\s+)\d+',    "`${1}$($versionArr[1])" `
 		-replace '(#define\s+VERSION_REVISION\s+)\d+', "`${1}$($versionArr[2])" `
 		-replace '(#define\s+VERSION_BUILD\s+)\d+',    "`${1}$($versionArr[3])" `
-	| Set-Content "$SolutionDir\$file"
+	| Set-Content $file
 }

--- a/Source/Script/UpdateVersion.ps1
+++ b/Source/Script/UpdateVersion.ps1
@@ -1,0 +1,22 @@
+Param
+(
+	$SolutionDir = $(Get-Location),
+	[Parameter(Mandatory=$true)]
+	[string] $Version,
+	[string[]] $Files = (
+		'Source\Project64-core\version.h',
+		'Source\nragev20\version.h',
+		'Source\RSP\version.h',
+		'Source\Project64-video\version.h'
+	)
+)
+
+$versionArr = $Version.Split('.')
+foreach ($file in $Files) {
+	(Get-Content "$SolutionDir\$file") `
+		-replace '(#define\s+VERSION_MAJOR\s+)\d+',    "`${1}$($versionArr[0])" `
+		-replace '(#define\s+VERSION_MINOR\s+)\d+',    "`${1}$($versionArr[1])" `
+		-replace '(#define\s+VERSION_REVISION\s+)\d+', "`${1}$($versionArr[2])" `
+		-replace '(#define\s+VERSION_BUILD\s+)\d+',    "`${1}$($versionArr[3])" `
+	| Set-Content "$SolutionDir\$file"
+}


### PR DESCRIPTION
PowerShell alternative to the CMD-based UpdateVersion script.

Advantages:
- Does not require `sed`, or any other external dependencies.
- Easier to read and maintain.