### PR TITLE
64DD support overhaul

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -7186,14 +7186,14 @@ Status=Compatible
 [E848D316-444B444A-C:4A]
 32bit=No
 Fixed Audio=0
-Good Name=Doshin no Kyojin 1 (J)
+Good Name=Kyojin no Doshin 1 (J)
 RDRAM Size=8
 Status=Compatible
 
 [E848D316-444B494A-C:4A]
 32bit=No
 Fixed Audio=0
-Good Name=Doshin no Kyojin 1 (J) (Store Demo)
+Good Name=Kyojin no Doshin 1 (J) (Store Demo)
 RDRAM Size=8
 Status=Compatible
 
@@ -7206,9 +7206,9 @@ Status=Only intro/part OK
 
 [E848D316-444B4B4A-C:4A]
 32bit=No
-Core Note=Expansion Disk for Doshin no Kyojin 1. Use the Swap feature.
+Core Note=Expansion Disk for Kyojin no Doshin 1. Use the Disk Swap feature to play.
 Fixed Audio=0
-Good Name=Doshin no Kyojin Kaihou Sensen Chibikkochikko Dai Shuugou (J)
+Good Name=Kyojin no Doshin - Kaihou Sensen Chibikkochikko Dai Shuugou (J)
 Status=Compatible
 
 [E848D316-45465A4A-C:4A]

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -7123,6 +7123,101 @@ Good Name=Zool - Majuu Tsukai Densetsu (J)
 Internal Name=½Þ°Ù Ï¼Þ­³Â¶²ÃÞÝ¾Â
 Status=Compatible
 
+//================ 64DD ================
+//
+// ROMs below are 64DD content
+
+[00000000-00000000-C:4A]
+32bit=No
+Fixed Audio=0
+Good Name=64DD IPL (JPN)
+RDRAM Size=8
+Status=Compatible
+
+[00000000-00000000-C:45]
+32bit=No
+Fixed Audio=0
+Good Name=64DD IPL (USA)
+RDRAM Size=8
+Status=Compatible
+
+[E848D316-444D504A-C:4A]
+32bit=No
+Fixed Audio=0
+Good Name=Mario Artist Paint Studio (J)
+RDRAM Size=8
+Status=Compatible
+
+[E848D316-444D544A-C:4A]
+32bit=No
+Fixed Audio=0
+Good Name=Mario Artist Talent Studio (J)
+RDRAM Size=8
+Status=Compatible
+
+[E848D316-444D424A-C:4A]
+32bit=No
+Core Note=Cannot use Randnet functionality.
+Fixed Audio=0
+Good Name=Mario Artist Communication Kit (J)
+Status=Compatible
+
+[E848D316-444D474A-C:4A]
+32bit=No
+Fixed Audio=0
+Good Name=Mario Artist Polygon Studio (J)
+Plugin Note=Cannot model on HLE plugins.
+Status=Issues (plugin)
+
+[E848D316-4453434A-C:4A]
+32bit=No
+Fixed Audio=0
+Good Name=Sim City 64 (J)
+Plugin Note=Very slow, city is not rendering properly in HLE
+Status=Issues (plugin)
+
+[E848D316-4450474A-C:4A]
+32bit=No
+Fixed Audio=0
+Good Name=Nihon Pro Golf Tour 64 (J)
+RDRAM Size=8
+Status=Compatible
+
+[E848D316-444B444A-C:4A]
+32bit=No
+Fixed Audio=0
+Good Name=Doshin no Kyojin 1 (J)
+RDRAM Size=8
+Status=Compatible
+
+[E848D316-444B494A-C:4A]
+32bit=No
+Fixed Audio=0
+Good Name=Doshin no Kyojin 1 (J) (Store Demo)
+RDRAM Size=8
+Status=Compatible
+
+[E848D316-4452444A-C:4A]
+32bit=No
+Core Note=Modem Pak is required
+Fixed Audio=0
+Good Name=Randnet Disk (J)
+Status=Only intro/part OK
+
+[E848D316-444B4B4A-C:4A]
+32bit=No
+Core Note=Expansion Disk for Doshin no Kyojin 1. Use the Swap feature.
+Fixed Audio=0
+Good Name=Doshin no Kyojin Kaihou Sensen Chibikkochikko Dai Shuugou (J)
+Status=Compatible
+
+[E848D316-45465A4A-C:4A]
+32bit=No
+Core Note=Expansion Disk for F-Zero X. Play F-Zero X (J) with this disk loaded.
+Fixed Audio=0
+Good Name=F-Zero X Expansion Kit (J)
+Status=Compatible
+
 //================  PD  ================
 //
 // ROMs below are PD/Intros/Emus and other Non Commercial
@@ -8200,15 +8295,3 @@ Internal Name=shut up and code
 CPU Type=Interpreter
 RDRAM Size=8
 Status=Unsupported
-
-[00000000-00000000-C:4A]
-32bit=No
-Good Name=64DD IPL (JPN)
-RDRAM Size=8
-Status=Compatible
-
-[00000000-00000000-C:45]
-32bit=No
-Good Name=64DD IPL (USA)
-RDRAM Size=8
-Status=Compatible

--- a/Lang/English.pj.Lang
+++ b/Lang/English.pj.Lang
@@ -519,6 +519,8 @@
 #2055#  "Graphics LLE is not for general use!!!\nIt is advisable that you only use this for testing and not for playing games.\n\nChange to graphics LLE?"
 #2056#  "Audio High-Level Emulation"
 #2057#  "Audio HLE requires a third-party plugin!!!\nIf you do not use a third-party audio plugin that supports HLE, you will hear no sound.\n\nChange to audio HLE?"
