### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,5 @@
+version: 1.0.{build}
 image: Visual Studio 2015
-build:
-  project: Project64.sln
-  parallel: true
-  verbosity: minimal
 platform:
 - Win32
 - x64
@@ -10,9 +7,17 @@ configuration:
 - Release
 
 before_build:
-- for /f "tokens=1 delims=" %%a in ('git describe --tags --long --dirty') do set current_tag=%%a
-- appveyor UpdateBuild -Version %current_tag%
-
+- ps: >-
+    If ($env:APPVEYOR_BUILD_VERSION -Like "1.0*") {
+      echo  $env:APPVEYOR_BUILD_VERSION
+      $current_tag = git describe --tags --long --dirty
+      echo  $current_tag
+      appveyor UpdateBuild -Version $current_tag
+    }
+build:
+  project: Project64.sln
+  parallel: true
+  verbosity: minimal
 after_build:
 - Source/Script/package_zip.cmd %current_tag%-%platform%.zip %platform%
 


### PR DESCRIPTION
Fixes race condition in which a force push may cause a build to fail in AppVeyor if the previous job isn't done yet, due to getting the status of the repo twice. Now it only sets the Version name for a job once, thus avoiding the issue.