### PR TITLE
fixed 64-bit memory pointer warnings

### DIFF
--- a/Source/Common/stdtypes.h
+++ b/Source/Common/stdtypes.h
@@ -5,6 +5,7 @@
  * have <stdint.h> removed in favor of these nonstandard built-in types:
  */
 #if defined(_MSC_VER) && (_MSC_VER < 1600)
+
 typedef signed __int8           int8_t;
 typedef signed __int16          int16_t;
 typedef signed __int32          int32_t;
@@ -14,6 +15,14 @@ typedef unsigned __int8         uint8_t;
 typedef unsigned __int16        uint16_t;
 typedef unsigned __int32        uint32_t;
 typedef unsigned __int64        uint64_t;
+
+/*
+ * Approximate pointer type size as the same as size_t.
+ * This assumption is not true in all cases, but on MSVC it works great.
+ */
+#include <stddef.h>
+typedef size_t                  uintptr_t;
+
 #else
 #include <stdint.h>
 #endif

--- a/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
+++ b/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
@@ -110,7 +110,7 @@ void CMipsMemoryVM::Reset(bool /*EraseMemory*/)
 
 void CMipsMemoryVM::ReserveMemory()
 {
-    m_Reserve1 = (uint8_t *)AllocateAddressSpace(0x20000000, (void *)g_Settings->LoadDword(Setting_FixedRdramAddress));
+    m_Reserve1 = (uint8_t *)AllocateAddressSpace(0x20000000, (void *)(uintptr_t)g_Settings->LoadDword(Setting_FixedRdramAddress));
     m_Reserve2 = (uint8_t *)AllocateAddressSpace(0x04002000);
 }
 

--- a/Source/Project64-core/N64System/Mips/Sram.cpp
+++ b/Source/Project64-core/N64System/Mips/Sram.cpp
@@ -62,7 +62,7 @@ void CSram::DmaFromSram(uint8_t * dest, int32_t StartOffset, int32_t len)
     // Fix Dezaemon 3D saves
     StartOffset = ((StartOffset >> 3) & 0xFFFF8000) | (StartOffset & 0x7FFF);
 
-    if (((StartOffset & 3) == 0) && ((((uint32_t)dest) & 3) == 0))
+    if (((StartOffset & 3) == 0) && ((((uintptr_t)dest) & 3) == 0))
     {
         m_File.Seek(StartOffset, CFile::begin);
         m_File.Read(dest, len);
@@ -72,7 +72,7 @@ void CSram::DmaFromSram(uint8_t * dest, int32_t StartOffset, int32_t len)
         for (i = 0; i < len; i++)
         {
             m_File.Seek((StartOffset + i) ^ 3, CFile::begin);
-            m_File.Read((uint8_t*)(((uint32_t)dest + i) ^ 3), 1);
+            m_File.Read((uint8_t*)(((uintptr_t)dest + i) ^ 3), 1);
         }
     }
 }
@@ -97,7 +97,7 @@ void CSram::DmaToSram(uint8_t * Source, int32_t StartOffset, int32_t len)
     // Fix Dezaemon 3D saves
     StartOffset = ((StartOffset >> 3) & 0xFFFF8000) | (StartOffset & 0x7FFF);
 
