### PR TITLE
Windows XP Fixes

### DIFF
--- a/Source/Project64-audio/Driver/SoundBase.cpp
+++ b/Source/Project64-audio/Driver/SoundBase.cpp
@@ -112,7 +112,7 @@ uint32_t SoundDriverBase::AI_ReadLength()
 
 void SoundDriverBase::LoadAiBuffer(uint8_t *start, uint32_t length)
 {
-    uint8_t nullBuff[MAX_SIZE];
+    static uint8_t nullBuff[MAX_SIZE];
     uint8_t *ptrStart = start != NULL ? start : nullBuff;
     uint32_t writePtr = 0, bytesToMove = length;
 


### PR DESCRIPTION
I identified two fixes for Windows XP.  I could not test the debugger fixes because I couldn't get the breakpoint to trip on CancelIoEx.  I am hoping someone would be able to help test that part.  The Project64-Audio is solid though.