### PR TITLE
Use 8MB RDRAM if ROM is not in RDB

### DIFF
--- a/Source/Project64-core/Settings/SettingType/SettingsType-RDBRamSize.cpp
+++ b/Source/Project64-core/Settings/SettingType/SettingsType-RDBRamSize.cpp
@@ -37,13 +37,15 @@ bool CSettingTypeRDBRDRamSize::Load (uint32_t /*Index*/, bool & /*Value*/ ) cons
 bool CSettingTypeRDBRDRamSize::Load (uint32_t Index, uint32_t & Value ) const
 {
     uint32_t ulValue;
+    stdstr Default;
+    bool existsInRdb = g_Settings->LoadStringVal(Rdb_GoodName,Default);
     bool bRes = m_SettingsIniFile->GetNumber(m_SectionIdent->c_str(),m_KeyName.c_str(),m_DefaultValue,ulValue);
     if (!bRes)
     {
         LoadDefault(Index,ulValue);
     }
     Value = 0x400000;
-    if (ulValue == 8)
+    if (ulValue == 8 || !existsInRdb) //default to 8MB if ROM is not in the RDB
     {
         Value = 0x800000;
     }


### PR DESCRIPTION
Reworked #1481 