### PR TITLE
Additional functionality for debugger scripts

### DIFF
--- a/Source/Project64/UserInterface/Debugger/Debugger-Scripts.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Scripts.cpp
@@ -196,7 +196,7 @@ LRESULT CDebugScripts::OnScriptListDblClicked(NMHDR* pNMHDR)
 
     m_ScriptList.SelectItem(nItem);
 
-    RunSelected();
+    ToggleSelected();
 
     return 0;
 }
@@ -405,4 +405,18 @@ void CDebugScripts::StopSelected()
     m_Debugger->ScriptSystem()->StopScript(m_SelectedScriptName);
 
     //m_Debugger->Debug_RefreshScriptsWindow();
+}
+
+void CDebugScripts::ToggleSelected()
+{
+    INSTANCE_STATE state = m_Debugger->ScriptSystem()->GetInstanceState(m_SelectedScriptName);
+
+    if (state == STATE_INVALID || state == STATE_STOPPED)
+    {
+        RunSelected();
+    }
+    else
+    {
+        StopSelected();
+    }
 }

--- a/Source/Project64/UserInterface/Debugger/Debugger-Scripts.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Scripts.cpp
@@ -178,6 +178,9 @@ LRESULT CDebugScripts::OnClicked(WORD /*wNotifyCode*/, WORD wID, HWND /*hWndCtl*
     case ID_POPUP_STOP:
         StopSelected();
         break;
+    case ID_POPUP_SCRIPT_EDIT:
+        EditSelected();
+        break;
     case IDC_CLEAR_BTN:
         ConsoleClear();
         break;
@@ -419,4 +422,9 @@ void CDebugScripts::ToggleSelected()
     {
         StopSelected();
     }
+}
+
+void CDebugScripts::EditSelected()
+{
+    ShellExecute(NULL, "edit", m_SelectedScriptName, NULL, "Scripts", SW_SHOWNORMAL);
 }

--- a/Source/Project64/UserInterface/Debugger/Debugger-Scripts.h
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Scripts.h
@@ -107,6 +107,7 @@ public:
     void EvaluateInSelectedInstance(char* code);
     void RunSelected();
     void StopSelected();
+    void ToggleSelected();
 
     LRESULT OnInitDialog(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnDestroy(void)

--- a/Source/Project64/UserInterface/Debugger/Debugger-Scripts.h
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Scripts.h
@@ -108,6 +108,7 @@ public:
     void RunSelected();
     void StopSelected();
     void ToggleSelected();
+    void EditSelected();
 
     LRESULT OnInitDialog(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnDestroy(void)

--- a/Source/Project64/UserInterface/Debugger/ScriptInstance.cpp
+++ b/Source/Project64/UserInterface/Debugger/ScriptInstance.cpp
@@ -114,7 +114,7 @@ void CScriptInstance::StateChanged()
 {
     // todo mutex might be needed here
 
-    //m_Debugger->Debug_RefreshScriptsWindow();
+    m_Debugger->Debug_RefreshScriptsWindow();
     //m_ScriptSystem->DeleteStoppedInstances();
 }
 

--- a/Source/Project64/UserInterface/UIResources.rc
+++ b/Source/Project64/UserInterface/UIResources.rc
@@ -1990,6 +1990,7 @@ BEGIN
     BEGIN
         MENUITEM "Run",                         ID_POPUP_RUN
         MENUITEM "Stop",                        ID_POPUP_STOP
+        MENUITEM "Edit",                        ID_POPUP_SCRIPT_EDIT
     END
 END
 

--- a/Source/Project64/UserInterface/resource.h
+++ b/Source/Project64/UserInterface/resource.h
@@ -721,6 +721,7 @@
 #define ID_POPUPMENU_CLEARALLBPS        40019
 #define ID_POPUPMENU_TOGGLERBP          40020
 #define ID_POPUPMENU_TOGGLEWBP          40021
+#define ID_POPUP_SCRIPT_EDIT            40023
 #define ID_POPUP_RUN                    40024
 #define ID_POPUP_STOP                   40025
 #define ID_POPUPMENU_INSERTNOP          40026


### PR DESCRIPTION
Pretty dumb PR based on my own usage. This is all that I'm suggesting:
1. Double clicking a script shall toggle its activation, rather than try to run it every time
2. An edit option in the script window's context menu, allowing for quick edits