### PR TITLE
[RDB] CF=1 for Bokujou Monogatari 2

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -759,16 +759,19 @@ Delay SI=Yes
 Good Name=Bokujou Monogatari 2 (J) (V1.0)
 Internal Name=ÎÞ¸¼Þ®³ÓÉ¶ÞÀØ2
 Status=Compatible
+Counter Factor=1
 
 [7365D8F8-9ED9326F-C:4A]
 Good Name=Bokujou Monogatari 2 (J) (V1.1)
 Internal Name=ÎÞ¸¼Þ®³ÓÉ¶ÞÀØ2
 Status=Compatible
+Counter Factor=1
 
 [736657F6-3C88A702-C:4A]
 Good Name=Bokujou Monogatari 2 (J) (V1.2)
 Internal Name=ÎÞ¸¼Þ®³ÓÉ¶ÞÀØ2
 Status=Compatible
+Counter Factor=1
 
 [5A160336-BC7B37B0-C:50]
 Good Name=Bomberman 64 (E)


### PR DESCRIPTION
Fixes the out of sync audio during the intro cutscene. Harvest Moon 64 (U) already has CF=1 enabled.