### PR TITLE
Debugger code cleanup in ScriptInstance.cpp

### DIFF
--- a/Source/Project64/UserInterface/Debugger/ScriptInstance.h
+++ b/Source/Project64/UserInterface/Debugger/ScriptInstance.h
@@ -60,6 +60,7 @@ class CScriptInstance
         int fd;
     } FILE_FD;
 
+	typedef BOOL(__stdcall *Dynamic_CancelIoEx)(HANDLE, LPOVERLAPPED);
 public:
 
     CScriptInstance(CDebuggerUI* debugger);
@@ -128,6 +129,10 @@ private:
     void CloseAllFiles();
 
     const char* EvalFile(const char* jsPath);
+
+	// Handle to to dynamically load CancelIoEx for Windows XP compatibility
+	HMODULE m_hKernel;
+	Dynamic_CancelIoEx m_CancelIoEx;
 
     // Lookup list of CScriptInstance instances for static js_* functions
     static vector<CScriptInstance*> Cache;


### PR DESCRIPTION
This PR cleans up some irresponsible code that never called a matching FreeLibrary to the LoadLibrary.
LoadLibrary was moved to the constructor to reduce the number of calls.
Made changes to be more inline with acceptable code standards.