### PR TITLE
 Added type, name, value, desc editing in the symbols window; 'new tab' shortcut to memory viewer

### DIFF
--- a/Source/Project64/UserInterface/Debugger/Debugger-Symbols.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Symbols.cpp
@@ -18,41 +18,19 @@
 #include "Symbols.h"
 
 const CSetValueDlg::ComboItem CDebugSymbols::ModalChangeTypeItems[] = {
-	{ "code",   SYM_CODE},
-	{ "uint8",  SYM_U8 },
-	{ "int8",   SYM_S8 },
-	{ "uint16", SYM_U16 },
-	{ "int16",  SYM_S16 },
-	{ "uint32", SYM_U32 },
-	{ "int32",  SYM_S32 },
-	{ "uint64", SYM_U64 },
-	{ "int64",  SYM_S64 },
-	{ "float",  SYM_FLOAT },
-	{ "double", SYM_DOUBLE },
-	{ NULL, 0 }
+    { "code",   SYM_CODE},
+    { "uint8",  SYM_U8 },
+    { "int8",   SYM_S8 },
+    { "uint16", SYM_U16 },
+    { "int16",  SYM_S16 },
+    { "uint32", SYM_U32 },
+    { "int32",  SYM_S32 },
+    { "uint64", SYM_U64 },
+    { "int64",  SYM_S64 },
+    { "float",  SYM_FLOAT },
+    { "double", SYM_DOUBLE },
+    { NULL, 0 }
 };
-
-const char* CDebugSymbols::GetTypeName(int m_Type)
-{
-	switch (m_Type)
-	{
-	case SYM_CODE:  return "code";
-	case SYM_DATA:   return "data";
-	case SYM_U8: return "uint8";
-	case SYM_U16:  return "uint16";
-	case SYM_U32: return "uint32";
-	case SYM_U64:  return "uint64";
-	case SYM_S8: return "int8";
-	case SYM_S16:  return "int16";
-	case SYM_S32:  return "int32";
-	case SYM_S64: return "int64";
-	case SYM_FLOAT: return "float";
-	case SYM_DOUBLE: return "double";
-	case SYM_INVALID: return "invalid";
-	}
-
-	return NULL;
-}
 
 CDebugSymbols::CDebugSymbols(CDebuggerUI * debugger) :
     CDebugDialog<CDebugSymbols>(debugger)