-    if (((StartOffset & 3) == 0) && ((((uint32_t)Source) & 3) == 0) && NULL != NULL)
+    if (((StartOffset & 3) == 0) && ((((uintptr_t)Source) & 3) == 0) && NULL != NULL)
     {
         m_File.Seek(StartOffset, CFile::begin);
         m_File.Write(Source, len);
@@ -107,7 +107,7 @@ void CSram::DmaToSram(uint8_t * Source, int32_t StartOffset, int32_t len)
         for (i = 0; i < len; i++)
         {
             m_File.Seek((StartOffset + i) ^ 3, CFile::begin);
-            m_File.Write((uint8_t*)(((uint32_t)Source + i) ^ 3), 1);
+            m_File.Write((uint8_t*)(((uintptr_t)Source + i) ^ 3), 1);
         }
     }
 }

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -1196,7 +1196,7 @@ void CN64System::SyncCPU(CN64System * const SecondCPU)
 
     if (bFastSP() && m_Recomp)
     {
-        if (m_Recomp->MemoryStackPos() != (uint32_t)(m_MMU_VM.Rdram() + (m_Reg.m_GPR[29].W[0] & 0x1FFFFFFF)))
+        if (m_Recomp->MemoryStackPos() != (uintptr_t)(m_MMU_VM.Rdram() + (m_Reg.m_GPR[29].W[0] & 0x1FFFFFFF)))
         {
             ErrorFound = true;
         }
@@ -1365,9 +1365,9 @@ void CN64System::DumpSyncErrors(CN64System * SecondCPU)
         }
         if (bFastSP() && m_Recomp)
         {
-            if (m_Recomp->MemoryStackPos() != (uint32_t)(m_MMU_VM.Rdram() + (m_Reg.m_GPR[29].W[0] & 0x1FFFFFFF)))
+            if (m_Recomp->MemoryStackPos() != (uintptr_t)(m_MMU_VM.Rdram() + (m_Reg.m_GPR[29].W[0] & 0x1FFFFFFF)))
             {
-                Error.LogF("MemoryStack = %X  should be: %X\r\n", m_Recomp->MemoryStackPos(), (uint32_t)(m_MMU_VM.Rdram() + (m_Reg.m_GPR[29].W[0] & 0x1FFFFFFF)));
+                Error.LogF("MemoryStack = %X  should be: %X\r\n", m_Recomp->MemoryStackPos(), (uintptr_t)(m_MMU_VM.Rdram() + (m_Reg.m_GPR[29].W[0] & 0x1FFFFFFF)));
             }
         }
 

--- a/Source/Project64-core/N64System/Recompiler/RecompilerClass.cpp
+++ b/Source/Project64-core/N64System/Recompiler/RecompilerClass.cpp
@@ -1004,7 +1004,7 @@ CCompiledFunc * CRecompiler::CompileCode()
     {
         WriteTrace(TraceRecompiler, TraceDebug, "info->Function() = %X", Func->Function());
         std::string dumpline;
-        uint32_t start_address = (uint32_t)(Func->Function()) & ~1;
+        uintptr_t start_address = (uintptr_t)(Func->Function()) & ~1;
         for (uint8_t * ptr = (uint8_t *)start_address; ptr < CodeBlock.CompiledLocationEnd(); ptr++)
         {
             if (dumpline.empty())
@@ -1012,7 +1012,7 @@ CCompiledFunc * CRecompiler::CompileCode()
                 dumpline += stdstr_f("%X: ", ptr);
             }
             dumpline += stdstr_f(" %02X", *ptr);
-            if ((((uint32_t)ptr - start_address) + 1) % 30 == 0)
+            if ((((uintptr_t)ptr - start_address) + 1) % 30 == 0)
             {
                 WriteTrace(TraceRecompiler, TraceDebug, "%s", dumpline.c_str());
                 dumpline.clear();
@@ -1126,7 +1126,7 @@ void CRecompiler::ResetMemoryStackPos()
     uint32_t pAddr = 0;
     if (m_MMU.TranslateVaddr(m_Registers.m_GPR[29].UW[0], pAddr))
     {
-        m_MemoryStack = (uint32_t)(m_MMU.Rdram() + pAddr);
+        m_MemoryStack = (uintptr_t)(m_MMU.Rdram() + pAddr);
     }
     else
     {
@@ -1144,7 +1144,7 @@ void CRecompiler::DumpFunctionTimes()
 
     for (FUNCTION_PROFILE::iterator itr = m_BlockProfile.begin(); itr != m_BlockProfile.end(); itr++)
     {
-        Log.LogF("%X,0x%X,%d\r\n", (uint32_t)itr->first, itr->second.Address, (uint32_t)itr->second.TimeTaken);
+        Log.LogF("%X,0x%X,%d\r\n", (uintptr_t)itr->first, itr->second.Address, (uint32_t)itr->second.TimeTaken);
     }
 }
 


### PR DESCRIPTION
Cast pointers to integers only of the same size as the integer type big enough to hold a pointer address.