### PR TITLE
[Project64-Audio] fix sync using audio off

### DIFF
--- a/Source/Project64-audio/Driver/SoundBase.cpp
+++ b/Source/Project64-audio/Driver/SoundBase.cpp
@@ -51,7 +51,14 @@ void SoundDriverBase::AI_LenChanged(uint8_t *start, uint32_t length)
     WriteTrace(TraceAudioDriver, TraceDebug, "Start");
 
     // Bleed off some of this buffer to smooth out audio
-    if (length < m_MaxBufferSize && g_settings->SyncAudio())
+    if (g_settings->SyncAudio())
+    {
+        while ((m_BufferRemaining) == m_MaxBufferSize)
+        {
+            pjutil::Sleep(1);
+        }
+    }
+    else if (!g_settings->FullSpeed())
     {
         while ((m_BufferRemaining) == m_MaxBufferSize)
         {


### PR DESCRIPTION
Changed condition so Azimer's Prevent Buffer Overruns option works with sync using audio on or off.