### PR TITLE
Fixed some debugger script bugs

### DIFF
--- a/Source/Project64/UserInterface/Debugger/Debugger-Scripts.h
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Scripts.h
@@ -89,6 +89,7 @@ private:
     char* m_SelectedScriptName;
 
     void RefreshStatus();
+	CRITICAL_SECTION m_CriticalSection;
 
 public:
     enum { IDD = IDD_Debugger_Scripts };

--- a/Source/Project64/UserInterface/Debugger/Debugger.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger.cpp
@@ -46,7 +46,9 @@ CDebuggerUI::CDebuggerUI() :
     m_DMALog = new CDMALog();
     m_CPULog = new CCPULog();
 
-    CSymbols::InitializeCriticalSection();
+	InitializeCriticalSection(&m_CriticalSection);
+
+	CSymbols::InitializeCriticalSection();
     g_Settings->RegisterChangeCB(GameRunning_InReset, this, (CSettings::SettingChangedFunc)GameReset);
     g_Settings->RegisterChangeCB(Debugger_SteppingOps, this, (CSettings::SettingChangedFunc)SteppingOpsChanged);
     g_Settings->RegisterChangeCB(GameRunning_CPU_Running, this, (CSettings::SettingChangedFunc)GameCpuRunningChanged);
@@ -75,6 +77,7 @@ CDebuggerUI::~CDebuggerUI(void)
     delete m_CPULog;
 
     CSymbols::DeleteCriticalSection();
+	DeleteCriticalSection(&m_CriticalSection);
 }
 
 void CDebuggerUI::SteppingOpsChanged(CDebuggerUI * _this)

--- a/Source/Project64/UserInterface/Debugger/ScriptSystem.cpp
+++ b/Source/Project64/UserInterface/Debugger/ScriptSystem.cpp
@@ -24,6 +24,8 @@ CScriptSystem::CScriptSystem(CDebuggerUI* debugger)
 
     m_Debugger = debugger;
 
+	InitializeCriticalSection(&m_CriticalSection);
+
     m_HookCPUExec = new CScriptHook(this);
     m_HookCPUExecOpcode = new CScriptHook(this);
     m_HookCPURead = new CScriptHook(this);
@@ -60,6 +62,8 @@ CScriptSystem::~CScriptSystem()
 
     UnregisterHooks();
     free(m_APIScript);
+
+	DeleteCriticalSection(&m_CriticalSection);
 }
 
 const char* CScriptSystem::APIScript()
@@ -72,8 +76,11 @@ void CScriptSystem::RunScript(char* path)
     CScriptInstance* scriptInstance = new CScriptInstance(m_Debugger);
     char* pathSaved = (char*)malloc(strlen(path)+1); // freed via DeleteStoppedInstances
     strcpy(pathSaved, path);
-    m_RunningInstances.push_back({ pathSaved, scriptInstance });
-    scriptInstance->Start(pathSaved);
+
+	EnterCriticalSection(&m_CriticalSection);
+	m_RunningInstances.push_back({ pathSaved, scriptInstance });
+	LeaveCriticalSection(&m_CriticalSection);
+	scriptInstance->Start(pathSaved);
 }
 
 void CScriptSystem::StopScript(char* path)
@@ -86,10 +93,13 @@ void CScriptSystem::StopScript(char* path)
     }
 
     scriptInstance->ForceStop();
+	DeleteStoppedInstances();
 }
 
 void CScriptSystem::DeleteStoppedInstances()
 {
+	EnterCriticalSection(&m_CriticalSection);
+
     int lastIndex = m_RunningInstances.size() - 1;
     for (int i = lastIndex; i >= 0; i--)
     {
@@ -101,29 +111,44 @@ void CScriptSystem::DeleteStoppedInstances()
             m_RunningInstances.erase(m_RunningInstances.begin() + i);
         }
     }
+
+	LeaveCriticalSection(&m_CriticalSection);
 }
 
 INSTANCE_STATE CScriptSystem::GetInstanceState(char* path)
 {
-    for (size_t i = 0; i < m_RunningInstances.size(); i++)
+	EnterCriticalSection(&m_CriticalSection);
+	for (size_t i = 0; i < m_RunningInstances.size(); i++)
     {
         if (strcmp(m_RunningInstances[i].path, path) == 0)
         {
-            return m_RunningInstances[i].scriptInstance->GetState();
+			INSTANCE_STATE ret = m_RunningInstances[i].scriptInstance->GetState();
+
+			LeaveCriticalSection(&m_CriticalSection);
+			return ret;
         }
     }
-    return STATE_INVALID;
+
+	LeaveCriticalSection(&m_CriticalSection);
+	return STATE_INVALID;
 }
 
 CScriptInstance* CScriptSystem::GetInstance(char* path)
 {
+	EnterCriticalSection(&m_CriticalSection);
+
     for (size_t i = 0; i < m_RunningInstances.size(); i++)
     {
         if (strcmp(m_RunningInstances[i].path, path) == 0)
         {
-            return m_RunningInstances[i].scriptInstance;
+			CScriptInstance *ret = m_RunningInstances[i].scriptInstance;
+
+			LeaveCriticalSection(&m_CriticalSection);
+            return ret;
         }
     }
+
+	LeaveCriticalSection(&m_CriticalSection);
     return NULL;
 }
 

--- a/Source/Project64/UserInterface/Debugger/ScriptSystem.h
+++ b/Source/Project64/UserInterface/Debugger/ScriptSystem.h
@@ -58,6 +58,8 @@ private:
 	CScriptHook* m_HookCPUGPRValue;
     CScriptHook* m_HookFrameDrawn;
 
+	CRITICAL_SECTION m_CriticalSection;
+
     void RegisterHook(const char* hookId, CScriptHook* cbList); // associate string id with callback list
     void UnregisterHooks();
 

--- a/Source/Project64/UserInterface/Debugger/debugger.h
+++ b/Source/Project64/UserInterface/Debugger/debugger.h
@@ -102,6 +102,7 @@ private:
     CDebuggerUI(const CDebuggerUI&);                // Disable copy constructor
     CDebuggerUI& operator=(const CDebuggerUI&);        // Disable assignment
 
+	CRITICAL_SECTION       m_CriticalSection;
     CDumpMemory          * m_MemoryDump;
     CDebugMemoryView     * m_MemoryView;
     CDebugMemorySearch   * m_MemorySearch;


### PR DESCRIPTION
Fixed a few bugs in the debugger script system.  The most important was removing two calls that script threads were making to the debugger UI thread, which was causing major race conditions (m_Debugger->Debug_RefreshScriptsWindow() and m_ScriptSystem->DeleteStoppedInstances()).

