### PR TITLE
[N-Rage] Mouse Lock Up fix when ending emulation when it's locked?

### DIFF
--- a/Source/nragev20/NRagePluginV2.cpp
+++ b/Source/nragev20/NRagePluginV2.cpp
@@ -499,7 +499,10 @@ EXPORT void CALL RomClosed(void)
 	EnterCriticalSection( &g_critical );
 
 	if (g_sysMouse.didHandle)
+	{
+		g_sysMouse.didHandle->Unacquire();
 		g_sysMouse.didHandle->SetCooperativeLevel(g_strEmuInfo.hMainWindow, DIB_KEYBOARD); // unlock the mouse, just in case
+	}
 
 	for( i = 0; i < ARRAYSIZE(g_pcControllers); ++i )
 	{


### PR DESCRIPTION
I managed to lock up the mouse by ending emulation while it was locked. This fixed it for me.