@@ -136,132 +114,132 @@ LRESULT CDebugSymbols::OnClicked(WORD /*wNotifyCode*/, WORD wID, HWND /*hWndCtl*
 
 LRESULT    CDebugSymbols::OnListDblClicked(NMHDR* pNMHDR)
 {
-	if (g_MMU == NULL)
-	{
-		return true;
-	}
+    if (g_MMU == NULL)
+    {
+        return true;
+    }
 
-	LONG iItem = m_SymbolsListView.GetNextItem(-1, LVNI_SELECTED);
-	if (iItem == -1)
-	{
-		return true;
-	}
+    LONG iItem = m_SymbolsListView.GetNextItem(-1, LVNI_SELECTED);
+    if (iItem == -1)
+    {
+        return true;
+    }
 
-	int nSelectedCol = -1;
+    int nSelectedCol = -1;
 
-	// hit test for column
+    // hit test for column
 
-	POINT mousePt;
-	RECT listRect;
-	GetCursorPos(&mousePt);
-	m_SymbolsListView.GetWindowRect(&listRect);
+    POINT mousePt;
+    RECT listRect;
+    GetCursorPos(&mousePt);
+    m_SymbolsListView.GetWindowRect(&listRect);
 
-	int mouseX = mousePt.x - listRect.left;
+    int mouseX = mousePt.x - listRect.left;
 
-	for (int nCol = 0, colX = 0; nCol < m_SymbolsListView_Num_Columns; nCol++)
-	{
-		int colWidth = m_SymbolsListView.GetColumnWidth(nCol);
-		if (mouseX >= colX && mouseX <= colX + colWidth)
-		{
-			nSelectedCol = nCol;
-			break;
-		}
-		colX += colWidth;
-	}
+    for (int nCol = 0, colX = 0; nCol < SymbolsListView_Num_Columns; nCol++)
+    {
+        int colWidth = m_SymbolsListView.GetColumnWidth(nCol);
+        if (mouseX >= colX && mouseX <= colX + colWidth)
+        {
+            nSelectedCol = nCol;
+            break;
+        }
+        colX += colWidth;
+    }
 
-	NMITEMACTIVATE* pIA = reinterpret_cast<NMITEMACTIVATE*>(pNMHDR);
-	int nItem = pIA->iItem;
-	int id = m_SymbolsListView.GetItemData(nItem);
+    NMITEMACTIVATE* pIA = reinterpret_cast<NMITEMACTIVATE*>(pNMHDR);
+    int nItem = pIA->iItem;
+    int id = m_SymbolsListView.GetItemData(nItem);
 
-	CSymbol symbol;
-	if (!m_Debugger->SymbolTable()->GetSymbolById(id, &symbol))
-	{
-		return 0;
-	}
+    CSymbol symbol;
+    if (!m_Debugger->SymbolTable()->GetSymbolById(id, &symbol))
+    {
+        return 0;
+    }
 
-	switch (nSelectedCol)
-	{
-	case m_SymbolsListView_Col_Address:
-		// Open it in memory viewer/commands viewer
-		if (symbol.m_Type == SYM_CODE) // code
-		{
-			m_Debugger->Debug_ShowCommandsLocation(symbol.m_Address, true);
-		}
-		else // data/number
-		{
-			m_Debugger->Debug_ShowMemoryLocation(symbol.m_Address, true);
-		}
-		break;
-	case m_SymbolsListView_Col_Type:
-		if (m_SetValueDlg.DoModal("Change type", "New type:", symbol.m_Type, ModalChangeTypeItems))
-		{
-			ValueType t = (ValueType)m_SetValueDlg.GetEnteredData();
+    switch (nSelectedCol)
+    {
+    case SymbolsListView_Col_Address:
+        // Open it in memory viewer/commands viewer
+        if (symbol.m_Type == SYM_CODE) // code
+        {
+            m_Debugger->Debug_ShowCommandsLocation(symbol.m_Address, true);
+        }
+        else // data/number
+        {
+            m_Debugger->Debug_ShowMemoryLocation(symbol.m_Address, true);
+        }
+        break;
+    case SymbolsListView_Col_Type:
+        if (m_SetValueDlg.DoModal("Change type", "New type:", symbol.m_Type, ModalChangeTypeItems))
+        {
+            ValueType t = (ValueType)m_SetValueDlg.GetEnteredData();
 
-			//Is there a better way?
-			m_Debugger->SymbolTable()->RemoveSymbolById(id);
-			m_Debugger->SymbolTable()->AddSymbol(t, symbol.m_Address, symbol.m_Name, symbol.m_Description);
-		}
-		break;
-	case m_SymbolsListView_Col_Name:
-		if (m_SetValueDlg.DoModal("Set name", "New name:", symbol.m_Name))
-		{
-			char* szEnteredString = m_SetValueDlg.GetEnteredString();
-			m_Debugger->SymbolTable()->RemoveSymbolById(id);
-			m_Debugger->SymbolTable()->AddSymbol(symbol.m_Type, symbol.m_Address, szEnteredString, symbol.m_Description);
-		}
-		break;
-	case m_SymbolsListView_Col_Value:
-		char szValue[64];
-		m_Debugger->SymbolTable()->GetValueString(szValue, &symbol);
+            //Is there a better way?
+            m_Debugger->SymbolTable()->RemoveSymbolById(id);
+            m_Debugger->SymbolTable()->AddSymbol(t, symbol.m_Address, symbol.m_Name, symbol.m_Description);
+        }
+        break;
+    case SymbolsListView_Col_Name:
+        if (m_SetValueDlg.DoModal("Set name", "New name:", symbol.m_Name))
+        {
+            char* szEnteredString = m_SetValueDlg.GetEnteredString();
+            m_Debugger->SymbolTable()->RemoveSymbolById(id);
+            m_Debugger->SymbolTable()->AddSymbol(symbol.m_Type, symbol.m_Address, szEnteredString, symbol.m_Description);
+        }
+        break;
+    case SymbolsListView_Col_Value:
+        char szValue[64];
+        m_Debugger->SymbolTable()->GetValueString(szValue, &symbol);
         if (m_SetValueDlg.DoModal("Change value", "New value:", szValue))
         {
-			switch (symbol.m_Type)
-			{
-			case SYM_U8:
-				m_Debugger->DebugStore_VAddr<uint8_t>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
-				break;
-			case SYM_U16:
-				m_Debugger->DebugStore_VAddr<uint16_t>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
-				break;
-			case SYM_U32:
-				m_Debugger->DebugStore_VAddr<uint32_t>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
-				break;
-			case SYM_U64:
-				m_Debugger->DebugStore_VAddr<uint64_t>(symbol.m_Address, atoll(m_SetValueDlg.GetEnteredString()));
-				break;
-			case SYM_S8:
-				m_Debugger->DebugStore_VAddr<int8_t>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
-				break;
-			case SYM_S16:
-				m_Debugger->DebugStore_VAddr<int16_t>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
-				break;
-			case SYM_S32:
-				m_Debugger->DebugStore_VAddr<int>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
-				break;
-			case SYM_S64:
-				m_Debugger->DebugStore_VAddr<int64_t>(symbol.m_Address, atoll(m_SetValueDlg.GetEnteredString()));
-				break;
-			case SYM_FLOAT:
-				m_Debugger->DebugStore_VAddr<float>(symbol.m_Address, atof(m_SetValueDlg.GetEnteredString()));
-				break;
-			case SYM_DOUBLE:
-				m_Debugger->DebugStore_VAddr<double>(symbol.m_Address, atof(m_SetValueDlg.GetEnteredString()));
-				break;
-			}
+            switch (symbol.m_Type)
+            {
+            case SYM_U8:
+                m_Debugger->DebugStore_VAddr<uint8_t>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
+                break;
+            case SYM_U16:
+                m_Debugger->DebugStore_VAddr<uint16_t>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
+                break;
+            case SYM_U32:
+                m_Debugger->DebugStore_VAddr<uint32_t>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
+                break;
+            case SYM_U64:
+                m_Debugger->DebugStore_VAddr<uint64_t>(symbol.m_Address, atoll(m_SetValueDlg.GetEnteredString()));
+                break;
+            case SYM_S8:
+                m_Debugger->DebugStore_VAddr<int8_t>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
+                break;
+            case SYM_S16:
+                m_Debugger->DebugStore_VAddr<int16_t>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
+                break;
+            case SYM_S32:
+                m_Debugger->DebugStore_VAddr<int>(symbol.m_Address, atoi(m_SetValueDlg.GetEnteredString()));
+                break;
+            case SYM_S64:
+                m_Debugger->DebugStore_VAddr<int64_t>(symbol.m_Address, atoll(m_SetValueDlg.GetEnteredString()));
+                break;
+            case SYM_FLOAT:
+                m_Debugger->DebugStore_VAddr<float>(symbol.m_Address, atof(m_SetValueDlg.GetEnteredString()));
+                break;
+            case SYM_DOUBLE:
+                m_Debugger->DebugStore_VAddr<double>(symbol.m_Address, atof(m_SetValueDlg.GetEnteredString()));
+                break;
+            }
         }
-		break;
-	case m_SymbolsListView_Col_Description:
-		if (m_SetValueDlg.DoModal("Set description", "New description:", symbol.m_Description))
-		{
-			char* szEnteredString = m_SetValueDlg.GetEnteredString();
-			m_Debugger->SymbolTable()->RemoveSymbolById(id);
-			m_Debugger->SymbolTable()->AddSymbol(symbol.m_Type, symbol.m_Address, symbol.m_Name, szEnteredString);
-		}
-		break;
-	} 
+        break;
+    case SymbolsListView_Col_Description:
+        if (m_SetValueDlg.DoModal("Set description", "New description:", symbol.m_Description))
+        {
+            char* szEnteredString = m_SetValueDlg.GetEnteredString();
+            m_Debugger->SymbolTable()->RemoveSymbolById(id);
+            m_Debugger->SymbolTable()->AddSymbol(symbol.m_Type, symbol.m_Address, symbol.m_Name, szEnteredString);
+        }
+        break;
+    } 
 
-	m_Debugger->SymbolTable()->Save();
-	Refresh();
+    m_Debugger->SymbolTable()->Save();
+    Refresh();
 
     return 0;
 }

--- a/Source/Project64/UserInterface/Debugger/Debugger-Symbols.h
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Symbols.h
@@ -20,22 +20,19 @@ class CDebugSymbols :
     public CDialogResize<CDebugSymbols>
 {
 private:
-	enum {
-		m_SymbolsListView_Col_Address,
-		m_SymbolsListView_Col_Type,
-		m_SymbolsListView_Col_Name,
-		m_SymbolsListView_Col_Value,
-		m_SymbolsListView_Col_Description,
-		m_SymbolsListView_Num_Columns
-	};
+    enum {
+        SymbolsListView_Col_Address,
+        SymbolsListView_Col_Type,
+        SymbolsListView_Col_Name,
+        SymbolsListView_Col_Value,
+        SymbolsListView_Col_Description,
+        SymbolsListView_Num_Columns
+    };
 
-	//Probably shouldn't be here?
-	const char* GetTypeName(int m_Type);
-
-	static const CSetValueDlg::ComboItem ModalChangeTypeItems[];
+    static const CSetValueDlg::ComboItem ModalChangeTypeItems[];
 
     CListViewCtrl m_SymbolsListView;
-	CSetValueDlg  m_SetValueDlg;
+    CSetValueDlg  m_SetValueDlg;
     CAddSymbolDlg m_AddSymbolDlg;
 
 public:

--- a/Source/Project64/UserInterface/Debugger/Debugger-Symbols.h
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Symbols.h
@@ -20,7 +20,22 @@ class CDebugSymbols :
     public CDialogResize<CDebugSymbols>
 {
 private:
+	enum {
+		m_SymbolsListView_Col_Address,
+		m_SymbolsListView_Col_Type,
+		m_SymbolsListView_Col_Name,
+		m_SymbolsListView_Col_Value,
+		m_SymbolsListView_Col_Description,
+		m_SymbolsListView_Num_Columns
+	};
+
+	//Probably shouldn't be here?
+	const char* GetTypeName(int m_Type);
+
+	static const CSetValueDlg::ComboItem ModalChangeTypeItems[];
+
     CListViewCtrl m_SymbolsListView;
+	CSetValueDlg  m_SetValueDlg;
     CAddSymbolDlg m_AddSymbolDlg;
 
 public:

--- a/Source/Project64/UserInterface/Debugger/Debugger-ViewMemory.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-ViewMemory.cpp
@@ -562,6 +562,9 @@ LRESULT CDebugMemoryView::OnHxCtrlKeyPressed(LPNMHDR lpNMHDR)
     case 'W':
         m_Breakpoints->WBPToggle(address);
         break;
+    case 'N':
+        AddTab(0x80000000, true, 4);
+        break;
     case 'R':
         m_Breakpoints->RBPToggle(address);
         break;


### PR DESCRIPTION
I'm not sure if this is written how it should be, but the lack of this feature had been bugging me for a bit and I would like to see it to be standard.

Edit: I added a 'new tab' shortcut in the memory viewer with ctrl+n. This is different from the duplicate tab feature since it opens a tab at the start of rdram. This may be preferred in some cases over ctrl+t, or for some who don't know all of the features, they might find this to be more intuitive. 