### PR TITLE
COP0 Cause register access for Scripts

### DIFF
--- a/Source/Project64/UserInterface/API.js
+++ b/Source/Project64/UserInterface/API.js
@@ -593,6 +593,20 @@ const dfpr = new Proxy({},
     }
 })
 
+const cop0 = new Proxy({},
+{
+    get: function (obj, prop) {
+        if (prop == "cause") {
+            return _native.getCauseVal();
+        }
+    },
+    set: function (obj, prop, val) {
+        if (prop == "cause") {
+            _native.setCauseVal(val);
+        }
+    }
+})
+
 const rom = {
     u8: new Proxy({},
     {

--- a/Source/Project64/UserInterface/Debugger/ScriptInstance.cpp
+++ b/Source/Project64/UserInterface/Debugger/ScriptInstance.cpp
@@ -974,6 +974,23 @@ duk_ret_t CScriptInstance::js_SetFPRVal(duk_context* ctx)
     return 1;
 }
 
+duk_ret_t CScriptInstance::js_GetCauseVal(duk_context* ctx)
+{
+	duk_push_uint(ctx, g_Reg->FAKE_CAUSE_REGISTER);
+	return 1;
+}
+
+duk_ret_t CScriptInstance::js_SetCauseVal(duk_context* ctx)
+{
+	uint32_t val = duk_to_uint32(ctx, 0);
+
+	g_Reg->FAKE_CAUSE_REGISTER = val;
+	g_Reg->CheckInterrupts();
+
+	duk_pop_n(ctx, 1);
+	return 1;
+}
+
 duk_ret_t CScriptInstance::js_GetROMInt(duk_context* ctx)
 {
     uint32_t address = duk_to_uint32(ctx, 0) & 0x0FFFFFFF;

--- a/Source/Project64/UserInterface/Debugger/ScriptInstance.h
+++ b/Source/Project64/UserInterface/Debugger/ScriptInstance.h
@@ -156,6 +156,8 @@ private:
     static duk_ret_t js_SetGPRVal(duk_context*); // (regNum, bUpper, value)
     static duk_ret_t js_GetFPRVal(duk_context*); // (regNum, bDouble)
     static duk_ret_t js_SetFPRVal(duk_context*); // (regNum, bDouble, value)
+	static duk_ret_t js_GetCauseVal(duk_context*); // ()
+	static duk_ret_t js_SetCauseVal(duk_context*); // (value)
     static duk_ret_t js_GetROMInt(duk_context*); // (address, bitwidth, signed)
     static duk_ret_t js_GetROMFloat(duk_context*); // (address, bDouble)
     static duk_ret_t js_GetROMBlock(duk_context*); // (address, nBytes) ; returns Buffer
@@ -202,6 +204,8 @@ private:
         { "getGPRVal",      js_GetGPRVal,      DUK_VARARGS },
         { "setFPRVal",      js_SetFPRVal,      DUK_VARARGS },
         { "getFPRVal",      js_GetFPRVal,      DUK_VARARGS },
+		{ "setCauseVal",    js_SetCauseVal,    DUK_VARARGS },
+		{ "getCauseVal",    js_GetCauseVal,    DUK_VARARGS },
 
         { "getROMInt",      js_GetROMInt,      DUK_VARARGS },
         { "getROMFloat",    js_GetROMFloat,    DUK_VARARGS },

--- a/apidoc.htm
+++ b/apidoc.htm
@@ -108,6 +108,7 @@ span.tag2 {
 		<a href="#ugpr">ugpr</a><br>
 		<a href="#fpr">fpr</a><br>
 		<a href="#dfpr">dfpr</a><br>
+		<a href="#cop0">cop0</a><br>
 		<a href="#Server">Server</a><br>
 		<a href="#Socket">Socket</a><br>
 		<a href="#AddressRange">AddressRange</a><br>
@@ -769,6 +770,16 @@ events.onexec(0x802CB1C0, function()
 		<div class="propertyname">dfpr[0|2|4 ...]</div>
 		<div class="propertydesc">
 			Variables representing the 64-bit floating point registers.
+		</div>
+	</div>
+</div>
+
+<div class="panel" id="cop0">
+	<div class="classname">cop0</div>
+	<div class="property">
+		<div class="propertyname">cop0.cause</div>
+		<div class="propertydesc">
+			Variable representing the Cause register. Updates interrupts when written.
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
It is mostly useful for debugging CART interrupts, which is something I used for simulating some of the 64DD's extra cartridges like the Capture Cartridge and Modem Cartridge.

I felt it was all right to include it officially.