+#2058#  "File loaded does not appear to be a valid 64DD IPL ROM.\n\nVerify your ROMs with GoodN64."
+#2059#  "Nintendo 64DD IPL ROM not found.\nIt is required to play 64DD disks.\n\nPlease select the required ROM."
 
 
 /*********************************************************************************

--- a/Lang/French.pj.Lang
+++ b/Lang/French.pj.Lang
@@ -518,6 +518,8 @@
 #2055#  "Les graphismes LLE ne sont pas à utiliser par tout le monde !!!\nIl est recommandé d’utiliser seulement ceci à des fins de test et non pour jouer.\n\nChanger pour les graphismes en mode LLE ?"
 #2056#  "Émulation audio haut niveau (HLE)"
 #2057#  "L’audio HLE nécessite un plugin tiers !!!\nSi vous n’utilisez pas un plugin audio tiers qui supporte le HLE, vous n’entendrez aucun son.\n\nChanger pour l’audio en mode HLE ?"
+#2058#  "Le fichier chargé ne semble pas être une ROM IPL 64DD valide.\n\nVérifiez vos ROM avec GoodN64."
+#2059#  "La ROM IPL 64DD n’a pas pu être trouvée.\nIl est nécéssaire pour jouer avec des disques 64DD.\n\nVeuillez sélectionner la ROM demandée."
 
 
 /*********************************************************************************

--- a/Source/Project64-core/Multilanguage.h
+++ b/Source/Project64-core/Multilanguage.h
@@ -557,6 +557,7 @@ enum LanguageStringID
     MSG_SET_HLE_AUD_TITLE = 2056,
     MSG_SET_HLE_AUD_MSG = 2057,
     MSG_FAIL_IMAGE_IPL = 2058,
+    MSG_IPL_REQUIRED = 2059,
 
     /*********************************************************************************
     * Android                                                                        *

--- a/Source/Project64-core/Multilanguage.h
+++ b/Source/Project64-core/Multilanguage.h
@@ -556,6 +556,7 @@ enum LanguageStringID
     MSG_SET_LLE_GFX_MSG = 2055,
     MSG_SET_HLE_AUD_TITLE = 2056,
     MSG_SET_HLE_AUD_MSG = 2057,
+    MSG_FAIL_IMAGE_IPL = 2058,
 
     /*********************************************************************************
     * Android                                                                        *

--- a/Source/Project64-core/Multilanguage/LanguageClass.cpp
+++ b/Source/Project64-core/Multilanguage/LanguageClass.cpp
@@ -522,6 +522,7 @@ void CLanguage::LoadDefaultStrings(void)
     DEF_STR(MSG_SET_LLE_GFX_MSG, "Graphics LLE is not for general use!!!\nIt is advisable that you only use this for testing and not for playing games.\n\nChange to graphics LLE?");
     DEF_STR(MSG_SET_HLE_AUD_TITLE, "Audio High-Level Emulation");
     DEF_STR(MSG_SET_HLE_AUD_MSG, "Audio HLE requires a third-party plugin!!!\nIf you do not use a third-party audio plugin that supports HLE, you will hear no sound.\n\nChange to audio HLE?");
+    DEF_STR(MSG_FAIL_IMAGE_IPL, "File loaded does not appear to be a valid 64DD IPL ROM.\n\nVerify your ROMs with GoodN64.");
 
     /*********************************************************************************
     * Android                                                                        *

--- a/Source/Project64-core/Multilanguage/LanguageClass.cpp
+++ b/Source/Project64-core/Multilanguage/LanguageClass.cpp
@@ -523,6 +523,7 @@ void CLanguage::LoadDefaultStrings(void)
     DEF_STR(MSG_SET_HLE_AUD_TITLE, "Audio High-Level Emulation");
     DEF_STR(MSG_SET_HLE_AUD_MSG, "Audio HLE requires a third-party plugin!!!\nIf you do not use a third-party audio plugin that supports HLE, you will hear no sound.\n\nChange to audio HLE?");
     DEF_STR(MSG_FAIL_IMAGE_IPL, "File loaded does not appear to be a valid 64DD IPL ROM.\n\nVerify your ROMs with GoodN64.");
+    DEF_STR(MSG_IPL_REQUIRED, "Nintendo 64DD IPL ROM not found.\nIt is required to play 64DD disks.\n\nPlease select the required ROM.");
 
     /*********************************************************************************
     * Android                                                                        *

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -374,11 +374,6 @@ bool CN64System::RunFileImage(const char * FileLoc)
     {
         return false;
     }
-	if (g_Rom == g_DDRom && g_Rom != NULL && g_DDRom != NULL && g_Disk != NULL)
-	{
-		g_Settings->SaveString(Game_IniKey, g_Disk->GetDiskIdent().c_str());
-		g_System->RefreshGameSettings();
-	}
     if (g_Settings->LoadBool(Setting_AutoStart) != 0)
     {
         WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
@@ -386,6 +381,49 @@ bool CN64System::RunFileImage(const char * FileLoc)
     }
     return true;
 }
+
+bool CN64System::RunDiskImage(const char * FileLoc)
+{
+	if (!LoadFileImage(g_Settings->LoadStringVal(File_DiskIPLPath).c_str()))
+	{
+		g_Settings->SaveString(File_DiskIPLPath, "");
+		return false;
+	}
+	if (!LoadDiskImage(FileLoc, false))
+	{
+		return false;
+	}
+	if (g_Settings->LoadBool(Setting_AutoStart) != 0)
+	{
+		WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
+		RunLoadedImage();
+	}
+	return true;
+}
+
+bool CN64System::RunDiskComboImage(const char * FileLoc, const char * FileLocDisk)
+{
+	if (!LoadFileImageIPL(g_Settings->LoadStringVal(File_DiskIPLPath).c_str()))
+	{
+		g_Settings->SaveString(File_DiskIPLPath, "");
+		return false;
+	}
+	if (!LoadDiskImage(FileLocDisk, true))
+	{
+		return false;
+	}
+	if (!LoadFileImage(FileLoc))
+	{
+		return false;
+	}
+	if (g_Settings->LoadBool(Setting_AutoStart) != 0)
+	{
+		WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
+		RunLoadedImage();
+	}
+	return true;
+}
+
 
 void CN64System::RunLoadedImage(void)
 {
@@ -402,7 +440,7 @@ void CN64System::RunLoadedImage(void)
     WriteTrace(TraceN64System, TraceDebug, "Done");
 }
 
-bool CN64System::RunFileImageIPL(const char * FileLoc)
+bool CN64System::LoadFileImageIPL(const char * FileLoc)
 {
     CloseSystem();
     if (g_Settings->LoadBool(GameRunning_LoadingInProgress))
@@ -459,7 +497,7 @@ bool CN64System::RunFileImageIPL(const char * FileLoc)
     return true;
 }
 
-bool CN64System::RunDiskImage(const char * FileLoc, const bool Expansion)
+bool CN64System::LoadDiskImage(const char * FileLoc, const bool Expansion)
 {
     CloseSystem();
     if (g_Settings->LoadBool(GameRunning_LoadingInProgress))

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -370,6 +370,17 @@ bool CN64System::LoadFileImage(const char * FileLoc)
 
 bool CN64System::RunFileImage(const char * FileLoc)
 {
+    //Uninitialize g_Disk and g_DDRom to prevent exception when ending emulation of a regular ROM after playing 64DD content previously.
+    if (g_Disk != NULL)
+    {
+        delete g_Disk;
+        g_Disk = NULL;
+    }
+    if (g_DDRom != NULL)
+    {
+        delete g_DDRom;
+        g_DDRom = NULL;
+    }
     if (!LoadFileImage(FileLoc))
     {
         return false;

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -328,7 +328,7 @@ bool CN64System::LoadFileImage(const char * FileLoc)
     WriteTrace(TraceN64System, TraceDebug, "Loading \"%s\"", FileLoc);
     if (g_Rom->LoadN64Image(FileLoc))
     {
-        if (g_Rom->CicChipID() == CIC_NUS_8303 || g_Rom->CicChipID() == CIC_NUS_DDUS)
+        if (g_Rom->IsLoadedRomDDIPL())
         {
             //64DD IPL
             if (g_DDRom == NULL)
@@ -341,7 +341,7 @@ bool CN64System::LoadFileImage(const char * FileLoc)
 
         g_System->RefreshGameSettings();
 
-        if (g_Rom->CicChipID() != CIC_NUS_8303 && g_Rom->CicChipID() != CIC_NUS_DDUS)
+        if (!g_Rom->IsLoadedRomDDIPL())
         {
             g_Settings->SaveString(Game_File, FileLoc);
         }
@@ -390,7 +390,7 @@ bool CN64System::LoadFileImageIPL(const char * FileLoc)
     WriteTrace(TraceN64System, TraceDebug, "Loading \"%s\"", FileLoc);
     if (g_DDRom->LoadN64ImageIPL(FileLoc))
     {
-        if (g_DDRom->CicChipID() != CIC_NUS_8303 && g_DDRom->CicChipID() != CIC_NUS_DDUS)
+        if (!g_DDRom->IsLoadedRomDDIPL())
         {
             //If not 64DD IPL then it's wrong
             WriteTrace(TraceN64System, TraceError, "LoadN64ImageIPL failed (\"%s\")", FileLoc);
@@ -504,7 +504,7 @@ bool CN64System::RunDiskImage(const char * FileLoc)
     }
     else
     {
-        if (g_Rom->CicChipID() != CIC_NUS_8303 && g_Rom->CicChipID() != CIC_NUS_DDUS)
+        if (!g_Rom->IsLoadedRomDDIPL())
         {
             g_Notify->DisplayError(MSG_FAIL_IMAGE_IPL);
             g_Settings->SaveString(File_DiskIPLPath, "");

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -344,12 +344,12 @@ bool CN64System::LoadFileImage(const char * FileLoc)
             g_Settings->SaveBool(Setting_EnableDisk, true);
         }
 
-		g_System->RefreshGameSettings();
+        g_System->RefreshGameSettings();
 
-		if (g_Rom->CicChipID() != CIC_NUS_8303 && g_Rom->CicChipID() != CIC_NUS_DDUS)
-		{
-			g_Settings->SaveString(Game_File, FileLoc);
-		}
+        if (g_Rom->CicChipID() != CIC_NUS_8303 && g_Rom->CicChipID() != CIC_NUS_DDUS)
+        {
+            g_Settings->SaveString(Game_File, FileLoc);
+        }
         g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
 
         WriteTrace(TraceN64System, TraceDebug, "Finished Loading (GoodName: %s)", g_Settings->LoadStringVal(Rdb_GoodName).c_str());
@@ -384,44 +384,44 @@ bool CN64System::RunFileImage(const char * FileLoc)
 
 bool CN64System::RunDiskImage(const char * FileLoc)
 {
-	if (!LoadFileImage(g_Settings->LoadStringVal(File_DiskIPLPath).c_str()))
-	{
-		g_Settings->SaveString(File_DiskIPLPath, "");
-		return false;
-	}
-	if (!LoadDiskImage(FileLoc, false))
-	{
-		return false;
-	}
-	if (g_Settings->LoadBool(Setting_AutoStart) != 0)
-	{
-		WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
-		RunLoadedImage();
-	}
-	return true;
+    if (!LoadFileImage(g_Settings->LoadStringVal(File_DiskIPLPath).c_str()))
+    {
+        g_Settings->SaveString(File_DiskIPLPath, "");
+        return false;
+    }
+    if (!LoadDiskImage(FileLoc, false))
+    {
+        return false;
+    }
+    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
+    {
+        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
+        RunLoadedImage();
+    }
+    return true;
 }
 
 bool CN64System::RunDiskComboImage(const char * FileLoc, const char * FileLocDisk)
 {
-	if (!LoadFileImageIPL(g_Settings->LoadStringVal(File_DiskIPLPath).c_str()))
-	{
-		g_Settings->SaveString(File_DiskIPLPath, "");
-		return false;
-	}
-	if (!LoadDiskImage(FileLocDisk, true))
-	{
-		return false;
-	}
-	if (!LoadFileImage(FileLoc))
-	{
-		return false;
-	}
-	if (g_Settings->LoadBool(Setting_AutoStart) != 0)
-	{
-		WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
-		RunLoadedImage();
-	}
-	return true;
+    if (!LoadFileImageIPL(g_Settings->LoadStringVal(File_DiskIPLPath).c_str()))
+    {
+        g_Settings->SaveString(File_DiskIPLPath, "");
+        return false;
+    }
+    if (!LoadDiskImage(FileLocDisk, true))
+    {
+        return false;
+    }
+    if (!LoadFileImage(FileLoc))
+    {
+        return false;
+    }
+    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
+    {
+        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
+        RunLoadedImage();
+    }
+    return true;
 }
 
 
@@ -526,10 +526,10 @@ bool CN64System::LoadDiskImage(const char * FileLoc, const bool Expansion)
     {
         g_System->RefreshGameSettings();
 
-		if (!Expansion)
-		{
-			g_Settings->SaveString(Game_File, FileLoc);
-		}
+        if (!Expansion)
+        {
+            g_Settings->SaveString(Game_File, FileLoc);
+        }
         g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
     }
     else

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -339,11 +339,6 @@ bool CN64System::LoadFileImage(const char * FileLoc)
             g_Settings->SaveString(File_DiskIPLPath, FileLoc);
         }
 
-        if (g_DDRom != NULL)
-        {
-            g_Settings->SaveBool(Setting_EnableDisk, true);
-        }
-
         g_System->RefreshGameSettings();
 
         if (g_Rom->CicChipID() != CIC_NUS_8303 && g_Rom->CicChipID() != CIC_NUS_DDUS)
@@ -373,11 +368,13 @@ bool CN64System::RunFileImage(const char * FileLoc)
     //Uninitialize g_Disk and g_DDRom to prevent exception when ending emulation of a regular ROM after playing 64DD content previously.
     if (g_Disk != NULL)
     {
+        g_Disk->UnallocateDiskImage();
         delete g_Disk;
         g_Disk = NULL;
     }
     if (g_DDRom != NULL)
     {
+        g_DDRom->UnallocateRomImage();
         delete g_DDRom;
         g_DDRom = NULL;
     }

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -301,7 +301,7 @@ bool CN64System::LoadFileImage(const char * FileLoc)
 {
     WriteTrace(TraceN64System, TraceDebug, "Start (FileLoc: %s)", FileLoc);
     CloseSystem();
-    g_Settings->SaveBool(Setting_EnableDisk, false);
+
     g_Settings->SaveDword(Game_CurrentSaveState, g_Settings->LoadDefaultDword(Game_CurrentSaveState));
     if (g_Settings->LoadBool(GameRunning_LoadingInProgress))
     {
@@ -382,6 +382,7 @@ bool CN64System::RunFileImage(const char * FileLoc)
     {
         return false;
     }
+    g_Settings->SaveBool(Setting_EnableDisk, false);
     if (g_Settings->LoadBool(Setting_AutoStart) != 0)
     {
         WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
@@ -401,6 +402,7 @@ bool CN64System::RunDiskImage(const char * FileLoc)
     {
         return false;
     }
+    g_Settings->SaveBool(Setting_EnableDisk, true);
     if (g_Settings->LoadBool(Setting_AutoStart) != 0)
     {
         WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
@@ -424,6 +426,7 @@ bool CN64System::RunDiskComboImage(const char * FileLoc, const char * FileLocDis
     {
         return false;
     }
+    g_Settings->SaveBool(Setting_EnableDisk, true);
     if (g_Settings->LoadBool(Setting_AutoStart) != 0)
     {
         WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -344,9 +344,12 @@ bool CN64System::LoadFileImage(const char * FileLoc)
             g_Settings->SaveBool(Setting_EnableDisk, true);
         }
 
-        g_System->RefreshGameSettings();
+		g_System->RefreshGameSettings();
 
-        g_Settings->SaveString(Game_File, FileLoc);
+		if (g_Rom->CicChipID() != CIC_NUS_8303 && g_Rom->CicChipID() != CIC_NUS_DDUS)
+		{
+			g_Settings->SaveString(Game_File, FileLoc);
+		}
         g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
 
         WriteTrace(TraceN64System, TraceDebug, "Finished Loading (GoodName: %s)", g_Settings->LoadStringVal(Rdb_GoodName).c_str());
@@ -371,6 +374,11 @@ bool CN64System::RunFileImage(const char * FileLoc)
     {
         return false;
     }
+	if (g_Rom == g_DDRom && g_Rom != NULL && g_DDRom != NULL && g_Disk != NULL)
+	{
+		g_Settings->SaveString(Game_IniKey, g_Disk->GetDiskIdent().c_str());
+		g_System->RefreshGameSettings();
+	}
     if (g_Settings->LoadBool(Setting_AutoStart) != 0)
     {
         WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
@@ -451,7 +459,7 @@ bool CN64System::RunFileImageIPL(const char * FileLoc)
     return true;
 }
 
-bool CN64System::RunDiskImage(const char * FileLoc)
+bool CN64System::RunDiskImage(const char * FileLoc, const bool Expansion)
 {
     CloseSystem();
     if (g_Settings->LoadBool(GameRunning_LoadingInProgress))
@@ -480,7 +488,10 @@ bool CN64System::RunDiskImage(const char * FileLoc)
     {
         g_System->RefreshGameSettings();
 
-        //g_Settings->SaveString(Game_File, FileLoc);
+		if (!Expansion)
+		{
+			g_Settings->SaveString(Game_File, FileLoc);
+		}
         g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
     }
     else

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -363,94 +363,6 @@ bool CN64System::LoadFileImage(const char * FileLoc)
     return true;
 }
 
-bool CN64System::RunFileImage(const char * FileLoc)
-{
-    //Uninitialize g_Disk and g_DDRom to prevent exception when ending emulation of a regular ROM after playing 64DD content previously.
-    if (g_Disk != NULL)
-    {
-        g_Disk->UnallocateDiskImage();
-        delete g_Disk;
-        g_Disk = NULL;
-    }
-    if (g_DDRom != NULL)
-    {
-        g_DDRom->UnallocateRomImage();
-        delete g_DDRom;
-        g_DDRom = NULL;
-    }
-    if (!LoadFileImage(FileLoc))
-    {
-        return false;
-    }
-    g_Settings->SaveBool(Setting_EnableDisk, false);
-    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
-    {
-        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
-        RunLoadedImage();
-    }
-    return true;
-}
-
-bool CN64System::RunDiskImage(const char * FileLoc)
-{
-    if (!LoadFileImage(g_Settings->LoadStringVal(File_DiskIPLPath).c_str()))
-    {
-        g_Settings->SaveString(File_DiskIPLPath, "");
-        return false;
-    }
-    if (!LoadDiskImage(FileLoc, false))
-    {
-        return false;
-    }
-    g_Settings->SaveBool(Setting_EnableDisk, true);
-    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
-    {
-        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
-        RunLoadedImage();
-    }
-    return true;
-}
-
-bool CN64System::RunDiskComboImage(const char * FileLoc, const char * FileLocDisk)
-{
-    if (!LoadFileImageIPL(g_Settings->LoadStringVal(File_DiskIPLPath).c_str()))
-    {
-        g_Settings->SaveString(File_DiskIPLPath, "");
-        return false;
-    }
-    if (!LoadDiskImage(FileLocDisk, true))
-    {
-        return false;
-    }
-    if (!LoadFileImage(FileLoc))
-    {
-        return false;
-    }
-    g_Settings->SaveBool(Setting_EnableDisk, true);
-    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
-    {
-        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
-        RunLoadedImage();
-    }
-    return true;
-}
-
-
-void CN64System::RunLoadedImage(void)
-{
-    WriteTrace(TraceN64System, TraceDebug, "Start");
-    g_BaseSystem = new CN64System(g_Plugins, (uint32_t)time(NULL), false, false);
-    if (g_BaseSystem)
-    {
-        g_BaseSystem->StartEmulation(true);
-    }
-    else
-    {
-        WriteTrace(TraceN64System, TraceError, "Failed to create CN64System");
-    }
-    WriteTrace(TraceN64System, TraceDebug, "Done");
-}
-
 bool CN64System::LoadFileImageIPL(const char * FileLoc)
 {
     CloseSystem();
@@ -553,6 +465,102 @@ bool CN64System::LoadDiskImage(const char * FileLoc, const bool Expansion)
         return false;
     }
     return true;
+}
+
+bool CN64System::RunFileImage(const char * FileLoc)
+{
+    //Uninitialize g_Disk and g_DDRom to prevent exception when ending emulation of a regular ROM after playing 64DD content previously.
+    if (g_Disk != NULL)
+    {
+        g_Disk->UnallocateDiskImage();
+        delete g_Disk;
+        g_Disk = NULL;
+    }
+    if (g_DDRom != NULL)
+    {
+        g_DDRom->UnallocateRomImage();
+        delete g_DDRom;
+        g_DDRom = NULL;
+    }
+    if (!LoadFileImage(FileLoc))
+    {
+        return false;
+    }
+    g_Settings->SaveBool(Setting_EnableDisk, false);
+    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
+    {
+        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
+        RunLoadedImage();
+    }
+    return true;
+}
+
+bool CN64System::RunDiskImage(const char * FileLoc)
+{
+    if (!LoadFileImage(g_Settings->LoadStringVal(File_DiskIPLPath).c_str()))
+    {
+        g_Settings->SaveString(File_DiskIPLPath, "");
+        return false;
+    }
+    else
+    {
+        if (g_Rom->CicChipID() != CIC_NUS_8303 && g_Rom->CicChipID() != CIC_NUS_DDUS)
+        {
+            g_Notify->DisplayError(MSG_FAIL_IMAGE_IPL);
+            g_Settings->SaveString(File_DiskIPLPath, "");
+            return false;
+        }
+    }
+    if (!LoadDiskImage(FileLoc, false))
+    {
+        return false;
+    }
+    g_Settings->SaveBool(Setting_EnableDisk, true);
+    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
+    {
+        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
+        RunLoadedImage();
+    }
+    return true;
+}
+
+bool CN64System::RunDiskComboImage(const char * FileLoc, const char * FileLocDisk)
+{
+    if (!LoadFileImageIPL(g_Settings->LoadStringVal(File_DiskIPLPath).c_str()))
+    {
+        g_Settings->SaveString(File_DiskIPLPath, "");
+        return false;
+    }
+    if (!LoadDiskImage(FileLocDisk, true))
+    {
+        return false;
+    }
+    if (!LoadFileImage(FileLoc))
+    {
+        return false;
+    }
+    g_Settings->SaveBool(Setting_EnableDisk, true);
+    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
+    {
+        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
+        RunLoadedImage();
+    }
+    return true;
+}
+
+void CN64System::RunLoadedImage(void)
+{
+    WriteTrace(TraceN64System, TraceDebug, "Start");
+    g_BaseSystem = new CN64System(g_Plugins, (uint32_t)time(NULL), false, false);
+    if (g_BaseSystem)
+    {
+        g_BaseSystem->StartEmulation(true);
+    }
+    else
+    {
+        WriteTrace(TraceN64System, TraceError, "Failed to create CN64System");
+    }
+    WriteTrace(TraceN64System, TraceDebug, "Done");
 }
 
 void CN64System::CloseSystem()

--- a/Source/Project64-core/N64System/N64Class.h
+++ b/Source/Project64-core/N64System/N64Class.h
@@ -60,7 +60,7 @@ public:
     static bool LoadFileImage(const char * FileLoc);
     static bool RunFileImage(const char * FileLoc);
     static bool RunFileImageIPL(const char * FileLoc);
-    static bool RunDiskImage(const char * FileLoc);
+    static bool RunDiskImage(const char * FileLoc, const bool Expansion);
     static void RunLoadedImage(void);
     static void CloseSystem(void);
 

--- a/Source/Project64-core/N64System/N64Class.h
+++ b/Source/Project64-core/N64System/N64Class.h
@@ -59,8 +59,8 @@ public:
     //Methods
     static bool LoadFileImage(const char * FileLoc);
     static bool RunFileImage(const char * FileLoc);
-	static bool RunDiskImage(const char * FileLoc);
-	static bool RunDiskComboImage(const char * FileLoc, const char * FileLocDisk);
+    static bool RunDiskImage(const char * FileLoc);
+    static bool RunDiskComboImage(const char * FileLoc, const char * FileLocDisk);
     static bool LoadFileImageIPL(const char * FileLoc);
     static bool LoadDiskImage(const char * FileLoc, const bool Expansion);
     static void RunLoadedImage(void);

--- a/Source/Project64-core/N64System/N64Class.h
+++ b/Source/Project64-core/N64System/N64Class.h
@@ -59,8 +59,10 @@ public:
     //Methods
     static bool LoadFileImage(const char * FileLoc);
     static bool RunFileImage(const char * FileLoc);
-    static bool RunFileImageIPL(const char * FileLoc);
-    static bool RunDiskImage(const char * FileLoc, const bool Expansion);
+	static bool RunDiskImage(const char * FileLoc);
+	static bool RunDiskComboImage(const char * FileLoc, const char * FileLocDisk);
+    static bool LoadFileImageIPL(const char * FileLoc);
+    static bool LoadDiskImage(const char * FileLoc, const bool Expansion);
     static void RunLoadedImage(void);
     static void CloseSystem(void);
 

--- a/Source/Project64-core/N64System/N64Class.h
+++ b/Source/Project64-core/N64System/N64Class.h
@@ -58,11 +58,11 @@ public:
 
     //Methods
     static bool LoadFileImage(const char * FileLoc);
+    static bool LoadFileImageIPL(const char * FileLoc);
+    static bool LoadDiskImage(const char * FileLoc, const bool Expansion);
     static bool RunFileImage(const char * FileLoc);
     static bool RunDiskImage(const char * FileLoc);
     static bool RunDiskComboImage(const char * FileLoc, const char * FileLocDisk);
-    static bool LoadFileImageIPL(const char * FileLoc);
-    static bool LoadDiskImage(const char * FileLoc, const bool Expansion);
     static void RunLoadedImage(void);
     static void CloseSystem(void);
 

--- a/Source/Project64-core/N64System/N64DiskClass.cpp
+++ b/Source/Project64-core/N64System/N64DiskClass.cpp
@@ -37,8 +37,6 @@ bool CN64Disk::LoadDiskImage(const char * FileLoc)
     stdstr ShadowFile = FileLoc;
     ShadowFile[ShadowFile.length() - 1] = 'r';
 
-    g_Settings->SaveBool(GameRunning_LoadingInProgress, true);
-
     WriteTrace(TraceN64System, TraceDebug, "Attempt to load shadow file.");
     if (!AllocateAndLoadDiskImage(ShadowFile.c_str()))
     {

--- a/Source/Project64-core/N64System/N64DiskClass.cpp
+++ b/Source/Project64-core/N64System/N64DiskClass.cpp
@@ -64,6 +64,7 @@ bool CN64Disk::LoadDiskImage(const char * FileLoc)
     if (g_Disk == this)
     {
         g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
+        g_Settings->SaveBool(Setting_EnableDisk, true);
         SaveDiskSettingID(false);
     }
     return true;

--- a/Source/Project64-core/N64System/N64DiskClass.cpp
+++ b/Source/Project64-core/N64System/N64DiskClass.cpp
@@ -64,7 +64,6 @@ bool CN64Disk::LoadDiskImage(const char * FileLoc)
     if (g_Disk == this)
     {
         g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
-        g_Settings->SaveBool(Setting_EnableDisk, true);
         SaveDiskSettingID(false);
     }
     return true;

--- a/Source/Project64-core/N64System/N64DiskClass.cpp
+++ b/Source/Project64-core/N64System/N64DiskClass.cpp
@@ -50,24 +50,24 @@ bool CN64Disk::LoadDiskImage(const char * FileLoc)
         }
     }
 
-	char RomName[5];
-	//Get the disk ID from the disk image
-	RomName[0] = (char)*(m_DiskImage + 0x43673);
-	RomName[1] = (char)*(m_DiskImage + 0x43672);
-	RomName[2] = (char)*(m_DiskImage + 0x43671);
-	RomName[3] = (char)*(m_DiskImage + 0x43670);
-	RomName[4] = '\0';
+    char RomName[5];
+    //Get the disk ID from the disk image
+    RomName[0] = (char)*(m_DiskImage + 0x43673);
+    RomName[1] = (char)*(m_DiskImage + 0x43672);
+    RomName[2] = (char)*(m_DiskImage + 0x43671);
+    RomName[3] = (char)*(m_DiskImage + 0x43670);
+    RomName[4] = '\0';
 
-	m_RomName = RomName;
+    m_RomName = RomName;
     m_FileName = FileLoc;
-	m_DiskIdent.Format("%08X-%08X-C:%X", *(uint32_t *)(&m_DiskImage[0]), *(uint32_t *)(&m_DiskImage[0x43670]), m_DiskImage[0x43670]);
-	m_Country = (Country)m_DiskImage[0x43670];
+    m_DiskIdent.Format("%08X-%08X-C:%X", *(uint32_t *)(&m_DiskImage[0]), *(uint32_t *)(&m_DiskImage[0x43670]), m_DiskImage[0x43670]);
+    m_Country = (Country)m_DiskImage[0x43670];
 
-	if (g_Disk == this)
-	{
-		g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
-		SaveDiskSettingID(false);
-	}
+    if (g_Disk == this)
+    {
+        g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
+        SaveDiskSettingID(false);
+    }
     return true;
 }
 
@@ -136,28 +136,28 @@ bool CN64Disk::IsValidDiskImage(uint8_t Test[4])
 //this rom
 void CN64Disk::SaveDiskSettingID(bool temp)
 {
-	g_Settings->SaveBool(Game_TempLoaded, temp);
-	g_Settings->SaveString(Game_GameName, m_RomName.c_str());
-	g_Settings->SaveString(Game_IniKey, m_DiskIdent.c_str());
-	//g_Settings->SaveString(Game_UniqueSaveDir, stdstr_f("%s-%s", m_RomName.c_str(), m_MD5.c_str()).c_str());
+    g_Settings->SaveBool(Game_TempLoaded, temp);
+    g_Settings->SaveString(Game_GameName, m_RomName.c_str());
+    g_Settings->SaveString(Game_IniKey, m_DiskIdent.c_str());
+    //g_Settings->SaveString(Game_UniqueSaveDir, stdstr_f("%s-%s", m_RomName.c_str(), m_MD5.c_str()).c_str());
 
-	switch (GetCountry())
-	{
-	case Germany: case french:  case Italian:
-	case Europe:  case Spanish: case Australia:
-	case X_PAL:   case Y_PAL:
-		g_Settings->SaveDword(Game_SystemType, SYSTEM_PAL);
-		break;
-	default:
-		g_Settings->SaveDword(Game_SystemType, SYSTEM_NTSC);
-		break;
-	}
+    switch (GetCountry())
+    {
+    case Germany: case french:  case Italian:
+    case Europe:  case Spanish: case Australia:
+    case X_PAL:   case Y_PAL:
+        g_Settings->SaveDword(Game_SystemType, SYSTEM_PAL);
+        break;
+    default:
+        g_Settings->SaveDword(Game_SystemType, SYSTEM_NTSC);
+        break;
+    }
 }
 
 void CN64Disk::ClearDiskSettingID()
 {
-	g_Settings->SaveString(Game_GameName, "");
-	g_Settings->SaveString(Game_IniKey, "");
+    g_Settings->SaveString(Game_GameName, "");
+    g_Settings->SaveString(Game_IniKey, "");
 }
 
 bool CN64Disk::AllocateDiskImage(uint32_t DiskFileSize)

--- a/Source/Project64-core/N64System/N64DiskClass.h
+++ b/Source/Project64-core/N64System/N64DiskClass.h
@@ -27,7 +27,7 @@ public:
     void    ClearDiskSettingID();
     uint8_t *  GetDiskAddress() { return m_DiskImage; }
     uint8_t *  GetDiskAddressBuffer() { return m_DiskImage + m_DiskBufAddress; }
-    uint8_t *  GetDiskHeader() { return m_DiskImage + 0x43650; }
+    uint8_t *  GetDiskHeader() { return m_DiskHeader; }
     void    SetDiskAddressBuffer(uint32_t address) { m_DiskBufAddress = address; }
     stdstr  GetRomName() const { return m_RomName; }
     stdstr  GetFileName() const { return m_FileName; }
@@ -39,6 +39,7 @@ public:
 
 private:
     bool   AllocateDiskImage(uint32_t DiskFileSize);
+    bool   AllocateDiskHeader();
     bool   AllocateAndLoadDiskImage(const char * FileLoc);
     void   ByteSwapDisk();
     void   ForceByteSwapDisk();
@@ -54,6 +55,8 @@ private:
     CFile m_DiskFile;
     uint8_t * m_DiskImage;
     uint8_t * m_DiskImageBase;
+    uint8_t * m_DiskHeader;
+    uint8_t * m_DiskHeaderBase;
     uint32_t m_DiskFileSize;
     uint32_t m_DiskBufAddress;
     LanguageStringID m_ErrorMsg;

--- a/Source/Project64-core/N64System/N64DiskClass.h
+++ b/Source/Project64-core/N64System/N64DiskClass.h
@@ -23,15 +23,15 @@ public:
     bool    SaveDiskImage();
     void    SwapDiskImage(const char * FileLoc);
     static bool IsValidDiskImage(uint8_t Test[4]);
-	void    SaveDiskSettingID(bool temp);
-	void    ClearDiskSettingID();
+    void    SaveDiskSettingID(bool temp);
+    void    ClearDiskSettingID();
     uint8_t *  GetDiskAddress() { return m_DiskImage; }
     uint8_t *  GetDiskAddressBuffer() { return m_DiskImage + m_DiskBufAddress; }
     void    SetDiskAddressBuffer(uint32_t address) { m_DiskBufAddress = address; }
-	stdstr  GetRomName() const { return m_RomName; }
-	stdstr  GetFileName() const { return m_FileName; }
-	stdstr  GetDiskIdent() const { return m_DiskIdent; }
-	Country GetCountry() const { return m_Country; }
+    stdstr  GetRomName() const { return m_RomName; }
+    stdstr  GetFileName() const { return m_FileName; }
+    stdstr  GetDiskIdent() const { return m_DiskIdent; }
+    Country GetCountry() const { return m_Country; }
     void    UnallocateDiskImage();
 
     LanguageStringID GetError() const { return m_ErrorMsg; }
@@ -56,7 +56,7 @@ private:
     uint32_t m_DiskFileSize;
     uint32_t m_DiskBufAddress;
     LanguageStringID m_ErrorMsg;
-	Country m_Country;
+    Country m_Country;
     stdstr m_RomName, m_FileName, m_DiskIdent;
     uint8_t m_DiskFormat; //0 = MAME, 1 = SDK
 

--- a/Source/Project64-core/N64System/N64DiskClass.h
+++ b/Source/Project64-core/N64System/N64DiskClass.h
@@ -9,6 +9,8 @@
 *                                                                           *
 ****************************************************************************/
 #pragma once
