### PR TITLE
added Random.cpp for Windows and non-Android Linux

### DIFF
--- a/Source/Script/MinGW/common.cmd
+++ b/Source/Script/MinGW/common.cmd
@@ -31,6 +31,7 @@ ECHO Compiling common library sources for Project64...
 %CC% -o %obj%\md5.asm                   %src%\md5.cpp %C_FLAGS%
 %CC% -o %obj%\MemTest.asm               %src%\MemTest.cpp %C_FLAGS%
 %CC% -o %obj%\path.asm                  %src%\path.cpp %C_FLAGS%
+%CC% -o %obj%\Random.asm                %src%\Random.cpp %C_FLAGS%
 %CC% -o %obj%\stdstring.asm             %src%\StdString.cpp %C_FLAGS%
 %CC% -o %obj%\SyncEvent.asm             %src%\SyncEvent.cpp %C_FLAGS%
 %CC% -o %obj%\Trace.asm                 %src%\Trace.cpp %C_FLAGS%
@@ -44,6 +45,7 @@ ECHO Assembling common library sources...
 %AS% -o %obj%\md5.o                     %obj%\md5.asm
 %AS% -o %obj%\MemTest.o                 %obj%\MemTest.asm
 %AS% -o %obj%\path.o                    %obj%\path.asm
+%AS% -o %obj%\Random.o                  %obj%\Random.asm
 %AS% -o %obj%\stdstring.o               %obj%\stdstring.asm
 %AS% -o %obj%\SyncEvent.o               %obj%\SyncEvent.asm
 %AS% -o %obj%\Trace.o                   %obj%\Trace.asm
@@ -55,6 +57,7 @@ set OBJ_LIST=^
  %obj%\Trace.o^
  %obj%\SyncEvent.o^
  %obj%\stdstring.o^
+ %obj%\Random.o^
  %obj%\path.o^
  %obj%\MemTest.o^
  %obj%\md5.o^

--- a/Source/Script/Unix/common.sh
+++ b/Source/Script/Unix/common.sh
@@ -26,6 +26,7 @@ $CC -o $obj/MemoryManagement.asm        $src/MemoryManagement.cpp $C_FLAGS
 $CC -o $obj/MemTest.asm                 $src/MemTest.cpp $C_FLAGS
 $CC -o $obj/path.asm                    $src/path.cpp $C_FLAGS
 $CC -o $obj/Platform.asm                $src/Platform.cpp $C_FLAGS
+$CC -o $obj/Random.asm                  $src/Random.cpp $C_FLAGS
 $CC -o $obj/stdstring.asm               $src/StdString.cpp $C_FLAGS
 $CC -o $obj/SyncEvent.asm               $src/SyncEvent.cpp $C_FLAGS
 $CC -o $obj/DateTimeClass.asm           $src/DateTimeClass.cpp $C_FLAGS
@@ -43,6 +44,7 @@ $AS -o $obj/MemoryManagement.o          $obj/MemoryManagement.asm
 $AS -o $obj/MemTest.o                   $obj/MemTest.asm
 $AS -o $obj/path.o                      $obj/path.asm
 $AS -o $obj/Platform.o                  $obj/Platform.asm
+$AS -o $obj/Random.o                    $obj/Random.asm
 $AS -o $obj/stdstring.o                 $obj/stdstring.asm
 $AS -o $obj/SyncEvent.o                 $obj/SyncEvent.asm
 $AS -o $obj/DateTimeClass.o             $obj/DateTimeClass.asm
@@ -57,6 +59,7 @@ OBJ_LIST="\
  $obj/DateTimeClass.o \
  $obj/SyncEvent.o \
  $obj/stdstring.o \
+ $obj/Random.o \
  $obj/Platform.o \
  $obj/path.o \
  $obj/MemTest.o \


### PR DESCRIPTION
Pretty much a follow-up to https://github.com/project64/project64/pull/1399 for including the `Random` translation unit in builds for Windows (mingw32), non-Android Linux and, possibly, UNIX.  (The shell syntax support is there for UNIX, but anything like GTK getting implemented will throw out building on it.)