### PR TITLE
[64DD] Handle disks that don't have Disk ID

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -7160,6 +7160,7 @@ Status=Compatible
 Core Note=Cannot use Randnet functionality.
 Fixed Audio=0
 Good Name=Mario Artist Communication Kit (J)
+RDRAM Size=8
 Status=Compatible
 
 [E848D316-444D474A-C:4A]
@@ -7167,6 +7168,7 @@ Status=Compatible
 Fixed Audio=0
 Good Name=Mario Artist Polygon Studio (J)
 Plugin Note=Cannot model on HLE plugins.
+RDRAM Size=8
 Status=Issues (plugin)
 
 [E848D316-4453434A-C:4A]
@@ -7174,6 +7176,7 @@ Status=Issues (plugin)
 Fixed Audio=0
 Good Name=Sim City 64 (J)
 Plugin Note=Very slow, city is not rendering properly in HLE
+RDRAM Size=8
 Status=Issues (plugin)
 
 [E848D316-4450474A-C:4A]
@@ -7202,6 +7205,7 @@ Status=Compatible
 Core Note=Modem Pak is required
 Fixed Audio=0
 Good Name=Randnet Disk (J)
+RDRAM Size=8
 Status=Only intro/part OK
 
 [E848D316-444B4B4A-C:4A]
@@ -7209,6 +7213,7 @@ Status=Only intro/part OK
 Core Note=Expansion Disk for Kyojin no Doshin 1. Use the Disk Swap feature to play.
 Fixed Audio=0
 Good Name=Kyojin no Doshin - Kaihou Sensen Chibikkochikko Dai Shuugou (J)
+RDRAM Size=8
 Status=Compatible
 
 [E848D316-45465A4A-C:4A]
@@ -7216,12 +7221,14 @@ Status=Compatible
 Core Note=Expansion Disk for F-Zero X. Play F-Zero X (J) with this disk loaded.
 Fixed Audio=0
 Good Name=F-Zero X Expansion Kit (J)
+RDRAM Size=8
 Status=Compatible
 
 [E848D316-7AB0252F-C:0]
 32bit=No
 Fixed Audio=0
 Good Name=Super Mario 64 Disk Version (J) (Spaceworld 1996 Demo)
+RDRAM Size=8
 Status=Compatible
 
 

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -7218,6 +7218,13 @@ Fixed Audio=0
 Good Name=F-Zero X Expansion Kit (J)
 Status=Compatible
 
+[E848D316-7AB0252F-C:0]
+32bit=No
+Fixed Audio=0
+Good Name=Super Mario 64 Disk Version (J) (Spaceworld 1996 Demo)
+Status=Compatible
+
+
 //================  PD  ================
 //
 // ROMs below are PD/Intros/Emus and other Non Commercial

--- a/Source/Project64-core/N64System/N64DiskClass.cpp
+++ b/Source/Project64-core/N64System/N64DiskClass.cpp
@@ -58,7 +58,19 @@ bool CN64Disk::LoadDiskImage(const char * FileLoc)
 
     m_RomName = RomName;
     m_FileName = FileLoc;
-    m_DiskIdent.Format("%08X-%08X-C:%X", *(uint32_t *)(&m_DiskImage[0]), *(uint32_t *)(&m_DiskImage[0x43670]), m_DiskImage[0x43670]);
+    if (*(uint32_t *)(&m_DiskImage[0x43670]) != 0)
+    {
+        m_DiskIdent.Format("%08X-%08X-C:%X", *(uint32_t *)(&m_DiskImage[0]), *(uint32_t *)(&m_DiskImage[0x43670]), m_DiskImage[0x43670]);
+    }
+    else
+    {
+        uint32_t crc = 0;
+        for (uint8_t i = 0; i < 0xE8; i += 4)
+        {
+            crc += *(uint32_t *)(m_DiskImage + i);
+        }
+        m_DiskIdent.Format("%08X-%08X-C:%X", *(uint32_t *)(&m_DiskImage[0]), crc, m_DiskImage[0x43670]);
+    }
     m_Country = (Country)m_DiskImage[0x43670];
 
     if (g_Disk == this)

--- a/Source/Project64-core/N64System/N64DiskClass.cpp
+++ b/Source/Project64-core/N64System/N64DiskClass.cpp
@@ -49,18 +49,16 @@ bool CN64Disk::LoadDiskImage(const char * FileLoc)
     }
 
     char RomName[5];
