### PR TITLE
[Project64-Audio] Fix Sync using audio OFF

### DIFF
--- a/Source/Project64-audio/AudioSettings.cpp
+++ b/Source/Project64-audio/AudioSettings.cpp
@@ -163,7 +163,7 @@ void CSettings::ReadSettings(void)
     m_FPSBuffer = GetSetting(Set_FPSBuffer) != 0;
     m_FullSpeed = m_Set_FullSpeed ? GetSystemSetting(m_Set_FullSpeed) != 0 : false;
 
-    m_SyncAudio = ((!m_advanced_options || bLimitFPS) && SyncAudio && m_FullSpeed);
+    m_SyncAudio = ((!m_advanced_options || bLimitFPS);
 
     if (m_Set_log_dir != 0)
     {

--- a/Source/Project64-audio/Driver/SoundBase.cpp
+++ b/Source/Project64-audio/Driver/SoundBase.cpp
@@ -51,7 +51,7 @@ void SoundDriverBase::AI_LenChanged(uint8_t *start, uint32_t length)
     WriteTrace(TraceAudioDriver, TraceDebug, "Start");
 
     // Bleed off some of this buffer to smooth out audio
-    if (length < m_MaxBufferSize && g_settings->SyncAudio())
+    if (g_settings->SyncAudio() || !g_settings->FullSpeed())
     {
         while ((m_BufferRemaining) == m_MaxBufferSize)
         {


### PR DESCRIPTION
Fix games running unlimited when turning Sync using audio OFF while game is running, and fixes clicks with Sync using audio OFF.