### PR TITLE
[N-Rage] Ignore input if main window isn't focused

### DIFF
--- a/Source/nragev20/NRagePluginV2.cpp
+++ b/Source/nragev20/NRagePluginV2.cpp
@@ -536,7 +536,7 @@ EXPORT void CALL GetKeys(int Control, BUTTONS * Keys )
 #ifdef ENABLE_RAWPAK_DEBUG
 	DebugWriteA("CALLED: GetKeys\n");
 #endif
-	if( g_bConfiguring )
+	if( g_bConfiguring || GetForegroundWindow() != g_strEmuInfo.hMainWindow)
 		Keys->Value = 0;
 	else
 	{


### PR DESCRIPTION
Ignore keyboard/controller input while while typing in other windows. Tested on Win7/10 and Wine