+
+#include <Project64-core/N64System/N64Types.h>
 #include <Common/stdtypes.h>
 
 class CN64Disk
@@ -21,9 +23,15 @@ public:
     bool    SaveDiskImage();
     void    SwapDiskImage(const char * FileLoc);
     static bool IsValidDiskImage(uint8_t Test[4]);
+	void    SaveDiskSettingID(bool temp);
+	void    ClearDiskSettingID();
     uint8_t *  GetDiskAddress() { return m_DiskImage; }
     uint8_t *  GetDiskAddressBuffer() { return m_DiskImage + m_DiskBufAddress; }
     void    SetDiskAddressBuffer(uint32_t address) { m_DiskBufAddress = address; }
+	stdstr  GetRomName() const { return m_RomName; }
+	stdstr  GetFileName() const { return m_FileName; }
+	stdstr  GetDiskIdent() const { return m_DiskIdent; }
+	Country GetCountry() const { return m_Country; }
     void    UnallocateDiskImage();
 
     LanguageStringID GetError() const { return m_ErrorMsg; }
@@ -48,7 +56,8 @@ private:
     uint32_t m_DiskFileSize;
     uint32_t m_DiskBufAddress;
     LanguageStringID m_ErrorMsg;
-    stdstr m_FileName, m_DiskIdent;
+	Country m_Country;
+    stdstr m_RomName, m_FileName, m_DiskIdent;
     uint8_t m_DiskFormat; //0 = MAME, 1 = SDK
 
     //disk convert

--- a/Source/Project64-core/N64System/N64DiskClass.h
+++ b/Source/Project64-core/N64System/N64DiskClass.h
@@ -27,6 +27,7 @@ public:
     void    ClearDiskSettingID();
     uint8_t *  GetDiskAddress() { return m_DiskImage; }
     uint8_t *  GetDiskAddressBuffer() { return m_DiskImage + m_DiskBufAddress; }
+    uint8_t *  GetDiskHeader() { return m_DiskImage + 0x43650; }
     void    SetDiskAddressBuffer(uint32_t address) { m_DiskBufAddress = address; }
     stdstr  GetRomName() const { return m_RomName; }
     stdstr  GetFileName() const { return m_FileName; }

--- a/Source/Project64-core/N64System/N64RomClass.cpp
+++ b/Source/Project64-core/N64System/N64RomClass.cpp
@@ -751,7 +751,6 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
     if (!LoadBootCodeOnly && g_DDRom == this)
     {
         g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
-        g_Settings->SaveBool(Setting_EnableDisk, true);
         SaveRomSettingID(false);
     }
 

--- a/Source/Project64-core/N64System/N64RomClass.cpp
+++ b/Source/Project64-core/N64System/N64RomClass.cpp
@@ -680,13 +680,13 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
             g_Notify->DisplayMessage(5, MSG_LOADING);
             if (!ZipFile.GetFile(i, m_ROMImage, RomFileSize))
             {
-                SetError(MSG_FAIL_IMAGE);
+                SetError(MSG_FAIL_IMAGE_IPL);
                 return false;
             }
 
             if (!IsValidRomImage(m_ROMImage))
             {
-                SetError(MSG_FAIL_IMAGE);
+                SetError(MSG_FAIL_IMAGE_IPL);
                 return false;
             }
             g_Notify->DisplayMessage(5, MSG_BYTESWAP);
@@ -747,6 +747,12 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
     m_RomIdent.Format("%08X-%08X-C:%X", *(uint32_t *)(&m_ROMImage[0x10]), *(uint32_t *)(&m_ROMImage[0x14]), m_ROMImage[0x3D]);
     WriteTrace(TraceN64System, TraceDebug, "Ident: %s", m_RomIdent.c_str());
     CalculateCicChip();
+
+    if (CicChipID() != CIC_NUS_8303 && CicChipID() != CIC_NUS_DDUS)
+    {
+        SetError(MSG_FAIL_IMAGE_IPL);
+        return false;
+    }
 
     if (!LoadBootCodeOnly && g_DDRom == this)
     {

--- a/Source/Project64-core/N64System/N64RomClass.cpp
+++ b/Source/Project64-core/N64System/N64RomClass.cpp
@@ -751,6 +751,7 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
     if (!LoadBootCodeOnly && g_DDRom == this)
     {
         g_Settings->SaveBool(GameRunning_LoadingInProgress, false);
+        g_Settings->SaveBool(Setting_EnableDisk, true);
         SaveRomSettingID(false);
     }
 

--- a/Source/Project64-core/N64System/N64RomClass.cpp
+++ b/Source/Project64-core/N64System/N64RomClass.cpp
@@ -416,6 +416,18 @@ bool CN64Rom::IsValidRomImage(uint8_t Test[4])
     return false;
 }
 
+bool CN64Rom::IsLoadedRomDDIPL()
+{
+    switch (CicChipID())
+    {
+        case CIC_NUS_8303:
+        case CIC_NUS_DDUS:
+            return true;
+        default:
+            return false;
+    }
+}
+
 void CN64Rom::CleanRomName(char * RomName, bool byteswap)
 {
     if (byteswap)
@@ -748,7 +760,7 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
     WriteTrace(TraceN64System, TraceDebug, "Ident: %s", m_RomIdent.c_str());
     CalculateCicChip();
 
-    if (CicChipID() != CIC_NUS_8303 && CicChipID() != CIC_NUS_DDUS)
+    if (!IsLoadedRomDDIPL())
     {
         SetError(MSG_FAIL_IMAGE_IPL);
         return false;

--- a/Source/Project64-core/N64System/N64RomClass.h
+++ b/Source/Project64-core/N64System/N64RomClass.h
@@ -24,6 +24,7 @@ public:
     bool    LoadN64Image(const char * FileLoc, bool LoadBootCodeOnly = false);
     bool    LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly = false);
     static bool IsValidRomImage(uint8_t Test[4]);
+    bool    IsLoadedRomDDIPL();
     void    SaveRomSettingID(bool temp);
     void    ClearRomSettingID();
     CICChip CicChipID();

--- a/Source/Project64-core/Plugins/AudioPlugin.cpp
+++ b/Source/Project64-core/Plugins/AudioPlugin.cpp
@@ -135,7 +135,7 @@ bool CAudioPlugin::Initiate(CN64System * System, RenderWindow * Window)
         CMipsMemoryVM & MMU = System->m_MMU_VM;
         CRegisters & Reg = System->m_Reg;
 
-        if ((g_Rom->CicChipID() == CIC_NUS_8303 || g_Rom->CicChipID() == CIC_NUS_DDUS) && g_Disk != NULL)
+        if (g_Rom->IsLoadedRomDDIPL() && g_Disk != NULL)
             Info.HEADER = g_Disk->GetDiskHeader();
         else
             Info.HEADER = g_Rom->GetRomAddress();

--- a/Source/Project64-core/Plugins/AudioPlugin.cpp
+++ b/Source/Project64-core/Plugins/AudioPlugin.cpp
@@ -11,6 +11,7 @@
 #include "stdafx.h"
 #include <Project64-core/N64System/SystemGlobals.h>
 #include <Project64-core/N64System/N64RomClass.h>
+#include <Project64-core/N64System/N64DiskClass.h>
 #include <Project64-core/N64System/Mips/MemoryVirtualMem.h>
 #include <Project64-core/N64System/Mips/RegisterClass.h>
 #include <Project64-core/N64System/N64Class.h>
@@ -134,7 +135,10 @@ bool CAudioPlugin::Initiate(CN64System * System, RenderWindow * Window)
         CMipsMemoryVM & MMU = System->m_MMU_VM;
         CRegisters & Reg = System->m_Reg;
 
-        Info.HEADER = g_Rom->GetRomAddress();
+        if ((g_Rom->CicChipID() == CIC_NUS_8303 || g_Rom->CicChipID() == CIC_NUS_DDUS) && g_Disk != NULL)
+            Info.HEADER = g_Disk->GetDiskHeader();
+        else
+            Info.HEADER = g_Rom->GetRomAddress();
         Info.RDRAM = MMU.Rdram();
         Info.DMEM = MMU.Dmem();
         Info.IMEM = MMU.Imem();

--- a/Source/Project64-core/Plugins/GFXPlugin.cpp
+++ b/Source/Project64-core/Plugins/GFXPlugin.cpp
@@ -11,6 +11,7 @@
 #include "stdafx.h"
 #include <Project64-core/N64System/SystemGlobals.h>
 #include <Project64-core/N64System/N64RomClass.h>
+#include <Project64-core/N64System/N64DiskClass.h>
 #include <Project64-core/N64System/Mips/MemoryVirtualMem.h>
 #include <Project64-core/N64System/Mips/RegisterClass.h>
 #include <Project64-core/N64System/N64Class.h>
@@ -228,7 +229,10 @@ bool CGfxPlugin::Initiate(CN64System * System, RenderWindow * Window)
         CMipsMemoryVM & MMU = System->m_MMU_VM;
         CRegisters & Reg = System->m_Reg;
 
-        Info.HEADER = g_Rom->GetRomAddress();
+        if ((g_Rom->CicChipID() == CIC_NUS_8303 || g_Rom->CicChipID() == CIC_NUS_DDUS) && g_Disk != NULL)
+            Info.HEADER = g_Disk->GetDiskHeader();
+        else
+            Info.HEADER = g_Rom->GetRomAddress();
         Info.RDRAM = MMU.Rdram();
         Info.DMEM = MMU.Dmem();
         Info.IMEM = MMU.Imem();

--- a/Source/Project64-core/Plugins/GFXPlugin.cpp
+++ b/Source/Project64-core/Plugins/GFXPlugin.cpp
@@ -229,7 +229,7 @@ bool CGfxPlugin::Initiate(CN64System * System, RenderWindow * Window)
         CMipsMemoryVM & MMU = System->m_MMU_VM;
         CRegisters & Reg = System->m_Reg;
 
-        if ((g_Rom->CicChipID() == CIC_NUS_8303 || g_Rom->CicChipID() == CIC_NUS_DDUS) && g_Disk != NULL)
+        if (g_Rom->IsLoadedRomDDIPL() && g_Disk != NULL)
             Info.HEADER = g_Disk->GetDiskHeader();
         else
             Info.HEADER = g_Rom->GetRomAddress();

--- a/Source/Project64-core/Plugins/RSPPlugin.cpp
+++ b/Source/Project64-core/Plugins/RSPPlugin.cpp
@@ -186,7 +186,7 @@ bool CRSP_Plugin::Initiate(CPlugins * Plugins, CN64System * System)
             CMipsMemoryVM & MMU = System->m_MMU_VM;
             CRegisters & Reg = System->m_Reg;
 
-            if ((g_Rom->CicChipID() == CIC_NUS_8303 || g_Rom->CicChipID() == CIC_NUS_DDUS) && g_Disk != NULL)
+            if (g_Rom->IsLoadedRomDDIPL() && g_Disk != NULL)
                 Info.HEADER = g_Disk->GetDiskHeader();
             else
                 Info.HEADER = g_Rom->GetRomAddress();

--- a/Source/Project64-core/Plugins/RSPPlugin.cpp
+++ b/Source/Project64-core/Plugins/RSPPlugin.cpp
@@ -13,6 +13,7 @@
 #include <Project64-core/N64System/Mips/MemoryVirtualMem.h>
 #include <Project64-core/N64System/Mips/RegisterClass.h>
 #include <Project64-core/N64System/N64Class.h>
+#include <Project64-core/N64System/N64DiskClass.h>
 #include "RSPPlugin.h"
 #include "GFXPlugin.h"
 #include <Project64-core/Plugins/AudioPlugin.h>
@@ -185,7 +186,10 @@ bool CRSP_Plugin::Initiate(CPlugins * Plugins, CN64System * System)
             CMipsMemoryVM & MMU = System->m_MMU_VM;
             CRegisters & Reg = System->m_Reg;
 
-            Info.HEADER = g_Rom->GetRomAddress();
+            if ((g_Rom->CicChipID() == CIC_NUS_8303 || g_Rom->CicChipID() == CIC_NUS_DDUS) && g_Disk != NULL)
+                Info.HEADER = g_Disk->GetDiskHeader();
+            else
+                Info.HEADER = g_Rom->GetRomAddress();
             Info.RDRAM = MMU.Rdram();
             Info.DMEM = MMU.Dmem();
             Info.IMEM = MMU.Imem();

--- a/Source/Project64-core/RomList/RomList.cpp
+++ b/Source/Project64-core/RomList/RomList.cpp
@@ -33,7 +33,7 @@ static const char* ROM_extensions[] =
     "usa",
     "eur",
     "bin",
-	"ndd",
+    "ndd",
 };
 
 CRomList::CRomList() :
