### PR TITLE
[Project64-Audio] Remove FAT from audio plugin.

### DIFF
--- a/Source/Project64-audio/AudioSettings.cpp
+++ b/Source/Project64-audio/AudioSettings.cpp
@@ -18,7 +18,6 @@ CSettings * g_settings = NULL;
 CSettings::CSettings() :
 	m_Set_SyncViaAudioEnabled(0),
     m_Set_EnableAudio(0),
-    m_Set_FixedAudio(0),
     m_Set_SyncAudio(0),
     m_Set_FullSpeed(0),
     m_Set_LimitFPS(0),
@@ -32,7 +31,6 @@ CSettings::CSettings() :
     m_debugger_enabled(false),
     m_Volume(100),
     m_Buffer(4),
-    m_FixedAudio(false),
     m_SyncAudio(false),
     m_FullSpeed(true)
 {
@@ -44,7 +42,6 @@ CSettings::CSettings() :
     if (m_Set_basic_mode != 0) { SettingsRegisterChange(true, m_Set_basic_mode, this, stSettingsChanged); }
     if (m_Set_debugger != 0) { SettingsRegisterChange(true, m_Set_debugger, this, stSettingsChanged); }
     if (m_Set_log_flush != 0) { SettingsRegisterChange(true, m_Set_log_flush, this, stSettingsChanged); }
-    if (m_Set_FixedAudio != 0) { SettingsRegisterChange(true, m_Set_FixedAudio, this, stSettingsChanged); }
     if (m_Set_SyncAudio != 0) { SettingsRegisterChange(true, m_Set_SyncAudio, this, stSettingsChanged); }
     if (m_Set_FullSpeed != 0) { SettingsRegisterChange(true, m_Set_FullSpeed, this, stSettingsChanged); }
     if (m_Set_LimitFPS != 0) { SettingsRegisterChange(true, m_Set_LimitFPS, this, stSettingsChanged); }
@@ -65,7 +62,6 @@ CSettings::~CSettings()
     if (m_Set_basic_mode != 0) { SettingsUnregisterChange(true, m_Set_basic_mode, this, stSettingsChanged); }
     if (m_Set_debugger != 0) { SettingsUnregisterChange(true, m_Set_debugger, this, stSettingsChanged); }
     if (m_Set_log_flush != 0) { SettingsUnregisterChange(true, m_Set_log_flush, this, stSettingsChanged); }
-    if (m_Set_FixedAudio != 0) { SettingsUnregisterChange(true, m_Set_FixedAudio, this, stSettingsChanged); }
     if (m_Set_SyncAudio != 0) { SettingsUnregisterChange(true, m_Set_SyncAudio, this, stSettingsChanged); }
     if (m_Set_FullSpeed != 0) { SettingsUnregisterChange(true, m_Set_FullSpeed, this, stSettingsChanged); }
     if (m_Set_LimitFPS != 0) { SettingsUnregisterChange(true, m_Set_LimitFPS, this, stSettingsChanged); }
@@ -85,7 +81,6 @@ void CSettings::RegisterSettings(void)
     SetModuleName("default");
     m_Set_SyncViaAudioEnabled = FindSystemSettingId("SyncViaAudioEnabled");
     m_Set_EnableAudio = FindSystemSettingId("Enable Audio");
-    m_Set_FixedAudio = FindSystemSettingId("Fixed Audio");
     m_Set_SyncAudio = FindSystemSettingId("Sync Audio");
     m_Set_FullSpeed = FindSystemSettingId("Full Speed");
     m_Set_LimitFPS = FindSystemSettingId("Limit FPS");
@@ -154,7 +149,6 @@ void CSettings::ReadSettings(void)
     m_debugger_enabled = m_advanced_options && m_Set_debugger ? GetSystemSetting(m_Set_debugger) == 1 : false;
     m_Buffer = GetSetting(Set_Buffer);
     m_FullSpeed = m_Set_FullSpeed ? GetSystemSetting(m_Set_FullSpeed) != 0 : false;
-    m_FixedAudio = m_Set_FixedAudio ? GetSystemSetting(m_Set_FixedAudio) != 0 : false;
     m_SyncAudio = (!m_advanced_options || bLimitFPS);
 
     if (m_Set_log_dir != 0)

--- a/Source/Project64-audio/AudioSettings.h
+++ b/Source/Project64-audio/AudioSettings.h
@@ -20,7 +20,6 @@ public:
     inline bool debugger_enabled(void) const { return m_debugger_enabled; }
     inline uint32_t GetVolume(void) const { return m_Volume; }
     inline uint32_t GetBuffer(void) const { return m_Buffer; }
-    inline bool FixedAudio(void) const { return m_FixedAudio; }
     inline bool SyncAudio(void) const { return m_SyncAudio; }
     inline bool FullSpeed(void) const { return m_FullSpeed; }
     inline bool FlushLogs(void) const { return m_FlushLogs; }
@@ -47,7 +46,6 @@ private:
 
 	short m_Set_SyncViaAudioEnabled;
 	short m_Set_EnableAudio;
-	short m_Set_FixedAudio;
     short m_Set_SyncAudio;
     short m_Set_FullSpeed;
     short m_Set_LimitFPS;
@@ -62,7 +60,6 @@ private:
     bool m_debugger_enabled;
     uint32_t m_Volume;
     uint32_t m_Buffer;
-    bool m_FixedAudio;
     bool m_SyncAudio;
     bool m_FullSpeed;
 };


### PR DESCRIPTION
Fixes main.cpp error.  Caused by FAT being read from Project64.rdb instead.