### PR TITLE
Add Combo Loading in Command Line & Main Menu

### DIFF
--- a/Lang/English.pj.Lang
+++ b/Lang/English.pj.Lang
@@ -34,6 +34,7 @@
 #107#  "Recent ROM"
 #108#  "Recent ROM Directories"
 #109#  "E&xit"
+#110#  "Open &Combo"
 
 //System Menu
 #120#  "&System"

--- a/Lang/French.pj.Lang
+++ b/Lang/French.pj.Lang
@@ -34,6 +34,7 @@
 #107#  "ROM récentes"
 #108#  "Répertoires des ROM récentes"
 #109#  "&Quitter"
+#110#  "Ouvrir &Combo"
 
 //System Menu
 #120#  "&Système"

--- a/Source/Project64-core/AppInit.cpp
+++ b/Source/Project64-core/AppInit.cpp
@@ -186,6 +186,19 @@ static bool ParseCommand(int32_t argc, char **argv)
             g_Settings->SaveBool(Cmd_ShowHelp, true);
             return false;
         }
+        else if (strcmp(argv[i], "--combo") == 0)
+        {
+            if (ArgsLeft >= 2)
+            {
+                g_Settings->SaveString(Cmd_ComboDiskFile, &(argv[i + 1][0]));
+                i++;
+            }
+            else
+            {
+                WriteTrace(TraceAppInit, TraceError, "not enough parameters for '%d: %s'", i, argv[i]);
+                return false;
+            }
+        }
         else if (ArgsLeft == 0 && argv[i][0] != '-')
         {
             g_Settings->SaveString(Cmd_RomFile, &(argv[i][0]));

--- a/Source/Project64-core/Multilanguage.h
+++ b/Source/Project64-core/Multilanguage.h
@@ -64,6 +64,7 @@ enum LanguageStringID
     MENU_RECENT_ROM = 107,
     MENU_RECENT_DIR = 108,
     MENU_EXIT = 109,
+    MENU_OPEN_COMBO = 110,
 
     //System Menu
     MENU_SYSTEM = 120,

--- a/Source/Project64-core/Multilanguage/LanguageClass.cpp
+++ b/Source/Project64-core/Multilanguage/LanguageClass.cpp
@@ -71,6 +71,7 @@ void CLanguage::LoadDefaultStrings(void)
     DEF_STR(MENU_RECENT_ROM, "Recent ROM");
     DEF_STR(MENU_RECENT_DIR, "Recent ROM Directories");
     DEF_STR(MENU_EXIT, "E&xit");
+    DEF_STR(MENU_OPEN_COMBO, "Open &Combo");
 
     //System Menu
     DEF_STR(MENU_SYSTEM, "&System");

--- a/Source/Project64-core/Settings.cpp
+++ b/Source/Project64-core/Settings.cpp
@@ -90,6 +90,7 @@ void CSettings::AddHowToHandleSetting(const char * BaseDirectory)
     AddHandler(Cmd_BaseDirectory, new CSettingTypeTempString(BaseDirectory));
     AddHandler(Cmd_ShowHelp, new CSettingTypeTempBool(false));
     AddHandler(Cmd_RomFile, new CSettingTypeTempString(""));
+    AddHandler(Cmd_ComboDiskFile, new CSettingTypeTempString(""));
 
     //Support Files
     AddHandler(SupportFile_Settings, new CSettingTypeApplicationPath("Settings", "ConfigFile", SupportFile_SettingsDefault));

--- a/Source/Project64-core/Settings/SettingsID.h
+++ b/Source/Project64-core/Settings/SettingsID.h
@@ -24,6 +24,7 @@ enum SettingID
     //Command Settings
     Cmd_BaseDirectory,
     Cmd_RomFile,
+    Cmd_ComboDiskFile,
     Cmd_ShowHelp,
 
     //Support Files

--- a/Source/Project64/UserInterface/MainMenu.h
+++ b/Source/Project64/UserInterface/MainMenu.h
@@ -4,7 +4,7 @@
 enum MainMenuID
 {
     //File Menu
-    ID_FILE_OPEN_ROM = 4000, ID_FILE_ROM_INFO, ID_FILE_STARTEMULATION, ID_FILE_ENDEMULATION,
+    ID_FILE_OPEN_ROM = 4000, ID_FILE_OPEN_COMBO, ID_FILE_ROM_INFO, ID_FILE_STARTEMULATION, ID_FILE_ENDEMULATION,
     ID_FILE_ROMDIRECTORY, ID_FILE_REFRESHROMLIST, ID_FILE_EXIT,
 
     //language
@@ -75,6 +75,7 @@ private:
     CMainMenu& operator=(const CMainMenu&);		// Disable assignment
 
     void OnOpenRom(HWND hWnd);
+    void OnOpenCombo(HWND hWnd);
     void OnRomInfo(HWND hWnd);
     void OnEndEmulation(void);
     void OnScreenShot(void);
@@ -88,6 +89,8 @@ private:
     stdstr GetFileLastMod(const CPath & FileName);
     void RebuildAccelerators(void);
     std::string ChooseFileToOpen(HWND hParent);
+    std::string ChooseROMFileToOpen(HWND hParent);
+    std::string ChooseDiskFileToOpen(HWND hParent);
     void SetTraceModuleSetttings(SettingID Type);
 
     static void SettingsChanged(CMainMenu * _this);

--- a/Source/Project64/UserInterface/MenuShortCuts.cpp
+++ b/Source/Project64/UserInterface/MenuShortCuts.cpp
@@ -379,6 +379,7 @@ void CShortCuts::Load(bool InitialValues)
     m_ShortCuts.clear();
 
     AddShortCut(ID_FILE_OPEN_ROM, STR_SHORTCUT_FILEMENU, MENU_OPEN, CMenuShortCutKey::ACCESS_NOT_IN_FULLSCREEN);
+    AddShortCut(ID_FILE_OPEN_COMBO, STR_SHORTCUT_FILEMENU, MENU_OPEN_COMBO, CMenuShortCutKey::ACCESS_NOT_IN_FULLSCREEN);
     AddShortCut(ID_FILE_ROM_INFO, STR_SHORTCUT_FILEMENU, MENU_ROM_INFO, CMenuShortCutKey::ACCESS_NOT_IN_FULLSCREEN);
     AddShortCut(ID_FILE_STARTEMULATION, STR_SHORTCUT_FILEMENU, MENU_START, CMenuShortCutKey::ACCESS_NOT_IN_FULLSCREEN);
     AddShortCut(ID_FILE_ENDEMULATION, STR_SHORTCUT_FILEMENU, MENU_END, CMenuShortCutKey::ACCESS_GAME_RUNNING);
@@ -431,6 +432,8 @@ void CShortCuts::Load(bool InitialValues)
     {
         m_ShortCuts.find(ID_FILE_OPEN_ROM)->second.AddShortCut('O', TRUE, false, false, CMenuShortCutKey::ACCESS_GAME_RUNNING);
         m_ShortCuts.find(ID_FILE_OPEN_ROM)->second.AddShortCut('O', TRUE, false, false, CMenuShortCutKey::ACCESS_GAME_NOT_RUNNING);
+        m_ShortCuts.find(ID_FILE_OPEN_COMBO)->second.AddShortCut('O', TRUE, false, TRUE, CMenuShortCutKey::ACCESS_GAME_RUNNING);
+        m_ShortCuts.find(ID_FILE_OPEN_COMBO)->second.AddShortCut('O', TRUE, false, TRUE, CMenuShortCutKey::ACCESS_GAME_NOT_RUNNING);
         m_ShortCuts.find(ID_FILE_STARTEMULATION)->second.AddShortCut(VK_F11, false, false, false, CMenuShortCutKey::ACCESS_GAME_NOT_RUNNING);
         m_ShortCuts.find(ID_FILE_ENDEMULATION)->second.AddShortCut(VK_F12, false, false, false, CMenuShortCutKey::ACCESS_GAME_RUNNING);
         m_ShortCuts.find(ID_FILE_REFRESHROMLIST)->second.AddShortCut(VK_F5, false, false, false, CMenuShortCutKey::ACCESS_GAME_NOT_RUNNING);


### PR DESCRIPTION
Implemented N64 ROM + 64DD Disk Combo Loading via Command Line `--combo <Disk File>` and via Load Combo in the Main Menu (shortcut is Ctrl+Shift+O and is most likely breaking the *.sc3 file).

I see something about a `--help` argument in AppInit but is completely unused, how did you intend to use it @project64 ?