-    //Get the disk ID from the disk image
-    RomName[0] = (char)*(m_DiskImage + 0x43673);
-    RomName[1] = (char)*(m_DiskImage + 0x43672);
-    RomName[2] = (char)*(m_DiskImage + 0x43671);
-    RomName[3] = (char)*(m_DiskImage + 0x43670);
-    RomName[4] = '\0';
-
-    m_RomName = RomName;
     m_FileName = FileLoc;
     if (*(uint32_t *)(&m_DiskImage[0x43670]) != 0)
     {
         m_DiskIdent.Format("%08X-%08X-C:%X", *(uint32_t *)(&m_DiskImage[0]), *(uint32_t *)(&m_DiskImage[0x43670]), m_DiskImage[0x43670]);
+        //Get the disk ID from the disk image
+        RomName[0] = (char)*(m_DiskImage + 0x43673);
+        RomName[1] = (char)*(m_DiskImage + 0x43672);
+        RomName[2] = (char)*(m_DiskImage + 0x43671);
+        RomName[3] = (char)*(m_DiskImage + 0x43670);
+        RomName[4] = '\0';
     }
     else
     {
@@ -70,7 +68,20 @@ bool CN64Disk::LoadDiskImage(const char * FileLoc)
             crc += *(uint32_t *)(m_DiskImage + i);
         }
         m_DiskIdent.Format("%08X-%08X-C:%X", *(uint32_t *)(&m_DiskImage[0]), crc, m_DiskImage[0x43670]);
+
+        //Get the disk ID from the disk image
+        RomName[0] = m_DiskIdent[12];
+        RomName[1] = m_DiskIdent[11];
+        RomName[2] = m_DiskIdent[10];
+        RomName[3] = m_DiskIdent[9];
+        RomName[4] = '\0';
+
+        for (uint8_t i = 0; i < 8; i++)
+        {
+            m_DiskHeader[0x20 + (i ^ 3)] = (uint8_t)m_DiskIdent[9 + i];
+        }
     }
+    m_RomName = RomName;
     m_Country = (Country)m_DiskImage[0x43670];
 
     if (g_Disk == this)

--- a/Source/Project64-core/RomList/RomList.cpp
+++ b/Source/Project64-core/RomList/RomList.cpp
@@ -429,12 +429,12 @@ bool CRomList::LoadDataFromRomFile(const char * FileName, uint8_t * Data, int32_
         {
             //Is a Disk Image
             File.SeekToBegin();
-            if (!File.Read(Data, 0x20))
+            if (!File.Read(Data, 0x100))
             {
                 return false;
             }
             File.Seek(0x43670, CFileBase::begin);
-            if (!File.Read(Data + 0x20, 0x20))
+            if (!File.Read(Data + 0x100, 0x20))
             {
                 return false;
             }
@@ -480,15 +480,22 @@ bool CRomList::FillRomInfo(ROM_INFO * pRomInfo)
         else
         {
             char InternalName[22];
-            memcpy(InternalName, (void *)(RomData + 0x20), 4);
+            memcpy(InternalName, (void *)(RomData + 0x100), 4);
             strcpy(pRomInfo->InternalName, InternalName);
-            pRomInfo->CartID[0] = *(RomData + 0x20);
-            pRomInfo->CartID[1] = *(RomData + 0x21);
-            pRomInfo->CartID[2] = *(RomData + 0x22);
+            pRomInfo->CartID[0] = *(RomData + 0x100);
+            pRomInfo->CartID[1] = *(RomData + 0x101);
+            pRomInfo->CartID[2] = *(RomData + 0x102);
             pRomInfo->Manufacturer = '\0';
-            pRomInfo->Country = *(RomData + 0x20);
+            pRomInfo->Country = *(RomData + 0x100);
             pRomInfo->CRC1 = *(uint32_t *)(RomData + 0x00);
-            pRomInfo->CRC2 = *(uint32_t *)(RomData + 0x20);
+            pRomInfo->CRC2 = *(uint32_t *)(RomData + 0x100);
+            if (pRomInfo->CRC2 == 0)
+            {
+                for (uint8_t i = 0; i < 0xE8; i += 4)
+                {
+                    pRomInfo->CRC2 += *(uint32_t *)(RomData + i);
+                }
+            }
             pRomInfo->CicChip = CIC_NUS_8303;
             FillRomExtensionInfo(pRomInfo);
         }


### PR DESCRIPTION
A bunch of changes to support Super Mario 64 Disk Version that doesn't have a Disk ID and potentially any other disk with the same problem.