### PR TITLE
Fix undefined behavior related to sprintf

### DIFF
--- a/Source/Project64-core/N64System/Mips/PifRam.cpp
+++ b/Source/Project64-core/N64System/Mips/PifRam.cpp
@@ -643,7 +643,9 @@ void CPifRam::LogControllerPakData(const char * Description)
             }
             else
             {
-                sprintf(Addon, "%s%c", Addon, PIF_Ram[(count << 2) + count2]);
+                char tmp[2];
+                sprintf(tmp, "%c", PIF_Ram[(count << 2) + count2]);
+                strcat(Addon, tmp);
             }
         }
         strcat(AsciiData, Addon);

--- a/Source/RSP/log.cpp
+++ b/Source/RSP/log.cpp
@@ -182,17 +182,23 @@ void RDP_LogDlist ( void )
 		}
 
 		for (count = 0; count < 0x10; count ++, Pos++ ) {
+			char tmp[3];
 			if ((count % 4) != 0 || count == 0) {
-				sprintf(Hex,"%s %02X",Hex,Mem[Pos]);
+				sprintf(tmp,"%02X",Mem[Pos]);
+				strcat(Hex," ");
+				strcat(Hex,tmp);
 			} else {
-				sprintf(Hex,"%s - %02X",Hex,Mem[Pos]);
+				sprintf(tmp,"%02X",Mem[Pos]);
+				strcat(Hex," - ");
+				strcat(Hex,tmp);
 			}
 
 			
 			if (Mem[Pos] < 30 || Mem[Pos] > 127) {
 				strcat(Ascii,".");
 			} else {
-				sprintf(Ascii,"%s%c",Ascii,Mem[Pos]);
+				sprintf(tmp,"%c",Mem[Pos]);
+				strcat(Ascii,tmp);
 			}
 		}
 		RDP_Message("   %s %s",Hex, Ascii);


### PR DESCRIPTION
sprintf source and destination should not overlap otherwise the behavior is undefined (as stated in C99 standard, section 7.19.6.6)