@@ -399,46 +399,46 @@ bool CRomList::LoadDataFromRomFile(const char * FileName, uint8_t * Data, int32_
         }
         FileFormat = Format_Zip;
     }
-	else
-	{
-		CFile File;
-		if (!File.Open(FileName, CFileBase::modeRead))
-		{
-			return false;
-		}
-		File.SeekToBegin();
-		if (!File.Read(Test, sizeof(Test)))
-		{
-			return false;
-		}
-		if (!CN64Rom::IsValidRomImage(Test) && !CN64Disk::IsValidDiskImage(Test))
-		{
-			return false;
-		}
+    else
+    {
+        CFile File;
+        if (!File.Open(FileName, CFileBase::modeRead))
+        {
+            return false;
+        }
+        File.SeekToBegin();
+        if (!File.Read(Test, sizeof(Test)))
+        {
+            return false;
+        }
+        if (!CN64Rom::IsValidRomImage(Test) && !CN64Disk::IsValidDiskImage(Test))
+        {
+            return false;
+        }
 
-		if (CN64Rom::IsValidRomImage(Test))
-		{
-			File.SeekToBegin();
-			if (!File.Read(Data, DataLen))
-			{
-				return false;
-			}
-		}
+        if (CN64Rom::IsValidRomImage(Test))
+        {
+            File.SeekToBegin();
+            if (!File.Read(Data, DataLen))
+            {
+                return false;
+            }
+        }
 
-		if (CN64Disk::IsValidDiskImage(Test))
-		{
-			//Is a Disk Image
-			File.SeekToBegin();
-			if (!File.Read(Data, 0x20))
-			{
-				return false;
-			}
-			File.Seek(0x43670, CFileBase::begin);
-			if (!File.Read(Data + 0x20, 0x20))
-			{
-				return false;
-			}
-		}
+        if (CN64Disk::IsValidDiskImage(Test))
+        {
+            //Is a Disk Image
+            File.SeekToBegin();
+            if (!File.Read(Data, 0x20))
+            {
+                return false;
+            }
+            File.Seek(0x43670, CFileBase::begin);
+            if (!File.Read(Data + 0x20, 0x20))
+            {
+                return false;
+            }
+        }
         *RomSize = File.GetLength();
         FileFormat = Format_Uncompressed;
     }
@@ -461,37 +461,37 @@ bool CRomList::FillRomInfo(ROM_INFO * pRomInfo)
             strncpy(pRomInfo->FileName, g_Settings->LoadBool(RomList_ShowFileExtensions) ? CPath(pRomInfo->szFullFileName).GetNameExtension().c_str() : CPath(pRomInfo->szFullFileName).GetName().c_str(), sizeof(pRomInfo->FileName) / sizeof(pRomInfo->FileName[0]));
         }
 
-		if (CPath(pRomInfo->szFullFileName).GetExtension() != "ndd")
-		{
-			char InternalName[22];
-			memcpy(InternalName, (void *)(RomData + 0x20), 20);
-			CN64Rom::CleanRomName(InternalName);
-			strcpy(pRomInfo->InternalName, InternalName);
-			pRomInfo->CartID[0] = *(RomData + 0x3F);
-			pRomInfo->CartID[1] = *(RomData + 0x3E);
-			pRomInfo->CartID[2] = '\0';
-			pRomInfo->Manufacturer = *(RomData + 0x38);
-			pRomInfo->Country = *(RomData + 0x3D);
-			pRomInfo->CRC1 = *(uint32_t *)(RomData + 0x10);
-			pRomInfo->CRC2 = *(uint32_t *)(RomData + 0x14);
-			pRomInfo->CicChip = CN64Rom::GetCicChipID(RomData);
-			FillRomExtensionInfo(pRomInfo);
-		}
-		else
-		{
-			char InternalName[22];
-			memcpy(InternalName, (void *)(RomData + 0x20), 4);
-			strcpy(pRomInfo->InternalName, InternalName);
-			pRomInfo->CartID[0] = *(RomData + 0x20);
-			pRomInfo->CartID[1] = *(RomData + 0x21);
-			pRomInfo->CartID[2] = *(RomData + 0x22);
-			pRomInfo->Manufacturer = '\0';
-			pRomInfo->Country = *(RomData + 0x20);
-			pRomInfo->CRC1 = *(uint32_t *)(RomData + 0x00);
-			pRomInfo->CRC2 = *(uint32_t *)(RomData + 0x20);
-			pRomInfo->CicChip = CIC_NUS_8303;
-			FillRomExtensionInfo(pRomInfo);
-		}
+        if (CPath(pRomInfo->szFullFileName).GetExtension() != "ndd")
+        {
+            char InternalName[22];
+            memcpy(InternalName, (void *)(RomData + 0x20), 20);
+            CN64Rom::CleanRomName(InternalName);
+            strcpy(pRomInfo->InternalName, InternalName);
+            pRomInfo->CartID[0] = *(RomData + 0x3F);
+            pRomInfo->CartID[1] = *(RomData + 0x3E);
+            pRomInfo->CartID[2] = '\0';
+            pRomInfo->Manufacturer = *(RomData + 0x38);
+            pRomInfo->Country = *(RomData + 0x3D);
+            pRomInfo->CRC1 = *(uint32_t *)(RomData + 0x10);
+            pRomInfo->CRC2 = *(uint32_t *)(RomData + 0x14);
+            pRomInfo->CicChip = CN64Rom::GetCicChipID(RomData);
+            FillRomExtensionInfo(pRomInfo);
+        }
+        else
+        {
+            char InternalName[22];
+            memcpy(InternalName, (void *)(RomData + 0x20), 4);
+            strcpy(pRomInfo->InternalName, InternalName);
+            pRomInfo->CartID[0] = *(RomData + 0x20);
+            pRomInfo->CartID[1] = *(RomData + 0x21);
+            pRomInfo->CartID[2] = *(RomData + 0x22);
+            pRomInfo->Manufacturer = '\0';
+            pRomInfo->Country = *(RomData + 0x20);
+            pRomInfo->CRC1 = *(uint32_t *)(RomData + 0x00);
+            pRomInfo->CRC2 = *(uint32_t *)(RomData + 0x20);
+            pRomInfo->CicChip = CIC_NUS_8303;
+            FillRomExtensionInfo(pRomInfo);
+        }
         return true;
     }
     return false;
@@ -565,9 +565,9 @@ void CRomList::ByteSwapRomData(uint8_t * Data, int32_t DataLen)
     switch (*((uint32_t *)&Data[0]))
     {
     case 0x12408037:
-	case 0x07408027: //64DD IPL
-	case 0xD316E848: //64DD JP Disk
-	case 0xEE562263: //64DD US Disk
+    case 0x07408027: //64DD IPL
+    case 0xD316E848: //64DD JP Disk
+    case 0xEE562263: //64DD US Disk
         for (count = 0; count < DataLen; count += 4)
         {
             Data[count] ^= Data[count + 2];
@@ -579,8 +579,8 @@ void CRomList::ByteSwapRomData(uint8_t * Data, int32_t DataLen)
         }
         break;
     case 0x40072780: //64DD IPL
-	case 0x16D348E8: //64DD JP Disk
-	case 0x56EE6322: //64DD US Disk
+    case 0x16D348E8: //64DD JP Disk
+    case 0x56EE6322: //64DD US Disk
     case 0x40123780:
         for (count = 0; count < DataLen; count += 4)
         {
@@ -593,10 +593,10 @@ void CRomList::ByteSwapRomData(uint8_t * Data, int32_t DataLen)
         }
         break;
     case 0x80371240:
-	case 0x80270740: //64DD IPL
-	case 0xE848D316: //64DD JP Disk
-	case 0x2263EE56: //64DD US Disk
-		break;
+    case 0x80270740: //64DD IPL
+    case 0xE848D316: //64DD JP Disk
+    case 0x2263EE56: //64DD US Disk
+        break;
     }
 }
 

--- a/Source/Project64/UserInterface/MainMenu.cpp
+++ b/Source/Project64/UserInterface/MainMenu.cpp
@@ -126,25 +126,25 @@ void CMainMenu::OnOpenRom(HWND hWnd)
         return;
     }
     // Open Disk
-	if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(File.c_str()))
-	{
-		CPath FileNameIPL;
-		const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-		if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-		{
-			g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
-			g_BaseSystem->RunDiskImage(File.c_str());
-		}
-	}
+    if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(File.c_str()))
+    {
+        CPath FileNameIPL;
+        const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+        if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+        {
+            g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
+            g_BaseSystem->RunDiskImage(File.c_str());
+        }
+    }
 }
 
 void CMainMenu::OnRomInfo(HWND hWnd)
 {
-	if (g_Disk)
-	{
-		RomInformation Info(g_Disk);
-		Info.DisplayInformation(hWnd);
-	}
+    if (g_Disk)
+    {
+        RomInformation Info(g_Disk);
+        Info.DisplayInformation(hWnd);
+    }
     else if (g_Rom)
     {
         RomInformation Info(g_Rom);
@@ -471,9 +471,9 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
     case ID_DEBUG_DISABLE_GAMEFIX:
         g_Settings->SaveBool(Debugger_DisableGameFixes, !g_Settings->LoadBool(Debugger_DisableGameFixes));
         break;
-	case ID_DEBUG_ENANCEMENT:
-		g_Settings->SaveBool(Setting_Enhancement, !g_Settings->LoadBool(Setting_Enhancement));
-		break;
+    case ID_DEBUG_ENANCEMENT:
+        g_Settings->SaveBool(Setting_Enhancement, !g_Settings->LoadBool(Setting_Enhancement));
+        break;
     case ID_DEBUGGER_TRACE_MD5: SetTraceModuleSetttings(Debugger_TraceMD5); break;
     case ID_DEBUGGER_TRACE_SETTINGS: SetTraceModuleSetttings(Debugger_TraceSettings); break;
     case ID_DEBUGGER_TRACE_UNKNOWN: SetTraceModuleSetttings(Debugger_TraceUnknown); break;
@@ -546,21 +546,21 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
             if (UISettingsLoadStringIndex(File_RecentGameFileIndex, MenuID - ID_RECENT_ROM_START, FileName) &&
                 FileName.length() > 0)
             {
-				if (CPath(FileName).GetExtension() != "ndd")
-					g_BaseSystem->RunFileImage(FileName.c_str());
-				else
-				{
-					if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(FileName.c_str()))
-					{
-						CPath FileNameIPL;
-						const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-						if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-						{
-							g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
-							g_BaseSystem->RunDiskImage(FileName.c_str());
-						}
-					}
-				}
+                if (CPath(FileName).GetExtension() != "ndd")
+                    g_BaseSystem->RunFileImage(FileName.c_str());
+                else
+                {
+                    if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(FileName.c_str()))
+                    {
+                        CPath FileNameIPL;
+                        const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+                        if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+                        {
+                            g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
+                            g_BaseSystem->RunDiskImage(FileName.c_str());
+                        }
+                    }
+                }
             }
         }
         if (MenuID >= ID_RECENT_DIR_START && MenuID < ID_RECENT_DIR_END)
@@ -652,8 +652,8 @@ std::wstring CMainMenu::GetSaveSlotString(int Slot)
     {
         FileName.AppendDirectory(g_Settings->LoadStringVal(Game_UniqueSaveDir).c_str());
     }
-	FileName.NormalizePath(CPath(CPath::MODULE_DIRECTORY));
-	if (Slot != 0)
+    FileName.NormalizePath(CPath(CPath::MODULE_DIRECTORY));
+    if (Slot != 0)
     {
         FileName.SetNameExtension(stdstr_f("%s.pj%d", g_Settings->LoadStringVal(Rdb_GoodName).c_str(), Slot).c_str());
     }
@@ -1241,13 +1241,13 @@ void CMainMenu::FillOutMenu(HMENU hMenu)
         DebugMenu.push_back(Item);
         Item.Reset(SUB_MENU, EMPTY_STRING, EMPTY_STDSTR, &DebugNotificationMenu, L"Notification");
         DebugMenu.push_back(Item);
-		Item.Reset(ID_DEBUG_ENANCEMENT, EMPTY_STRING, EMPTY_STDSTR, NULL, L"Enable Enhancement");
-		if (g_Settings->LoadBool(Setting_Enhancement))
-		{
-			Item.SetItemTicked(true);
-		}
-		DebugMenu.push_back(Item);
-		DebugMenu.push_back(MENU_ITEM(SPLITER));
+        Item.Reset(ID_DEBUG_ENANCEMENT, EMPTY_STRING, EMPTY_STDSTR, NULL, L"Enable Enhancement");
+        if (g_Settings->LoadBool(Setting_Enhancement))
+        {
+            Item.SetItemTicked(true);
+        }
+        DebugMenu.push_back(Item);
+        DebugMenu.push_back(MENU_ITEM(SPLITER));
         Item.Reset(ID_DEBUG_SHOW_TLB_MISSES, EMPTY_STRING, EMPTY_STDSTR, NULL, L"Show TLB Misses");
         if (g_Settings->LoadBool(Debugger_ShowTLBMisses))
         {

--- a/Source/Project64/UserInterface/MainMenu.cpp
+++ b/Source/Project64/UserInterface/MainMenu.cpp
@@ -126,20 +126,16 @@ void CMainMenu::OnOpenRom(HWND hWnd)
         return;
     }
     // Open Disk
