### PR TITLE
[Audio] Move SetTimerResolution() to InitiateAudio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 
 Thumbs.db
 /.vs
+/git.properties
 /Bin/Debug
 /Bin/Debug64
 /Bin/Package

--- a/Source/Project64-audio/AudioMain.cpp
+++ b/Source/Project64-audio/AudioMain.cpp
@@ -58,9 +58,7 @@ void PluginInit(void)
     SetupTrace();
     SetupAudioSettings();
     StartTrace();
-#ifdef _WIN32
-    SetTimerResolution();
-#endif
+    //SetTimerResolution();
     g_PluginInit = true;
 }
 
@@ -224,6 +222,9 @@ EXPORT int32_t CALL InitiateAudio(AUDIO_INFO Audio_Info)
         g_SoundDriver->AI_Shutdown();
         delete g_SoundDriver;
     }
+#ifdef _WIN32
+    SetTimerResolution();
+#endif
     g_AudioInfo = Audio_Info;
 #ifdef _WIN32
     g_SoundDriver = new DirectSoundDriver;


### PR DESCRIPTION
Enforces a timer of 1.0ms without conflicting with other plugins that might reset it unknowingly
Fixes VI drop when changing settings in GLideN64