### PR TITLE
Fix x64 compile error

### DIFF
--- a/Source/Project64-core/N64System/Recompiler/CodeSection.h
+++ b/Source/Project64-core/N64System/Recompiler/CodeSection.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "JumpInfo.h"
 #include <Project64-core/N64System/Recompiler/RecompilerOps.h>
+#include <Project64-core/Settings/DebugSettings.h>
 
 class CCodeBlock;
 


### PR DESCRIPTION
I don't know why x86 build works fine without this include.  x64 build fails with Project64-core/N64System/Recompiler/CodeSection.h(19): error C2504: 'CDebugSettings': base class undefined.