-    if (!g_BaseSystem->RunDiskImage(File.c_str(), false))
-    {
-        return;
-    }
-    stdstr IPLROM = g_Settings->LoadStringVal(File_DiskIPLPath);
-    if ((IPLROM.length() <= 0) || (!g_BaseSystem->RunFileImage(IPLROM.c_str())))
-    {
-        const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-        CPath FileName;
-        if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-        {
-            g_BaseSystem->RunFileImage(FileName);
-        }
-    }
+	if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(File.c_str()))
+	{
+		CPath FileNameIPL;
+		const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+		if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+		{
+			g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
+			g_BaseSystem->RunDiskImage(File.c_str());
+		}
+	}
 }
 
 void CMainMenu::OnRomInfo(HWND hWnd)
@@ -554,17 +550,14 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
 					g_BaseSystem->RunFileImage(FileName.c_str());
 				else
 				{
-					if (g_BaseSystem->RunDiskImage(FileName.c_str(), false))
+					if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(FileName.c_str()))
 					{
-						stdstr IPLROM = g_Settings->LoadStringVal(File_DiskIPLPath);
-						if ((IPLROM.length() <= 0) || (!g_BaseSystem->RunFileImage(IPLROM.c_str())))
+						CPath FileNameIPL;
+						const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+						if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
 						{
-							const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-							CPath FileNameIPL;
-							if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-							{
-								g_BaseSystem->RunFileImage(FileNameIPL);
-							}
+							g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
+							g_BaseSystem->RunDiskImage(FileName.c_str());
 						}
 					}
 				}

--- a/Source/Project64/UserInterface/MainMenu.cpp
+++ b/Source/Project64/UserInterface/MainMenu.cpp
@@ -128,6 +128,7 @@ void CMainMenu::OnOpenRom(HWND hWnd)
     // Open Disk
     if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(File.c_str()))
     {
+        if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists()) { g_Notify->DisplayError(MSG_IPL_REQUIRED); }
         CPath FileNameIPL;
         const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
         if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
@@ -552,6 +553,7 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
                 {
                     if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(FileName.c_str()))
                     {
+                        if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists()) { g_Notify->DisplayError(MSG_IPL_REQUIRED); }
                         CPath FileNameIPL;
                         const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
                         if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))

--- a/Source/Project64/UserInterface/MainWindow.cpp
+++ b/Source/Project64/UserInterface/MainWindow.cpp
@@ -982,43 +982,43 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
 
             switch (LOWORD(wParam)) {
             case ID_POPUPMENU_PLAYGAME: 
-				{
-					if (CPath(_this->CurrentedSelectedRom()).GetExtension() != "ndd")
-					{
-						g_BaseSystem->RunFileImage(_this->CurrentedSelectedRom());
-					}
-					else
-					{
-						if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(_this->CurrentedSelectedRom()))
-						{
-							CPath FileName;
-							const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-							if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-							{
-								g_Settings->SaveString(File_DiskIPLPath, (const char *)FileName);
-								g_BaseSystem->RunDiskImage(_this->CurrentedSelectedRom());
-							}
-						}
-					}
-					break;
-				}
+                {
+                    if (CPath(_this->CurrentedSelectedRom()).GetExtension() != "ndd")
+                    {
+                        g_BaseSystem->RunFileImage(_this->CurrentedSelectedRom());
+                    }
+                    else
+                    {
+                        if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(_this->CurrentedSelectedRom()))
+                        {
+                            CPath FileName;
+                            const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+                            if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+                            {
+                                g_Settings->SaveString(File_DiskIPLPath, (const char *)FileName);
+                                g_BaseSystem->RunDiskImage(_this->CurrentedSelectedRom());
+                            }
+                        }
+                    }
+                    break;
+                }
             case ID_POPUPMENU_PLAYGAMEWITHDISK:
                 {
-					CPath FileName;
-					const char * Filter = "N64DD Disk Image (*.ndd)\0*.ndd\0All files (*.*)\0*.*\0";
-					if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-					{
-						if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskComboImage(_this->CurrentedSelectedRom(), FileName))
-						{
-							CPath FileNameIPL;
-							const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-							if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-							{
-								g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
-								g_BaseSystem->RunDiskComboImage(_this->CurrentedSelectedRom(), FileName);
-							}
-						}
-					}
+                    CPath FileName;
+                    const char * Filter = "N64DD Disk Image (*.ndd)\0*.ndd\0All files (*.*)\0*.*\0";
+                    if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+                    {
+                        if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskComboImage(_this->CurrentedSelectedRom(), FileName))
+                        {
+                            CPath FileNameIPL;
+                            const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+                            if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+                            {
+                                g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
+                                g_BaseSystem->RunDiskComboImage(_this->CurrentedSelectedRom(), FileName);
+                            }
+                        }
+                    }
                 }
                 break;
             case ID_POPUPMENU_ROMDIRECTORY:   _this->SelectRomDir(); break;
@@ -1031,78 +1031,78 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
                 break;
             case ID_POPUPMENU_EDITSETTINGS:
             case ID_POPUPMENU_EDITCHEATS:
-			case ID_POPUPMENU_CHOOSEENHANCEMENT:
+            case ID_POPUPMENU_CHOOSEENHANCEMENT:
                 {
-					if (CPath(_this->CurrentedSelectedRom()).GetExtension() != "ndd")
-					{
-						CN64Rom Rom;
-						Rom.LoadN64Image(_this->CurrentedSelectedRom(), true);
-						Rom.SaveRomSettingID(true);
+                    if (CPath(_this->CurrentedSelectedRom()).GetExtension() != "ndd")
+                    {
+                        CN64Rom Rom;
+                        Rom.LoadN64Image(_this->CurrentedSelectedRom(), true);
+                        Rom.SaveRomSettingID(true);
 
-						if (LOWORD(wParam) == ID_POPUPMENU_EDITSETTINGS)
-						{
-							CSettingConfig SettingConfig(true);
-							SettingConfig.Display(hWnd);
-						}
-						else if (LOWORD(wParam) == ID_POPUPMENU_CHOOSEENHANCEMENT)
-						{
-							CEnhancementConfig().Display(hWnd);
-						}
-						else if (LOWORD(wParam) == ID_POPUPMENU_EDITCHEATS)
-						{
-							CCheatsUI * cheatUI = new CCheatsUI;
-							g_cheatUI = cheatUI;
-							cheatUI->SelectCheats(hWnd, true);
-							if (g_cheatUI == cheatUI)
-							{
-								g_cheatUI = NULL;
-							}
-						}
+                        if (LOWORD(wParam) == ID_POPUPMENU_EDITSETTINGS)
+                        {
+                            CSettingConfig SettingConfig(true);
+                            SettingConfig.Display(hWnd);
+                        }
+                        else if (LOWORD(wParam) == ID_POPUPMENU_CHOOSEENHANCEMENT)
+                        {
+                            CEnhancementConfig().Display(hWnd);
+                        }
+                        else if (LOWORD(wParam) == ID_POPUPMENU_EDITCHEATS)
+                        {
+                            CCheatsUI * cheatUI = new CCheatsUI;
+                            g_cheatUI = cheatUI;
+                            cheatUI->SelectCheats(hWnd, true);
+                            if (g_cheatUI == cheatUI)
+                            {
+                                g_cheatUI = NULL;
+                            }
+                        }
 
-						if (g_Rom)
-						{
-							g_Rom->SaveRomSettingID(false);
-						}
-						else
-						{
-							Rom.ClearRomSettingID();
-						}
-					}
-					else
-					{
-						CN64Disk Disk;
-						Disk.LoadDiskImage(_this->CurrentedSelectedRom());
-						Disk.SaveDiskSettingID(true);
+                        if (g_Rom)
+                        {
+                            g_Rom->SaveRomSettingID(false);
+                        }
+                        else
+                        {
+                            Rom.ClearRomSettingID();
+                        }
+                    }
+                    else
+                    {
+                        CN64Disk Disk;
+                        Disk.LoadDiskImage(_this->CurrentedSelectedRom());
+                        Disk.SaveDiskSettingID(true);
 
-						if (LOWORD(wParam) == ID_POPUPMENU_EDITSETTINGS)
-						{
-							CSettingConfig SettingConfig(true);
-							SettingConfig.Display(hWnd);
-						}
-						else if (LOWORD(wParam) == ID_POPUPMENU_CHOOSEENHANCEMENT)
-						{
-							CEnhancementConfig().Display(hWnd);
-						}
-						else if (LOWORD(wParam) == ID_POPUPMENU_EDITCHEATS)
-						{
-							CCheatsUI * cheatUI = new CCheatsUI;
-							g_cheatUI = cheatUI;
-							cheatUI->SelectCheats(hWnd, true);
-							if (g_cheatUI == cheatUI)
-							{
-								g_cheatUI = NULL;
-							}
-						}
+                        if (LOWORD(wParam) == ID_POPUPMENU_EDITSETTINGS)
+                        {
+                            CSettingConfig SettingConfig(true);
+                            SettingConfig.Display(hWnd);
+                        }
+                        else if (LOWORD(wParam) == ID_POPUPMENU_CHOOSEENHANCEMENT)
+                        {
+                            CEnhancementConfig().Display(hWnd);
+                        }
+                        else if (LOWORD(wParam) == ID_POPUPMENU_EDITCHEATS)
+                        {
+                            CCheatsUI * cheatUI = new CCheatsUI;
+                            g_cheatUI = cheatUI;
+                            cheatUI->SelectCheats(hWnd, true);
+                            if (g_cheatUI == cheatUI)
+                            {
+                                g_cheatUI = NULL;
+                            }
+                        }
 
-						if (g_Disk)
-						{
-							g_Disk->SaveDiskSettingID(false);
-						}
-						else
-						{
-							Disk.ClearDiskSettingID();
-						}
-					}
+                        if (g_Disk)
+                        {
+                            g_Disk->SaveDiskSettingID(false);
+                        }
+                        else
+                        {
+                            Disk.ClearDiskSettingID();
+                        }
+                    }
                 }
                 break;
             default:
@@ -1175,16 +1175,16 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
             else
             {
                 // Open Disk
-				if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(filename))
-				{
-					CPath FileName;
-					const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-					if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-					{
-						g_Settings->SaveString(File_DiskIPLPath, (const char *)FileName);
-						g_BaseSystem->RunDiskImage(filename);
-					}
-				}
+                if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(filename))
+                {
+                    CPath FileName;
+                    const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+                    if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+                    {
+                        g_Settings->SaveString(File_DiskIPLPath, (const char *)FileName);
+                        g_BaseSystem->RunDiskImage(filename);
+                    }
+                }
             }
         }
         break;

--- a/Source/Project64/UserInterface/MainWindow.cpp
+++ b/Source/Project64/UserInterface/MainWindow.cpp
@@ -991,6 +991,7 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
                     {
                         if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(_this->CurrentedSelectedRom()))
                         {
+                            if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists()) { g_Notify->DisplayError(MSG_IPL_REQUIRED); }
                             CPath FileName;
                             const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
                             if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
@@ -1010,6 +1011,7 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
                     {
                         if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskComboImage(_this->CurrentedSelectedRom(), FileName))
                         {
+                            if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists()) { g_Notify->DisplayError(MSG_IPL_REQUIRED); }
                             CPath FileNameIPL;
                             const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
                             if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
@@ -1177,6 +1179,7 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
                 // Open Disk
                 if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(filename))
                 {
+                    if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists()) { g_Notify->DisplayError(MSG_IPL_REQUIRED); }
                     CPath FileName;
                     const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
                     if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))

--- a/Source/Project64/UserInterface/MainWindow.cpp
+++ b/Source/Project64/UserInterface/MainWindow.cpp
@@ -989,17 +989,14 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
 					}
 					else
 					{
-						if (g_BaseSystem->RunDiskImage(_this->CurrentedSelectedRom(), false))
+						if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(_this->CurrentedSelectedRom()))
 						{
-							stdstr IPLROM = g_Settings->LoadStringVal(File_DiskIPLPath);
-							if ((IPLROM.length() <= 0) || (!g_BaseSystem->RunFileImage(IPLROM.c_str())))
+							CPath FileName;
+							const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+							if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
 							{
-								CPath FileName;
-								const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-								if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-								{
-									g_BaseSystem->RunFileImage(FileName);
-								}
+								g_Settings->SaveString(File_DiskIPLPath, (const char *)FileName);
+								g_BaseSystem->RunDiskImage(_this->CurrentedSelectedRom());
 							}
 						}
 					}
@@ -1007,38 +1004,21 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
 				}
             case ID_POPUPMENU_PLAYGAMEWITHDISK:
                 {
-                    stdstr IPLROM = g_Settings->LoadStringVal(File_DiskIPLPath);
-                    if ((IPLROM.length() <= 0) || (!g_BaseSystem->RunFileImageIPL(IPLROM.c_str())))
-                    {
-                        const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-                        CPath FileName;
-                        if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-                        {
-                            g_BaseSystem->RunFileImageIPL(FileName);
-                            // Open Disk
-                            const char * N64DDFilter = "N64DD Disk Image (*.ndd)\0*.ndd\0All files (*.*)\0*.*\0";
-                            if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), N64DDFilter, true))
-                            {
-                                if (g_BaseSystem->RunDiskImage(FileName, true))
-                                {
-                                    g_BaseSystem->RunFileImage(_this->CurrentedSelectedRom());
-                                }
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // Open Disk
-                        CPath FileName;
-                        const char * Filter = "N64DD Disk Image (*.ndd)\0*.ndd\0All files (*.*)\0*.*\0";
-                        if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-                        {
-                            if (g_BaseSystem->RunDiskImage(FileName, true))
-                            {
-                                g_BaseSystem->RunFileImage(_this->CurrentedSelectedRom());
-                            }
-                        }
-                    }
+					CPath FileName;
+					const char * Filter = "N64DD Disk Image (*.ndd)\0*.ndd\0All files (*.*)\0*.*\0";
+					if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+					{
+						if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskComboImage(_this->CurrentedSelectedRom(), FileName))
+						{
+							CPath FileNameIPL;
+							const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+							if (FileNameIPL.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+							{
+								g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
+								g_BaseSystem->RunDiskComboImage(_this->CurrentedSelectedRom(), FileName);
+							}
+						}
+					}
                 }
                 break;
             case ID_POPUPMENU_ROMDIRECTORY:   _this->SelectRomDir(); break;
@@ -1195,19 +1175,16 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
             else
             {
                 // Open Disk
-                if (CN64System::RunDiskImage(filename, false))
-                {
-                    stdstr IPLROM = g_Settings->LoadStringVal(File_DiskIPLPath);
-                    if ((IPLROM.length() <= 0) || (!CN64System::RunFileImage(IPLROM.c_str())))
-                    {
-                        CPath FileName;
-                        const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-                        if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-                        {                            
-                            CN64System::RunFileImage(FileName);
-                        }
-                    }
-                }
+				if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(filename))
+				{
+					CPath FileName;
+					const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+					if (FileName.SelectFile(hWnd, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+					{
+						g_Settings->SaveString(File_DiskIPLPath, (const char *)FileName);
+						g_BaseSystem->RunDiskImage(filename);
+					}
+				}
             }
         }
         break;

--- a/Source/Project64/UserInterface/RomBrowserClass.cpp
+++ b/Source/Project64/UserInterface/RomBrowserClass.cpp
@@ -807,7 +807,24 @@ void CRomBrowser::RomList_OpenRom(uint32_t /*pnmh*/)
     delete g_DDRom;
     g_DDRom = NULL;
 
