### PR TITLE
[appveyor] Fix package zip filename

### DIFF
--- a/Source/Script/SetGitProperties.cmd
+++ b/Source/Script/SetGitProperties.cmd
@@ -12,6 +12,7 @@ for /F "tokens=1,2,3 delims=-" %%i in ("%GIT_DESCRIBE%") do call :process_git_de
 for /F "tokens=1,2,3" %%i in (%base_dir%\Source\Project64-core\version.h.in) do call :process_version %%i %%j %%k
 set VERSION=v%VERSION_MAJOR%.%VERSION_MINOR%.%VERSION_REVISION%-%VERSION_BUILD%-%VERSION_COMMIT%
 
+echo %VERSION%
 echo GIT_DESCRIBE = %VERSION% > "%base_dir%\git.properties"
 goto :EOF
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,17 +9,15 @@ configuration:
 before_build:
 - ps: >-
     If ($env:APPVEYOR_BUILD_VERSION -Like "1.0*") {
-      echo  $env:APPVEYOR_BUILD_VERSION
-      $current_tag = git describe --tags --long --dirty
-      echo  $current_tag
-      appveyor UpdateBuild -Version $current_tag
+      $version = Source/Script/SetGitProperties.cmd
+      appveyor UpdateBuild -Version $version
     }
 build:
   project: Project64.sln
   parallel: true
   verbosity: minimal
 after_build:
-- Source/Script/package_zip.cmd %current_tag%-%platform%.zip %platform%
+- Source/Script/package_zip.cmd %APPVEYOR_BUILD_VERSION%-%platform%.zip %platform%
 
 artifacts:
 - path: Package/*.zip


### PR DESCRIPTION
instead of using `current_tag` for the zip, use `APPVEYOR_BUILD_VERSION`. this fixes an empty zip filename