### PR TITLE
Make code base compatible with Visual Studio 2019.

### DIFF
--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -2,7 +2,8 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Configuration">
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!=''">$(DefaultPlatformToolset)_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(DefaultPlatformToolset)'!='v142'">$(DefaultPlatformToolset)_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'=='v142'">$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
 
   <ImportGroup Label="PropertySheets">

--- a/Source/Project64/UserInterface/Debugger/Breakpoints.cpp
+++ b/Source/Project64/UserInterface/Debugger/Breakpoints.cpp
@@ -64,7 +64,12 @@ bool CBreakpoints::WBPAdd(uint32_t address)
 bool CBreakpoints::AddExecution(uint32_t address, bool bTemporary)
 {
     PreUpdateBP();
+#if _MSC_VER >= 1920 // Visual Studio 2019 deprecates _Pairib
     auto res = m_Execution.insert(breakpoint_t::value_type(address, bTemporary));
+#else
+    breakpoints_t::_Pairib res = m_Execution.insert(breakpoint_t::value_type(address, bTemporary));
+#endif // _MSC_VER
+
     if (!res.second && !bTemporary)
     {
         res.first->second = true;

--- a/Source/Project64/UserInterface/Debugger/Breakpoints.cpp
+++ b/Source/Project64/UserInterface/Debugger/Breakpoints.cpp
@@ -64,7 +64,7 @@ bool CBreakpoints::WBPAdd(uint32_t address)
 bool CBreakpoints::AddExecution(uint32_t address, bool bTemporary)
 {
     PreUpdateBP();
-    breakpoints_t::_Pairib res = m_Execution.insert(breakpoint_t::value_type(address, bTemporary));
+    auto res = m_Execution.insert(breakpoint_t::value_type(address, bTemporary));
     if (!res.second && !bTemporary)
     {
         res.first->second = true;


### PR DESCRIPTION
- Allow building with the MSVC 14.2 toolset.
- Removed explicit reference to deprecated typedef std::map::_Pairib.