-    CN64System::RunFileImage(pRomInfo->szFullFileName);
+	if (CPath(pRomInfo->szFullFileName).GetExtension() != "ndd")
+		CN64System::RunFileImage(pRomInfo->szFullFileName);
+	else
+	{
+		if (CN64System::RunDiskImage(pRomInfo->szFullFileName, false))
+		{
+			stdstr IPLROM = g_Settings->LoadStringVal(File_DiskIPLPath);
+			if ((IPLROM.length() <= 0) || (!CN64System::RunFileImage(IPLROM.c_str())))
+			{
+				CPath FileName;
+				const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+				if (FileName.SelectFile(m_MainWindow, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+				{
+					CN64System::RunFileImage(FileName);
+				}
+			}
+		}
+	}
 }
 
 void CRomBrowser::RomList_PopupMenu(uint32_t /*pnmh*/)

--- a/Source/Project64/UserInterface/RomBrowserClass.cpp
+++ b/Source/Project64/UserInterface/RomBrowserClass.cpp
@@ -811,17 +811,14 @@ void CRomBrowser::RomList_OpenRom(uint32_t /*pnmh*/)
 		CN64System::RunFileImage(pRomInfo->szFullFileName);
 	else
 	{
-		if (CN64System::RunDiskImage(pRomInfo->szFullFileName, false))
+		if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(pRomInfo->szFullFileName))
 		{
-			stdstr IPLROM = g_Settings->LoadStringVal(File_DiskIPLPath);
-			if ((IPLROM.length() <= 0) || (!CN64System::RunFileImage(IPLROM.c_str())))
+			CPath FileName;
+			const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+			if (FileName.SelectFile(m_MainWindow, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
 			{
-				CPath FileName;
-				const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-				if (FileName.SelectFile(m_MainWindow, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-				{
-					CN64System::RunFileImage(FileName);
-				}
+				g_Settings->SaveString(File_DiskIPLPath, (const char *)FileName);
+				g_BaseSystem->RunDiskImage(pRomInfo->szFullFileName);
 			}
 		}
 	}
@@ -887,6 +884,7 @@ void CRomBrowser::RomList_PopupMenu(uint32_t /*pnmh*/)
 		if (inBasicMode) { DeleteMenu(hPopupMenu, 9, MF_BYPOSITION); }
         if (inBasicMode && !CheatsRemembered) { DeleteMenu(hPopupMenu, 8, MF_BYPOSITION); }
         DeleteMenu(hPopupMenu, 7, MF_BYPOSITION);
+		if (CPath(m_SelectedRom).GetExtension() == "ndd") { DeleteMenu(hPopupMenu, 1, MF_BYPOSITION); }
         if (!inBasicMode && g_Plugins && g_Plugins->Gfx() && g_Plugins->Gfx()->GetRomBrowserMenu != NULL)
         {
             HMENU GfxMenu = (HMENU)g_Plugins->Gfx()->GetRomBrowserMenu();

--- a/Source/Project64/UserInterface/RomBrowserClass.cpp
+++ b/Source/Project64/UserInterface/RomBrowserClass.cpp
@@ -813,6 +813,7 @@ void CRomBrowser::RomList_OpenRom(uint32_t /*pnmh*/)
     {
         if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(pRomInfo->szFullFileName))
         {
+            if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists()) { g_Notify->DisplayError(MSG_IPL_REQUIRED); }
             CPath FileName;
             const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
             if (FileName.SelectFile(m_MainWindow, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))

--- a/Source/Project64/UserInterface/RomBrowserClass.cpp
+++ b/Source/Project64/UserInterface/RomBrowserClass.cpp
@@ -807,21 +807,21 @@ void CRomBrowser::RomList_OpenRom(uint32_t /*pnmh*/)
     delete g_DDRom;
     g_DDRom = NULL;
 
-	if (CPath(pRomInfo->szFullFileName).GetExtension() != "ndd")
-		CN64System::RunFileImage(pRomInfo->szFullFileName);
-	else
-	{
-		if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(pRomInfo->szFullFileName))
-		{
-			CPath FileName;
-			const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-			if (FileName.SelectFile(m_MainWindow, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-			{
-				g_Settings->SaveString(File_DiskIPLPath, (const char *)FileName);
-				g_BaseSystem->RunDiskImage(pRomInfo->szFullFileName);
-			}
-		}
-	}
+    if (CPath(pRomInfo->szFullFileName).GetExtension() != "ndd")
+        CN64System::RunFileImage(pRomInfo->szFullFileName);
+    else
+    {
+        if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(pRomInfo->szFullFileName))
+        {
+            CPath FileName;
+            const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+            if (FileName.SelectFile(m_MainWindow, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+            {
+                g_Settings->SaveString(File_DiskIPLPath, (const char *)FileName);
+                g_BaseSystem->RunDiskImage(pRomInfo->szFullFileName);
+            }
+        }
+    }
 }
 
 void CRomBrowser::RomList_PopupMenu(uint32_t /*pnmh*/)
@@ -857,14 +857,14 @@ void CRomBrowser::RomList_PopupMenu(uint32_t /*pnmh*/)
     MenuSetText(hPopupMenu, 6, wGS(POPUP_INFO).c_str(), NULL);
     MenuSetText(hPopupMenu, 7, wGS(POPUP_GFX_PLUGIN).c_str(), NULL);
     MenuSetText(hPopupMenu, 9, wGS(POPUP_SETTINGS).c_str(), NULL);
-	MenuSetText(hPopupMenu, 10, wGS(POPUP_CHEATS).c_str(), NULL);
-	MenuSetText(hPopupMenu, 11, wGS(POPUP_ENHANCEMENTS).c_str(), NULL);
+    MenuSetText(hPopupMenu, 10, wGS(POPUP_CHEATS).c_str(), NULL);
+    MenuSetText(hPopupMenu, 11, wGS(POPUP_ENHANCEMENTS).c_str(), NULL);
 
     if (m_SelectedRom.size() == 0)
     {
-		DeleteMenu(hPopupMenu, 11, MF_BYPOSITION);
-		DeleteMenu(hPopupMenu, 10, MF_BYPOSITION);
-		DeleteMenu(hPopupMenu, 9, MF_BYPOSITION);
+        DeleteMenu(hPopupMenu, 11, MF_BYPOSITION);
+        DeleteMenu(hPopupMenu, 10, MF_BYPOSITION);
+        DeleteMenu(hPopupMenu, 9, MF_BYPOSITION);
         DeleteMenu(hPopupMenu, 8, MF_BYPOSITION);
         DeleteMenu(hPopupMenu, 7, MF_BYPOSITION);
         DeleteMenu(hPopupMenu, 6, MF_BYPOSITION);
@@ -876,15 +876,15 @@ void CRomBrowser::RomList_PopupMenu(uint32_t /*pnmh*/)
     else
     {
         bool inBasicMode = g_Settings->LoadBool(UserInterface_BasicMode);
-		bool CheatsRemembered = g_Settings->LoadBool(Setting_RememberCheats);
-		bool Enhancement = !inBasicMode && g_Settings->LoadBool(Setting_Enhancement);
+        bool CheatsRemembered = g_Settings->LoadBool(Setting_RememberCheats);
+        bool Enhancement = !inBasicMode && g_Settings->LoadBool(Setting_Enhancement);
 
-		if (!Enhancement) { DeleteMenu(hPopupMenu, 11, MF_BYPOSITION); }
-		if (!CheatsRemembered) { DeleteMenu(hPopupMenu, 10, MF_BYPOSITION); }
-		if (inBasicMode) { DeleteMenu(hPopupMenu, 9, MF_BYPOSITION); }
+        if (!Enhancement) { DeleteMenu(hPopupMenu, 11, MF_BYPOSITION); }
+        if (!CheatsRemembered) { DeleteMenu(hPopupMenu, 10, MF_BYPOSITION); }
+        if (inBasicMode) { DeleteMenu(hPopupMenu, 9, MF_BYPOSITION); }
         if (inBasicMode && !CheatsRemembered) { DeleteMenu(hPopupMenu, 8, MF_BYPOSITION); }
         DeleteMenu(hPopupMenu, 7, MF_BYPOSITION);
-		if (CPath(m_SelectedRom).GetExtension() == "ndd") { DeleteMenu(hPopupMenu, 1, MF_BYPOSITION); }
+        if (CPath(m_SelectedRom).GetExtension() == "ndd") { DeleteMenu(hPopupMenu, 1, MF_BYPOSITION); }
         if (!inBasicMode && g_Plugins && g_Plugins->Gfx() && g_Plugins->Gfx()->GetRomBrowserMenu != NULL)
         {
             HMENU GfxMenu = (HMENU)g_Plugins->Gfx()->GetRomBrowserMenu();

--- a/Source/Project64/UserInterface/RomInformationClass.cpp
+++ b/Source/Project64/UserInterface/RomInformationClass.cpp
@@ -20,26 +20,26 @@ m_pRomInfo(NULL),
 m_pDiskInfo(NULL)
 {
     if (m_FileName.length() == 0)  { return; }
-	if (CPath(m_FileName).GetExtension() != "ndd")
-	{
-		m_pRomInfo = new CN64Rom;
-		if (!m_pRomInfo->LoadN64Image(m_FileName.c_str()))
-		{
-			delete m_pRomInfo;
-			m_pRomInfo = NULL;
-			return;
-		}
-	}
-	else
-	{
-		m_pDiskInfo = new CN64Disk;
-		if (!m_pDiskInfo->LoadDiskImage(m_FileName.c_str()))
-		{
-			delete m_pDiskInfo;
-			m_pDiskInfo = NULL;
-			return;
-		}
-	}
+    if (CPath(m_FileName).GetExtension() != "ndd")
+    {
+        m_pRomInfo = new CN64Rom;
+        if (!m_pRomInfo->LoadN64Image(m_FileName.c_str()))
+        {
+            delete m_pRomInfo;
+            m_pRomInfo = NULL;
+            return;
+        }
+    }
+    else
+    {
+        m_pDiskInfo = new CN64Disk;
+        if (!m_pDiskInfo->LoadDiskImage(m_FileName.c_str()))
+        {
+            delete m_pDiskInfo;
+            m_pDiskInfo = NULL;
+            return;
+        }
+    }
 }
 
 RomInformation::RomInformation(CN64Rom * RomInfo) :
@@ -62,8 +62,8 @@ RomInformation::~RomInformation()
 {
     if (m_DeleteRomInfo)
         delete m_pRomInfo;
-	if (m_DeleteDiskInfo)
-		delete m_pDiskInfo;
+    if (m_DeleteDiskInfo)
+        delete m_pDiskInfo;
 }
 
 #include <windows.h>
@@ -80,145 +80,145 @@ DWORD CALLBACK RomInfoProc(HWND hDlg, DWORD uMsg, DWORD wParam, DWORD lParam)
     {
     case WM_INITDIALOG:
     {
-		//record class for future usage
-		SetProp(hDlg, "this", (RomInformation *)lParam);
-		RomInformation * _this = (RomInformation *)lParam;
+        //record class for future usage
+        SetProp(hDlg, "this", (RomInformation *)lParam);
+        RomInformation * _this = (RomInformation *)lParam;
 
-		if (_this->m_pDiskInfo == NULL)
-		{
-			SetWindowTextW(hDlg, wGS(INFO_TITLE).c_str());
+        if (_this->m_pDiskInfo == NULL)
+        {
+            SetWindowTextW(hDlg, wGS(INFO_TITLE).c_str());
 
-			SetDlgItemTextW(hDlg, IDC_ROM_NAME, wGS(INFO_ROM_NAME_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_FILE_NAME, wGS(INFO_FILE_NAME_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_LOCATION, wGS(INFO_LOCATION_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_ROM_MD5, wGS(INFO_MD5_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_ROM_SIZE, wGS(INFO_SIZE_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_CART_ID, wGS(INFO_CART_ID_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_MANUFACTURER, wGS(INFO_MANUFACTURER_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_COUNTRY, wGS(INFO_COUNTRY_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_CRC1, wGS(INFO_CRC1_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_CRC2, wGS(INFO_CRC2_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_CIC_CHIP, wGS(INFO_CIC_CHIP_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_CLOSE_BUTTON, wGS(BOTTOM_CLOSE).c_str());
+            SetDlgItemTextW(hDlg, IDC_ROM_NAME, wGS(INFO_ROM_NAME_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_FILE_NAME, wGS(INFO_FILE_NAME_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_LOCATION, wGS(INFO_LOCATION_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_ROM_MD5, wGS(INFO_MD5_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_ROM_SIZE, wGS(INFO_SIZE_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_CART_ID, wGS(INFO_CART_ID_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_MANUFACTURER, wGS(INFO_MANUFACTURER_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_COUNTRY, wGS(INFO_COUNTRY_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_CRC1, wGS(INFO_CRC1_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_CRC2, wGS(INFO_CRC2_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_CIC_CHIP, wGS(INFO_CIC_CHIP_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_CLOSE_BUTTON, wGS(BOTTOM_CLOSE).c_str());
 
-			SetDlgItemTextW(hDlg, IDC_INFO_ROMNAME, _this->m_pRomInfo->GetRomName().ToUTF16(stdstr::CODEPAGE_932).c_str());
+            SetDlgItemTextW(hDlg, IDC_INFO_ROMNAME, _this->m_pRomInfo->GetRomName().ToUTF16(stdstr::CODEPAGE_932).c_str());
 
-			SetDlgItemTextW(hDlg, IDC_INFO_FILENAME, stdstr(CPath(_this->m_pRomInfo->GetFileName()).GetNameExtension()).ToUTF16(CP_ACP).c_str());
-			SetDlgItemTextW(hDlg, IDC_INFO_LOCATION, stdstr(CPath(_this->m_pRomInfo->GetFileName()).GetDriveDirectory()).ToUTF16(CP_ACP).c_str());
+            SetDlgItemTextW(hDlg, IDC_INFO_FILENAME, stdstr(CPath(_this->m_pRomInfo->GetFileName()).GetNameExtension()).ToUTF16(CP_ACP).c_str());
+            SetDlgItemTextW(hDlg, IDC_INFO_LOCATION, stdstr(CPath(_this->m_pRomInfo->GetFileName()).GetDriveDirectory()).ToUTF16(CP_ACP).c_str());
 
-			SetDlgItemTextW(hDlg, IDC_INFO_MD5, _this->m_pRomInfo->GetRomMD5().ToUTF16().c_str());
-			SetDlgItemTextW(hDlg, IDC_INFO_ROMSIZE, stdstr_f("%.1f MBit", (float)_this->m_pRomInfo->GetRomSize() / 0x20000).ToUTF16().c_str());
+            SetDlgItemTextW(hDlg, IDC_INFO_MD5, _this->m_pRomInfo->GetRomMD5().ToUTF16().c_str());
+            SetDlgItemTextW(hDlg, IDC_INFO_ROMSIZE, stdstr_f("%.1f MBit", (float)_this->m_pRomInfo->GetRomSize() / 0x20000).ToUTF16().c_str());
 
-			BYTE * RomHeader = _this->m_pRomInfo->GetRomAddress();
-			SetDlgItemTextW(hDlg, IDC_INFO_CARTID, stdstr_f("%c%c", RomHeader[0x3F], RomHeader[0x3E]).ToUTF16().c_str());
+            BYTE * RomHeader = _this->m_pRomInfo->GetRomAddress();
+            SetDlgItemTextW(hDlg, IDC_INFO_CARTID, stdstr_f("%c%c", RomHeader[0x3F], RomHeader[0x3E]).ToUTF16().c_str());
 
-			switch (RomHeader[0x38])
-			{
-			case 'N': SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"Nintendo"); break;
-			case 0:   SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"None"); break;
-			default:  SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"(Unknown)"); break;
-			}
+            switch (RomHeader[0x38])
+            {
+            case 'N': SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"Nintendo"); break;
+            case 0:   SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"None"); break;
+            default:  SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"(Unknown)"); break;
+            }
 
-			switch (RomHeader[0x3D])
-			{
-			case NTSC_BETA: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Beta"); break;
-			case X_NTSC:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"NTSC"); break;
-			case Germany:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Germany"); break;
-			case USA:       SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"America"); break;
-			case french:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"France"); break;
-			case Italian:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Italy"); break;
-			case Japan:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Japan"); break;
-			case Europe:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Europe"); break;
-			case Spanish:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Spain"); break;
-			case Australia: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Australia"); break;
-			case X_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
-			case Y_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
-			case 0: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"None"); break;
-			default:
-				SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, stdstr_f(" Unknown %c (%02X)", RomHeader[0x3D], RomHeader[0x3D]).ToUTF16().c_str());
-			}
-			SetDlgItemTextW(hDlg, IDC_INFO_CRC1, stdstr_f("0x%08X", *(uint32_t *)(RomHeader + 0x10)).ToUTF16().c_str());
-			SetDlgItemTextW(hDlg, IDC_INFO_CRC2, stdstr_f("0x%08X", *(DWORD *)(RomHeader + 0x14)).ToUTF16().c_str());
+            switch (RomHeader[0x3D])
+            {
+            case NTSC_BETA: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Beta"); break;
+            case X_NTSC:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"NTSC"); break;
+            case Germany:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Germany"); break;
+            case USA:       SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"America"); break;
+            case french:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"France"); break;
+            case Italian:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Italy"); break;
+            case Japan:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Japan"); break;
+            case Europe:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Europe"); break;
+            case Spanish:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Spain"); break;
+            case Australia: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Australia"); break;
+            case X_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
+            case Y_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
+            case 0: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"None"); break;
+            default:
+                SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, stdstr_f(" Unknown %c (%02X)", RomHeader[0x3D], RomHeader[0x3D]).ToUTF16().c_str());
+            }
+            SetDlgItemTextW(hDlg, IDC_INFO_CRC1, stdstr_f("0x%08X", *(uint32_t *)(RomHeader + 0x10)).ToUTF16().c_str());
+            SetDlgItemTextW(hDlg, IDC_INFO_CRC2, stdstr_f("0x%08X", *(DWORD *)(RomHeader + 0x14)).ToUTF16().c_str());
 
-			std::wstring CicChip;
-			switch (_this->m_pRomInfo->CicChipID())
-			{
-			case CIC_UNKNOWN: CicChip = L"Unknown"; break;
-			case CIC_NUS_8303: CicChip = L"CIC-NUS-8303"; break;
-			case CIC_NUS_5167: CicChip = L"CIC-NUS-5167"; break;
-			case CIC_NUS_DDUS: CicChip = L"CIC-NUS-????"; break;
-			default: CicChip = stdstr_f("CIC-NUS-610%d", _this->m_pRomInfo->CicChipID()).ToUTF16(); break;
-			}
-			SetDlgItemTextW(hDlg, IDC_INFO_CIC, CicChip.c_str());
-		}
-		else
-		{
-			SetWindowTextW(hDlg, wGS(INFO_TITLE).c_str());
+            std::wstring CicChip;
+            switch (_this->m_pRomInfo->CicChipID())
+            {
+            case CIC_UNKNOWN: CicChip = L"Unknown"; break;
+            case CIC_NUS_8303: CicChip = L"CIC-NUS-8303"; break;
+            case CIC_NUS_5167: CicChip = L"CIC-NUS-5167"; break;
+            case CIC_NUS_DDUS: CicChip = L"CIC-NUS-????"; break;
+            default: CicChip = stdstr_f("CIC-NUS-610%d", _this->m_pRomInfo->CicChipID()).ToUTF16(); break;
+            }
+            SetDlgItemTextW(hDlg, IDC_INFO_CIC, CicChip.c_str());
+        }
+        else
+        {
+            SetWindowTextW(hDlg, wGS(INFO_TITLE).c_str());
 
-			SetDlgItemTextW(hDlg, IDC_ROM_NAME, wGS(INFO_ROM_NAME_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_FILE_NAME, wGS(INFO_FILE_NAME_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_LOCATION, wGS(INFO_LOCATION_TEXT).c_str());
-			//SetDlgItemTextW(hDlg, IDC_ROM_MD5, wGS(INFO_MD5_TEXT).c_str());
-			//SetDlgItemTextW(hDlg, IDC_ROM_SIZE, wGS(INFO_SIZE_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_CART_ID, wGS(INFO_CART_ID_TEXT).c_str());
-			//SetDlgItemTextW(hDlg, IDC_MANUFACTURER, wGS(INFO_MANUFACTURER_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_COUNTRY, wGS(INFO_COUNTRY_TEXT).c_str());
-			//SetDlgItemTextW(hDlg, IDC_CRC1, wGS(INFO_CRC1_TEXT).c_str());
-			//SetDlgItemTextW(hDlg, IDC_CRC2, wGS(INFO_CRC2_TEXT).c_str());
-			//SetDlgItemTextW(hDlg, IDC_CIC_CHIP, wGS(INFO_CIC_CHIP_TEXT).c_str());
-			SetDlgItemTextW(hDlg, IDC_CLOSE_BUTTON, wGS(BOTTOM_CLOSE).c_str());
+            SetDlgItemTextW(hDlg, IDC_ROM_NAME, wGS(INFO_ROM_NAME_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_FILE_NAME, wGS(INFO_FILE_NAME_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_LOCATION, wGS(INFO_LOCATION_TEXT).c_str());
+            //SetDlgItemTextW(hDlg, IDC_ROM_MD5, wGS(INFO_MD5_TEXT).c_str());
+            //SetDlgItemTextW(hDlg, IDC_ROM_SIZE, wGS(INFO_SIZE_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_CART_ID, wGS(INFO_CART_ID_TEXT).c_str());
+            //SetDlgItemTextW(hDlg, IDC_MANUFACTURER, wGS(INFO_MANUFACTURER_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_COUNTRY, wGS(INFO_COUNTRY_TEXT).c_str());
+            //SetDlgItemTextW(hDlg, IDC_CRC1, wGS(INFO_CRC1_TEXT).c_str());
+            //SetDlgItemTextW(hDlg, IDC_CRC2, wGS(INFO_CRC2_TEXT).c_str());
+            //SetDlgItemTextW(hDlg, IDC_CIC_CHIP, wGS(INFO_CIC_CHIP_TEXT).c_str());
+            SetDlgItemTextW(hDlg, IDC_CLOSE_BUTTON, wGS(BOTTOM_CLOSE).c_str());
 
-			SetDlgItemTextW(hDlg, IDC_INFO_ROMNAME, _this->m_pDiskInfo->GetRomName().ToUTF16(stdstr::CODEPAGE_932).c_str());
+            SetDlgItemTextW(hDlg, IDC_INFO_ROMNAME, _this->m_pDiskInfo->GetRomName().ToUTF16(stdstr::CODEPAGE_932).c_str());
 
-			SetDlgItemTextW(hDlg, IDC_INFO_FILENAME, stdstr(CPath(_this->m_pDiskInfo->GetFileName()).GetNameExtension()).ToUTF16(CP_ACP).c_str());
-			SetDlgItemTextW(hDlg, IDC_INFO_LOCATION, stdstr(CPath(_this->m_pDiskInfo->GetFileName()).GetDriveDirectory()).ToUTF16(CP_ACP).c_str());
+            SetDlgItemTextW(hDlg, IDC_INFO_FILENAME, stdstr(CPath(_this->m_pDiskInfo->GetFileName()).GetNameExtension()).ToUTF16(CP_ACP).c_str());
+            SetDlgItemTextW(hDlg, IDC_INFO_LOCATION, stdstr(CPath(_this->m_pDiskInfo->GetFileName()).GetDriveDirectory()).ToUTF16(CP_ACP).c_str());
 
-			//SetDlgItemTextW(hDlg, IDC_INFO_MD5, _this->m_pRomInfo->GetRomMD5().ToUTF16().c_str());
-			//SetDlgItemTextW(hDlg, IDC_INFO_ROMSIZE, stdstr_f("%.1f MBit", (float)_this->m_pDiskInfo->GetRomSize() / 0x20000).ToUTF16().c_str());
+            //SetDlgItemTextW(hDlg, IDC_INFO_MD5, _this->m_pRomInfo->GetRomMD5().ToUTF16().c_str());
+            //SetDlgItemTextW(hDlg, IDC_INFO_ROMSIZE, stdstr_f("%.1f MBit", (float)_this->m_pDiskInfo->GetRomSize() / 0x20000).ToUTF16().c_str());
 
-			BYTE * DiskHeader = _this->m_pDiskInfo->GetDiskAddress() + 0x43670;
-			SetDlgItemTextW(hDlg, IDC_INFO_CARTID, stdstr_f("%c%c", DiskHeader[0x02], DiskHeader[0x01]).ToUTF16().c_str());
+            BYTE * DiskHeader = _this->m_pDiskInfo->GetDiskAddress() + 0x43670;
+            SetDlgItemTextW(hDlg, IDC_INFO_CARTID, stdstr_f("%c%c", DiskHeader[0x02], DiskHeader[0x01]).ToUTF16().c_str());
 
-			/*switch (DiskHeader[0x00])
-			{
-			case 'N': SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"Nintendo"); break;
-			case 0:   SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"None"); break;
-			default:  SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"(Unknown)"); break;
-			}*/
+            /*switch (DiskHeader[0x00])
+            {
+            case 'N': SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"Nintendo"); break;
+            case 0:   SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"None"); break;
+            default:  SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"(Unknown)"); break;
+            }*/
 
-			switch (DiskHeader[0x00])
-			{
-			case NTSC_BETA: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Beta"); break;
-			case X_NTSC:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"NTSC"); break;
-			case Germany:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Germany"); break;
-			case USA:       SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"America"); break;
-			case french:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"France"); break;
-			case Italian:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Italy"); break;
-			case Japan:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Japan"); break;
-			case Europe:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Europe"); break;
-			case Spanish:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Spain"); break;
-			case Australia: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Australia"); break;
-			case X_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
-			case Y_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
-			case 0: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"None"); break;
-			default:
-				SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, stdstr_f(" Unknown %c (%02X)", DiskHeader[0x03], DiskHeader[0x03]).ToUTF16().c_str());
-			}
-			SetDlgItemTextW(hDlg, IDC_INFO_CRC1, stdstr_f("0x%08X", *(uint32_t *)(_this->m_pDiskInfo->GetDiskAddress())).ToUTF16().c_str());
-			SetDlgItemTextW(hDlg, IDC_INFO_CRC2, stdstr_f("0x%08X", *(DWORD *)(DiskHeader)).ToUTF16().c_str());
-			/*
-			std::wstring CicChip;
-			switch (_this->m_pRomInfo->CicChipID())
-			{
-			case CIC_UNKNOWN: CicChip = L"Unknown"; break;
-			case CIC_NUS_8303: CicChip = L"CIC-NUS-8303"; break;
-			case CIC_NUS_5167: CicChip = L"CIC-NUS-5167"; break;
-			case CIC_NUS_DDUS: CicChip = L"CIC-NUS-????"; break;
-			default: CicChip = stdstr_f("CIC-NUS-610%d", _this->m_pRomInfo->CicChipID()).ToUTF16(); break;
-			}
-			SetDlgItemTextW(hDlg, IDC_INFO_CIC, CicChip.c_str());
-			*/
-		}
+            switch (DiskHeader[0x00])
+            {
+            case NTSC_BETA: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Beta"); break;
+            case X_NTSC:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"NTSC"); break;
+            case Germany:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Germany"); break;
+            case USA:       SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"America"); break;
+            case french:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"France"); break;
+            case Italian:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Italy"); break;
+            case Japan:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Japan"); break;
+            case Europe:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Europe"); break;
+            case Spanish:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Spain"); break;
+            case Australia: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Australia"); break;
+            case X_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
+            case Y_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
+            case 0: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"None"); break;
+            default:
+                SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, stdstr_f(" Unknown %c (%02X)", DiskHeader[0x03], DiskHeader[0x03]).ToUTF16().c_str());
+            }
+            SetDlgItemTextW(hDlg, IDC_INFO_CRC1, stdstr_f("0x%08X", *(uint32_t *)(_this->m_pDiskInfo->GetDiskAddress())).ToUTF16().c_str());
+            SetDlgItemTextW(hDlg, IDC_INFO_CRC2, stdstr_f("0x%08X", *(DWORD *)(DiskHeader)).ToUTF16().c_str());
+            /*
+            std::wstring CicChip;
+            switch (_this->m_pRomInfo->CicChipID())
+            {
+            case CIC_UNKNOWN: CicChip = L"Unknown"; break;
+            case CIC_NUS_8303: CicChip = L"CIC-NUS-8303"; break;
+            case CIC_NUS_5167: CicChip = L"CIC-NUS-5167"; break;
+            case CIC_NUS_DDUS: CicChip = L"CIC-NUS-????"; break;
+            default: CicChip = stdstr_f("CIC-NUS-610%d", _this->m_pRomInfo->CicChipID()).ToUTF16(); break;
+            }
+            SetDlgItemTextW(hDlg, IDC_INFO_CIC, CicChip.c_str());
+            */
+        }
     }
     break;
     case WM_COMMAND:

--- a/Source/Project64/UserInterface/RomInformationClass.cpp
+++ b/Source/Project64/UserInterface/RomInformationClass.cpp
@@ -10,26 +10,51 @@
 ****************************************************************************/
 #include "stdafx.h"
 #include "RomInformationClass.h"
+#include <Project64-core/N64System/N64DiskClass.h>
 
 RomInformation::RomInformation(const char * RomFile) :
 m_DeleteRomInfo(true),
+m_DeleteDiskInfo(true),
 m_FileName(RomFile ? RomFile : ""),
-m_pRomInfo(NULL)
+m_pRomInfo(NULL),
+m_pDiskInfo(NULL)
 {
     if (m_FileName.length() == 0)  { return; }
-    m_pRomInfo = new CN64Rom;
-    if (!m_pRomInfo->LoadN64Image(m_FileName.c_str()))
-    {
-        delete m_pRomInfo;
-        m_pRomInfo = NULL;
-        return;
-    }
+	if (CPath(m_FileName).GetExtension() != "ndd")
+	{
+		m_pRomInfo = new CN64Rom;
+		if (!m_pRomInfo->LoadN64Image(m_FileName.c_str()))
+		{
+			delete m_pRomInfo;
+			m_pRomInfo = NULL;
+			return;
+		}
+	}
+	else
+	{
+		m_pDiskInfo = new CN64Disk;
+		if (!m_pDiskInfo->LoadDiskImage(m_FileName.c_str()))
+		{
+			delete m_pDiskInfo;
+			m_pDiskInfo = NULL;
+			return;
+		}
+	}
 }
 
 RomInformation::RomInformation(CN64Rom * RomInfo) :
 m_DeleteRomInfo(false),
+m_DeleteDiskInfo(false),
 m_FileName(RomInfo ? RomInfo->GetFileName().c_str() : ""),
 m_pRomInfo(RomInfo)
+{
+}
+
+RomInformation::RomInformation(CN64Disk * DiskInfo) :
+m_DeleteRomInfo(false),
+m_DeleteDiskInfo(false),
+m_FileName(DiskInfo ? DiskInfo->GetFileName().c_str() : ""),
+m_pDiskInfo(DiskInfo)
 {
 }
 
@@ -37,6 +62,8 @@ RomInformation::~RomInformation()
 {
     if (m_DeleteRomInfo)
         delete m_pRomInfo;
+	if (m_DeleteDiskInfo)
+		delete m_pDiskInfo;
 }
 
 #include <windows.h>
@@ -53,74 +80,145 @@ DWORD CALLBACK RomInfoProc(HWND hDlg, DWORD uMsg, DWORD wParam, DWORD lParam)
     {
     case WM_INITDIALOG:
     {
-        //record class for future usage
-        SetProp(hDlg, "this", (RomInformation *)lParam);
-        RomInformation * _this = (RomInformation *)lParam;
+		//record class for future usage
+		SetProp(hDlg, "this", (RomInformation *)lParam);
+		RomInformation * _this = (RomInformation *)lParam;
 
-        SetWindowTextW(hDlg, wGS(INFO_TITLE).c_str());
+		if (_this->m_pDiskInfo == NULL)
+		{
+			SetWindowTextW(hDlg, wGS(INFO_TITLE).c_str());
 
-        SetDlgItemTextW(hDlg, IDC_ROM_NAME, wGS(INFO_ROM_NAME_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_FILE_NAME, wGS(INFO_FILE_NAME_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_LOCATION, wGS(INFO_LOCATION_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_ROM_MD5, wGS(INFO_MD5_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_ROM_SIZE, wGS(INFO_SIZE_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_CART_ID, wGS(INFO_CART_ID_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_MANUFACTURER, wGS(INFO_MANUFACTURER_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_COUNTRY, wGS(INFO_COUNTRY_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_CRC1, wGS(INFO_CRC1_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_CRC2, wGS(INFO_CRC2_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_CIC_CHIP, wGS(INFO_CIC_CHIP_TEXT).c_str());
-        SetDlgItemTextW(hDlg, IDC_CLOSE_BUTTON, wGS(BOTTOM_CLOSE).c_str());
+			SetDlgItemTextW(hDlg, IDC_ROM_NAME, wGS(INFO_ROM_NAME_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_FILE_NAME, wGS(INFO_FILE_NAME_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_LOCATION, wGS(INFO_LOCATION_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_ROM_MD5, wGS(INFO_MD5_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_ROM_SIZE, wGS(INFO_SIZE_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_CART_ID, wGS(INFO_CART_ID_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_MANUFACTURER, wGS(INFO_MANUFACTURER_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_COUNTRY, wGS(INFO_COUNTRY_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_CRC1, wGS(INFO_CRC1_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_CRC2, wGS(INFO_CRC2_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_CIC_CHIP, wGS(INFO_CIC_CHIP_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_CLOSE_BUTTON, wGS(BOTTOM_CLOSE).c_str());
 
-        SetDlgItemTextW(hDlg, IDC_INFO_ROMNAME, _this->m_pRomInfo->GetRomName().ToUTF16(stdstr::CODEPAGE_932).c_str());
+			SetDlgItemTextW(hDlg, IDC_INFO_ROMNAME, _this->m_pRomInfo->GetRomName().ToUTF16(stdstr::CODEPAGE_932).c_str());
 
-        SetDlgItemTextW(hDlg, IDC_INFO_FILENAME, stdstr(CPath(_this->m_pRomInfo->GetFileName()).GetNameExtension()).ToUTF16(CP_ACP).c_str());
-        SetDlgItemTextW(hDlg, IDC_INFO_LOCATION, stdstr(CPath(_this->m_pRomInfo->GetFileName()).GetDriveDirectory()).ToUTF16(CP_ACP).c_str());
+			SetDlgItemTextW(hDlg, IDC_INFO_FILENAME, stdstr(CPath(_this->m_pRomInfo->GetFileName()).GetNameExtension()).ToUTF16(CP_ACP).c_str());
+			SetDlgItemTextW(hDlg, IDC_INFO_LOCATION, stdstr(CPath(_this->m_pRomInfo->GetFileName()).GetDriveDirectory()).ToUTF16(CP_ACP).c_str());
 
-        SetDlgItemTextW(hDlg, IDC_INFO_MD5, _this->m_pRomInfo->GetRomMD5().ToUTF16().c_str());
-        SetDlgItemTextW(hDlg, IDC_INFO_ROMSIZE, stdstr_f("%.1f MBit", (float)_this->m_pRomInfo->GetRomSize() / 0x20000).ToUTF16().c_str());
+			SetDlgItemTextW(hDlg, IDC_INFO_MD5, _this->m_pRomInfo->GetRomMD5().ToUTF16().c_str());
+			SetDlgItemTextW(hDlg, IDC_INFO_ROMSIZE, stdstr_f("%.1f MBit", (float)_this->m_pRomInfo->GetRomSize() / 0x20000).ToUTF16().c_str());
 
-        BYTE * RomHeader = _this->m_pRomInfo->GetRomAddress();
-        SetDlgItemTextW(hDlg, IDC_INFO_CARTID, stdstr_f("%c%c", RomHeader[0x3F], RomHeader[0x3E]).ToUTF16().c_str());
+			BYTE * RomHeader = _this->m_pRomInfo->GetRomAddress();
+			SetDlgItemTextW(hDlg, IDC_INFO_CARTID, stdstr_f("%c%c", RomHeader[0x3F], RomHeader[0x3E]).ToUTF16().c_str());
 
-        switch (RomHeader[0x38])
-        {
-        case 'N': SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"Nintendo"); break;
-        case 0:   SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"None"); break;
-        default:  SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"(Unknown)"); break;
-        }
+			switch (RomHeader[0x38])
+			{
+			case 'N': SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"Nintendo"); break;
+			case 0:   SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"None"); break;
+			default:  SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"(Unknown)"); break;
+			}
 
-        switch (RomHeader[0x3D])
-        {
-        case NTSC_BETA: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Beta"); break;
-        case X_NTSC:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"NTSC"); break;
-        case Germany:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Germany"); break;
-        case USA:       SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"America"); break;
-        case french:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"France"); break;
-        case Italian:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Italy"); break;
-        case Japan:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Japan"); break;
-        case Europe:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Europe"); break;
-        case Spanish:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Spain"); break;
-        case Australia: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Australia"); break;
-        case X_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
-        case Y_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
-        case 0: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"None"); break;
-        default:
-            SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, stdstr_f(" Unknown %c (%02X)", RomHeader[0x3D], RomHeader[0x3D]).ToUTF16().c_str());
-        }
-        SetDlgItemTextW(hDlg, IDC_INFO_CRC1, stdstr_f("0x%08X", *(uint32_t *)(RomHeader + 0x10)).ToUTF16().c_str());
-        SetDlgItemTextW(hDlg, IDC_INFO_CRC2, stdstr_f("0x%08X", *(DWORD *)(RomHeader + 0x14)).ToUTF16().c_str());
+			switch (RomHeader[0x3D])
+			{
+			case NTSC_BETA: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Beta"); break;
+			case X_NTSC:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"NTSC"); break;
+			case Germany:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Germany"); break;
+			case USA:       SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"America"); break;
+			case french:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"France"); break;
+			case Italian:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Italy"); break;
+			case Japan:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Japan"); break;
+			case Europe:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Europe"); break;
+			case Spanish:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Spain"); break;
+			case Australia: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Australia"); break;
+			case X_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
+			case Y_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
+			case 0: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"None"); break;
+			default:
+				SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, stdstr_f(" Unknown %c (%02X)", RomHeader[0x3D], RomHeader[0x3D]).ToUTF16().c_str());
+			}
+			SetDlgItemTextW(hDlg, IDC_INFO_CRC1, stdstr_f("0x%08X", *(uint32_t *)(RomHeader + 0x10)).ToUTF16().c_str());
+			SetDlgItemTextW(hDlg, IDC_INFO_CRC2, stdstr_f("0x%08X", *(DWORD *)(RomHeader + 0x14)).ToUTF16().c_str());
 
-        std::wstring CicChip;
-        switch (_this->m_pRomInfo->CicChipID())
-        {
-        case CIC_UNKNOWN: CicChip = L"Unknown"; break;
-        case CIC_NUS_8303: CicChip = L"CIC-NUS-8303"; break;
-        case CIC_NUS_5167: CicChip = L"CIC-NUS-5167"; break;
-        case CIC_NUS_DDUS: CicChip = L"CIC-NUS-????"; break;
-        default: CicChip = stdstr_f("CIC-NUS-610%d", _this->m_pRomInfo->CicChipID()).ToUTF16(); break;
-        }
-        SetDlgItemTextW(hDlg, IDC_INFO_CIC, CicChip.c_str());
+			std::wstring CicChip;
+			switch (_this->m_pRomInfo->CicChipID())
+			{
+			case CIC_UNKNOWN: CicChip = L"Unknown"; break;
+			case CIC_NUS_8303: CicChip = L"CIC-NUS-8303"; break;
+			case CIC_NUS_5167: CicChip = L"CIC-NUS-5167"; break;
+			case CIC_NUS_DDUS: CicChip = L"CIC-NUS-????"; break;
+			default: CicChip = stdstr_f("CIC-NUS-610%d", _this->m_pRomInfo->CicChipID()).ToUTF16(); break;
+			}
+			SetDlgItemTextW(hDlg, IDC_INFO_CIC, CicChip.c_str());
+		}
+		else
+		{
+			SetWindowTextW(hDlg, wGS(INFO_TITLE).c_str());
+
+			SetDlgItemTextW(hDlg, IDC_ROM_NAME, wGS(INFO_ROM_NAME_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_FILE_NAME, wGS(INFO_FILE_NAME_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_LOCATION, wGS(INFO_LOCATION_TEXT).c_str());
+			//SetDlgItemTextW(hDlg, IDC_ROM_MD5, wGS(INFO_MD5_TEXT).c_str());
+			//SetDlgItemTextW(hDlg, IDC_ROM_SIZE, wGS(INFO_SIZE_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_CART_ID, wGS(INFO_CART_ID_TEXT).c_str());
+			//SetDlgItemTextW(hDlg, IDC_MANUFACTURER, wGS(INFO_MANUFACTURER_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_COUNTRY, wGS(INFO_COUNTRY_TEXT).c_str());
+			//SetDlgItemTextW(hDlg, IDC_CRC1, wGS(INFO_CRC1_TEXT).c_str());
+			//SetDlgItemTextW(hDlg, IDC_CRC2, wGS(INFO_CRC2_TEXT).c_str());
+			//SetDlgItemTextW(hDlg, IDC_CIC_CHIP, wGS(INFO_CIC_CHIP_TEXT).c_str());
+			SetDlgItemTextW(hDlg, IDC_CLOSE_BUTTON, wGS(BOTTOM_CLOSE).c_str());
+
+			SetDlgItemTextW(hDlg, IDC_INFO_ROMNAME, _this->m_pDiskInfo->GetRomName().ToUTF16(stdstr::CODEPAGE_932).c_str());
+
+			SetDlgItemTextW(hDlg, IDC_INFO_FILENAME, stdstr(CPath(_this->m_pDiskInfo->GetFileName()).GetNameExtension()).ToUTF16(CP_ACP).c_str());
+			SetDlgItemTextW(hDlg, IDC_INFO_LOCATION, stdstr(CPath(_this->m_pDiskInfo->GetFileName()).GetDriveDirectory()).ToUTF16(CP_ACP).c_str());
+
+			//SetDlgItemTextW(hDlg, IDC_INFO_MD5, _this->m_pRomInfo->GetRomMD5().ToUTF16().c_str());
+			//SetDlgItemTextW(hDlg, IDC_INFO_ROMSIZE, stdstr_f("%.1f MBit", (float)_this->m_pDiskInfo->GetRomSize() / 0x20000).ToUTF16().c_str());
+
+			BYTE * DiskHeader = _this->m_pDiskInfo->GetDiskAddress() + 0x43670;
+			SetDlgItemTextW(hDlg, IDC_INFO_CARTID, stdstr_f("%c%c", DiskHeader[0x02], DiskHeader[0x01]).ToUTF16().c_str());
+
+			/*switch (DiskHeader[0x00])
+			{
+			case 'N': SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"Nintendo"); break;
+			case 0:   SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"None"); break;
+			default:  SetDlgItemTextW(hDlg, IDC_INFO_MANUFACTURER, L"(Unknown)"); break;
+			}*/
+
+			switch (DiskHeader[0x00])
+			{
+			case NTSC_BETA: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Beta"); break;
+			case X_NTSC:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"NTSC"); break;
+			case Germany:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Germany"); break;
+			case USA:       SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"America"); break;
+			case french:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"France"); break;
+			case Italian:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Italy"); break;
+			case Japan:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Japan"); break;
+			case Europe:    SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Europe"); break;
+			case Spanish:   SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Spain"); break;
+			case Australia: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"Australia"); break;
+			case X_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
+			case Y_PAL:     SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"PAL"); break;
+			case 0: SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, L"None"); break;
+			default:
+				SetDlgItemTextW(hDlg, IDC_INFO_COUNTRY, stdstr_f(" Unknown %c (%02X)", DiskHeader[0x03], DiskHeader[0x03]).ToUTF16().c_str());
+			}
+			SetDlgItemTextW(hDlg, IDC_INFO_CRC1, stdstr_f("0x%08X", *(uint32_t *)(_this->m_pDiskInfo->GetDiskAddress())).ToUTF16().c_str());
+			SetDlgItemTextW(hDlg, IDC_INFO_CRC2, stdstr_f("0x%08X", *(DWORD *)(DiskHeader)).ToUTF16().c_str());
+			/*
+			std::wstring CicChip;
+			switch (_this->m_pRomInfo->CicChipID())
+			{
+			case CIC_UNKNOWN: CicChip = L"Unknown"; break;
+			case CIC_NUS_8303: CicChip = L"CIC-NUS-8303"; break;
+			case CIC_NUS_5167: CicChip = L"CIC-NUS-5167"; break;
+			case CIC_NUS_DDUS: CicChip = L"CIC-NUS-????"; break;
+			default: CicChip = stdstr_f("CIC-NUS-610%d", _this->m_pRomInfo->CicChipID()).ToUTF16(); break;
+			}
+			SetDlgItemTextW(hDlg, IDC_INFO_CIC, CicChip.c_str());
+			*/
+		}
     }
     break;
     case WM_COMMAND:

--- a/Source/Project64/UserInterface/RomInformationClass.h
+++ b/Source/Project64/UserInterface/RomInformationClass.h
@@ -13,17 +13,17 @@
 class RomInformation
 {
     bool const    m_DeleteRomInfo;
-	bool const    m_DeleteDiskInfo;
+    bool const    m_DeleteDiskInfo;
     stdstr  const m_FileName;
     CN64Rom *     m_pRomInfo;
-	CN64Disk *    m_pDiskInfo;
+    CN64Disk *    m_pDiskInfo;
 
     friend DWORD CALLBACK RomInfoProc(HWND, DWORD, DWORD, DWORD);
 
 public:
     RomInformation(const char* RomFile);
     RomInformation(CN64Rom* RomInfo);
-	RomInformation(CN64Disk* DiskInfo);
+    RomInformation(CN64Disk* DiskInfo);
     ~RomInformation();
 
     void DisplayInformation(HWND hParent) const;

--- a/Source/Project64/UserInterface/RomInformationClass.h
+++ b/Source/Project64/UserInterface/RomInformationClass.h
@@ -13,14 +13,17 @@
 class RomInformation
 {
     bool const    m_DeleteRomInfo;
+	bool const    m_DeleteDiskInfo;
     stdstr  const m_FileName;
     CN64Rom *     m_pRomInfo;
+	CN64Disk *    m_pDiskInfo;
 
     friend DWORD CALLBACK RomInfoProc(HWND, DWORD, DWORD, DWORD);
 
 public:
     RomInformation(const char* RomFile);
     RomInformation(CN64Rom* RomInfo);
+	RomInformation(CN64Disk* DiskInfo);
     ~RomInformation();
 
     void DisplayInformation(HWND hParent) const;

--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -37,19 +37,16 @@ int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /
             else
             {
                 //Ext is *.ndd, so it should be a disk file.
-                if (CN64System::RunDiskImage(g_Settings->LoadStringVal(Cmd_RomFile).c_str(), false))
-                {
-                    stdstr IPLROM = g_Settings->LoadStringVal(File_DiskIPLPath);
-                    if ((IPLROM.length() <= 0) || (!CN64System::RunFileImage(IPLROM.c_str())))
-                    {
-                        CPath FileName;
-                        const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-                        if (FileName.SelectFile(NULL, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-                        {
-                            CN64System::RunFileImage(FileName);
-                        }
-                    }
-                }
+				if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(g_Settings->LoadStringVal(Cmd_RomFile).c_str()))
+				{
+					CPath FileNameIPL;
+					const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+					if (FileNameIPL.SelectFile(NULL, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+					{
+						g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
+						g_BaseSystem->RunDiskImage(g_Settings->LoadStringVal(Cmd_RomFile).c_str());
+					}
+				}
             }
         }
         else

--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -39,6 +39,7 @@ int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /
                 //Ext is *.ndd, so it should be a disk file.
                 if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(g_Settings->LoadStringVal(Cmd_RomFile).c_str()))
                 {
+                    if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists()) { g_Notify->DisplayError(MSG_IPL_REQUIRED); }
                     CPath FileNameIPL;
                     const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
                     if (FileNameIPL.SelectFile(NULL, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))

--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -37,16 +37,16 @@ int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /
             else
             {
                 //Ext is *.ndd, so it should be a disk file.
-				if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(g_Settings->LoadStringVal(Cmd_RomFile).c_str()))
-				{
-					CPath FileNameIPL;
-					const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
-					if (FileNameIPL.SelectFile(NULL, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
-					{
-						g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
-						g_BaseSystem->RunDiskImage(g_Settings->LoadStringVal(Cmd_RomFile).c_str());
-					}
-				}
+                if (!CPath(g_Settings->LoadStringVal(File_DiskIPLPath)).Exists() || !g_BaseSystem->RunDiskImage(g_Settings->LoadStringVal(Cmd_RomFile).c_str()))
+                {
+                    CPath FileNameIPL;
+                    const char * Filter = "64DD IPL ROM Image (*.zip, *.7z, *.?64, *.rom, *.usa, *.jap, *.pal, *.bin)\0*.?64;*.zip;*.7z;*.bin;*.rom;*.usa;*.jap;*.pal\0All files (*.*)\0*.*\0";
+                    if (FileNameIPL.SelectFile(NULL, g_Settings->LoadStringVal(RomList_GameDir).c_str(), Filter, true))
+                    {
+                        g_Settings->SaveString(File_DiskIPLPath, (const char *)FileNameIPL);
+                        g_BaseSystem->RunDiskImage(g_Settings->LoadStringVal(Cmd_RomFile).c_str());
+                    }
+                }
             }
         }
         else

--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -37,7 +37,7 @@ int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /
             else
             {
                 //Ext is *.ndd, so it should be a disk file.
-                if (CN64System::RunDiskImage(g_Settings->LoadStringVal(Cmd_RomFile).c_str()))
+                if (CN64System::RunDiskImage(g_Settings->LoadStringVal(Cmd_RomFile).c_str(), false))
                 {
                     stdstr IPLROM = g_Settings->LoadStringVal(File_DiskIPLPath);
                     if ((IPLROM.length() <= 0) || (!CN64System::RunFileImage(IPLROM.c_str())))


### PR DESCRIPTION
Currently overhauling 64DD support almost entirely.

### Features:
- 64DD Disk Images now appear in the ROM Browser, Recent Games as well.
- Seperate settings for each 64DD disk (RDB and User Config)
- Refactored game loading into core instead of UI.
- Unload Disk and 64DD IPL when playing a regular N64 game (frees memory when you don't need it, reminder that a 64DD Disk is almost 64MB)
  - This also fixes that exception error when it's about to save a disk file when it was not used.
- Forge Header of a 64DD game for plugin usage (or not? a discussion could be done about that)
  - Done but I'm not sure if I caused a bug with GUI Messages now or before then...
- More explicit error messages.
- Handle 64DD IPL loading errors better.
- **RDB to contain 64DD game configurations**
- Translation in French

### TODO:
- Proper Rom Information window for 64DD games?
- ***FIX BUGS***