### PR TITLE
[Audio] Code cleanup and slightly smaller buffer.

### DIFF
--- a/Source/Project64-audio/AudioMain.cpp
+++ b/Source/Project64-audio/AudioMain.cpp
@@ -112,7 +112,7 @@ EXPORT void CALL AiDacrateChanged(int SystemType)
                 framerate = (framerate / 2);
             }
             audio_clock = (video_clock / framerate);
-            BufferSize = (int32_t)(audio_clock / (g_Dacrate + 1)) & ~0x1;
+            BufferSize = (int32_t)(audio_clock / (g_Dacrate + 1)) + 1 & ~0x1;
             g_SoundDriver->AI_SetFrequency(Frequency, BufferSize);
         }
     }

--- a/Source/Project64-audio/AudioMain.cpp
+++ b/Source/Project64-audio/AudioMain.cpp
@@ -85,7 +85,8 @@ EXPORT void CALL AiDacrateChanged(int SystemType)
             WriteTrace(TraceAudioInterface, TraceNotice, "Unknown/reserved bits in AI_DACRATE_REG set. 0x%08X", *g_AudioInfo.AI_DACRATE_REG);
         }
 
-        uint32_t video_clock = 0; int32_t BufferSize = 0; double audio_clock = 0; double framerate = 29.97;
+        uint32_t video_clock = 0; int32_t BufferSize = 0;
+        double audio_clock = 0; double framerate = (30 / 1.001);
 
         switch (SystemType)
         {

--- a/Source/Project64-audio/AudioMain.cpp
+++ b/Source/Project64-audio/AudioMain.cpp
@@ -85,14 +85,15 @@ EXPORT void CALL AiDacrateChanged(int SystemType)
             WriteTrace(TraceAudioInterface, TraceNotice, "Unknown/reserved bits in AI_DACRATE_REG set. 0x%08X", *g_AudioInfo.AI_DACRATE_REG);
         }
 
-        uint32_t video_clock = 0;
+        uint32_t video_clock = 0; int32_t BufferSize = 0; double audio_clock = 0; double framerate = 29.97;
+
         switch (SystemType)
         {
         case SYSTEM_NTSC: video_clock = 48681812; break;
-        case SYSTEM_PAL: video_clock = 49656530; break;
+        case SYSTEM_PAL: video_clock = 49656530; framerate = 25; break;
         case SYSTEM_MPAL: video_clock = 48628316; break;
         }
-        uint32_t Frequency = video_clock / (g_Dacrate + 1);
+        uint32_t Frequency = (video_clock / (g_Dacrate + 1));
 
         if (Frequency < 4000)
         {
@@ -101,28 +102,16 @@ EXPORT void CALL AiDacrateChanged(int SystemType)
         }
         else
         {
-            int32_t BufferSize = 0; double audio_clock = 0; double framerate = 0;
-
-            if (g_settings->FPSBuffer() == true)
+            if (g_settings->FPSBuffer() == false && SystemType != SYSTEM_PAL)
             {
-                framerate = 59.94004;
-                if (SystemType == SYSTEM_PAL) { framerate = 50; }
+                framerate = 30.475;		// Needed for Body Harvest (U)
             }
-            else
+            if (g_settings->TinyBuffer() == false)
             {
-                framerate = 60.95;                // Needed for Body Harvest (U)
-                if (SystemType == SYSTEM_PAL) { framerate = 50.79166; }
+                framerate = (framerate / 2);
             }
-            if (g_settings->TinyBuffer() == true)
-            {
-                audio_clock = ((video_clock / framerate) * 2);
-            }
-            else
-            {
-                audio_clock = ((video_clock / framerate) * 4);
-            }
-
-            BufferSize = (int32_t)audio_clock / (g_Dacrate) + 1 & ~0x1;
+            audio_clock = (video_clock / framerate);
+            BufferSize = (int32_t)(audio_clock / (g_Dacrate + 1)) & ~0x1;
             g_SoundDriver->AI_SetFrequency(Frequency, BufferSize);
         }
     }


### PR DESCRIPTION
NTSC consists of ​30 / 1.001 (approximately 29.97) interlaced frames of video per second. Each frame is composed of two fields, a field refresh frequency of ​60 / 1.001 Hz (approximately 59.94 Hz).

I added +1 to the dacrate in the buffer_size = audio clock / dacrate calculation.