### PR TITLE
Cleaning up unclear booleans with a clearer enum class

### DIFF
--- a/Source/Project64/Project64.vcxproj
+++ b/Source/Project64/Project64.vcxproj
@@ -203,6 +203,7 @@
     <ClInclude Include="UserInterface\Settings\SettingsPage.h" />
     <ClInclude Include="UserInterface\SupportEnterCode.h" />
     <ClInclude Include="UserInterface\SupportWindow.h" />
+    <ClInclude Include="UserInterface\WTLControls\DisplayMode.h" />
     <ClInclude Include="UserInterface\WTLControls\EditNumber32.h" />
     <ClInclude Include="UserInterface\WTLControls\HexEditCtrl.h" />
     <ClInclude Include="UserInterface\WTLControls\ModifiedCheckBox.h" />

--- a/Source/Project64/Project64.vcxproj.filters
+++ b/Source/Project64/Project64.vcxproj.filters
@@ -467,6 +467,9 @@
     <ClInclude Include="UserInterface\Debugger\DebugMMU.h">
       <Filter>Header Files\User Interface Headers\Debugger Headers</Filter>
     </ClInclude>
+    <ClInclude Include="UserInterface\WTLControls\DisplayMode.h">
+      <Filter>Header Files\User Interface Headers\WTL Controls Headers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="res\divider.cur">

--- a/Source/Project64/UserInterface/Debugger/Debugger-AddSymbol.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-AddSymbol.cpp
@@ -39,7 +39,7 @@ LRESULT CAddSymbolDlg::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*l
 
     if (m_bHaveAddress)
     {
-        m_AddressEdit.SetValue(m_InitAddress, false, true);
+        m_AddressEdit.SetValue(m_InitAddress, DisplayMode::ZeroExtend);
         m_TypeComboBox.SetFocus();
     }
 

--- a/Source/Project64/UserInterface/Debugger/Debugger-Commands.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Commands.cpp
@@ -100,7 +100,7 @@ LRESULT CDebugCommandsView::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARA
     m_PCEdit.SetLimitText(8);
 
     m_bIgnorePCChange = true;
-    m_PCEdit.SetValue(0x80000180, false, true);
+    m_PCEdit.SetValue(0x80000180, DisplayMode::ZeroExtend);
 
     // Setup View PC button
     m_ViewPCButton.EnableWindow(FALSE);
@@ -124,7 +124,7 @@ LRESULT CDebugCommandsView::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARA
     m_OpEdit.SetCommandsWindow(this);
 
     m_bIgnoreAddrChange = true;
-    m_AddressEdit.SetValue(0x80000000, false, true);
+    m_AddressEdit.SetValue(0x80000000, DisplayMode::ZeroExtend);
     ShowAddress(0x80000000, TRUE);
     m_bIgnoreAddrChange = false;
 
@@ -231,7 +231,7 @@ void CDebugCommandsView::InterceptMouseWheel(WPARAM wParam, LPARAM /*lParam*/)
 
     m_StartAddress = newAddress;
 
-    m_AddressEdit.SetValue(m_StartAddress, false, true);
+    m_AddressEdit.SetValue(m_StartAddress, DisplayMode::ZeroExtend);
 }
 
 LRESULT CALLBACK CDebugCommandsView::HookProc(int nCode, WPARAM wParam, LPARAM lParam)
@@ -512,7 +512,7 @@ void CDebugCommandsView::ShowAddress(uint32_t address, bool top, bool bUserInput
         if (!bUserInput)
         {
             m_bIgnoreAddrChange = true;
-            m_AddressEdit.SetValue(address, false, true);
+            m_AddressEdit.SetValue(address, DisplayMode::ZeroExtend);
         }
 
         if (!isStepping())
@@ -536,7 +536,7 @@ void CDebugCommandsView::ShowAddress(uint32_t address, bool top, bool bUserInput
         {
             m_StartAddress = address - address % 4;
             m_bIgnoreAddrChange = true;
-            m_AddressEdit.SetValue(address, false, true);
+            m_AddressEdit.SetValue(address, DisplayMode::ZeroExtend);
         }
 
         if (m_History.size() == 0 || m_History[m_HistoryIndex] != m_StartAddress)
@@ -545,7 +545,7 @@ void CDebugCommandsView::ShowAddress(uint32_t address, bool top, bool bUserInput
         }
 
         m_bIgnorePCChange = true;
-        m_PCEdit.SetValue(g_Reg->m_PROGRAM_COUNTER, false, true);
+        m_PCEdit.SetValue(g_Reg->m_PROGRAM_COUNTER, DisplayMode::ZeroExtend);
 
         // Enable buttons
         m_ViewPCButton.EnableWindow(TRUE);
@@ -1128,7 +1128,7 @@ LRESULT CDebugCommandsView::OnBackButton(WORD /*wNotifyCode*/, WORD /*wID*/, HWN
     if (m_HistoryIndex > 0)
     {
         m_HistoryIndex--;
-        m_AddressEdit.SetValue(m_History[m_HistoryIndex], false, true);
+        m_AddressEdit.SetValue(m_History[m_HistoryIndex], DisplayMode::ZeroExtend);
         ToggleHistoryButtons();
     }
     return FALSE;
@@ -1139,7 +1139,7 @@ LRESULT CDebugCommandsView::OnForwardButton(WORD /*wNotifyCode*/, WORD /*wID*/, 
     if (m_History.size() > 0 && m_HistoryIndex < (int)m_History.size() - 1)
     {
         m_HistoryIndex++;
-        m_AddressEdit.SetValue(m_History[m_HistoryIndex], false, true);
+        m_AddressEdit.SetValue(m_History[m_HistoryIndex], DisplayMode::ZeroExtend);
         ToggleHistoryButtons();
     }
     return FALSE;

--- a/Source/Project64/UserInterface/Debugger/Debugger-MemoryDump.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-MemoryDump.cpp
@@ -40,8 +40,8 @@ LRESULT CDumpMemory::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*lPa
     uint32_t startAddress = 0x80000000;
     uint32_t endAddress = startAddress + (g_MMU ? g_MMU->RdramSize() : 0x400000);
 
-    m_StartAddress.SetValue(startAddress, true, true);
-    m_EndAddress.SetValue(endAddress, true, true);
+    m_StartAddress.SetValue(startAddress, DisplayMode::AllHex);
+    m_EndAddress.SetValue(endAddress, DisplayMode::AllHex);
     m_PC.SetValue(startAddress);
     
     int nIndex = m_FormatList.AddString("TEXT - Disassembly + PC");
@@ -172,8 +172,8 @@ bool CDumpMemory::DumpMemory(LPCSTR FileName, DumpFormat Format, DWORD StartPC, 
             LogFile.LogF("%X: %-15s%s\r\n", DumpPC, cmdName, cmdArgs);
         }
 
-        m_StartAddress.SetValue(StartPC, true, true);
-        m_EndAddress.SetValue(EndPC, true, true);
+        m_StartAddress.SetValue(StartPC, DisplayMode::AllHex);
+        m_EndAddress.SetValue(EndPC, DisplayMode::AllHex);
         return true;
     }
 

--- a/Source/Project64/UserInterface/Debugger/Debugger-MemorySearch.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-MemorySearch.cpp
@@ -109,8 +109,8 @@ LRESULT CDebugMemorySearch::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARA
     
     uint32_t ramSize = (g_MMU != NULL) ? g_MMU->RdramSize() : 0x00400000;
 
-    m_AddrStart.SetValue(0x80000000, true, true);
-    m_AddrEnd.SetValue(0x80000000 + ramSize - 1, true, true);
+    m_AddrStart.SetValue(0x80000000, DisplayMode::AllHex);
+    m_AddrEnd.SetValue(0x80000000 + ramSize - 1, DisplayMode::AllHex);
 
     FixListHeader(m_WatchListCtrl);
     FixListHeader(m_ResultsListCtrl);
@@ -347,8 +347,8 @@ LRESULT CDebugMemorySearch::OnRdramButton(WORD /*wNotifyCode*/, WORD /*wID*/, HW
     bool bPhysicalChecked = (m_PhysicalCheckbox.GetCheck() == BST_CHECKED);
     uint32_t addrStart = bPhysicalChecked ? 0 : 0x80000000;
     uint32_t ramSize = (g_MMU != NULL) ? g_MMU->RdramSize() : 0x00400000;
-    m_AddrStart.SetValue(addrStart, true, true);
-    m_AddrEnd.SetValue(addrStart + ramSize - 1, true, true);
+    m_AddrStart.SetValue(addrStart, DisplayMode::AllHex);
+    m_AddrEnd.SetValue(addrStart + ramSize - 1, DisplayMode::AllHex);
     return FALSE;
 }
 
@@ -356,8 +356,8 @@ LRESULT CDebugMemorySearch::OnRomButton(WORD /*wNotifyCode*/, WORD /*wID*/, HWND
 {
     bool bPhysicalChecked = (m_PhysicalCheckbox.GetCheck() == BST_CHECKED);
     uint32_t addrStart = bPhysicalChecked ? 0x10000000 : 0xB0000000;
-    m_AddrStart.SetValue(addrStart, true, true);
-    m_AddrEnd.SetValue(addrStart + g_Rom->GetRomSize() - 1, true, true);
+    m_AddrStart.SetValue(addrStart, DisplayMode::AllHex);
+    m_AddrEnd.SetValue(addrStart + g_Rom->GetRomSize() - 1, DisplayMode::AllHex);
     return FALSE;
 }
 
@@ -365,8 +365,8 @@ LRESULT CDebugMemorySearch::OnSpmemButton(WORD /*wNotifyCode*/, WORD /*wID*/, HW
 {
     bool bPhysicalChecked = (m_PhysicalCheckbox.GetCheck() == BST_CHECKED);
     uint32_t addrStart = bPhysicalChecked ? 0x04000000 : 0xA4000000;
-    m_AddrStart.SetValue(addrStart, true, true);
-    m_AddrEnd.SetValue(addrStart + 0x1FFF, true, true);
+    m_AddrStart.SetValue(addrStart, DisplayMode::AllHex);
+    m_AddrEnd.SetValue(addrStart + 0x1FFF, DisplayMode::AllHex);
     return FALSE;
 }
 

--- a/Source/Project64/UserInterface/Debugger/Debugger-RegisterTabs.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-RegisterTabs.cpp
@@ -135,32 +135,32 @@ void CRegisterTabs::RefreshEdits()
     for (int i = 0; i < 32; i++)
     {
         m_GPREdits[i].SetValue(g_Reg->m_GPR[i].UDW);
-        m_FPREdits[i].SetValue(*(uint32_t *)g_Reg->m_FPR_S[i], false, true);
+        m_FPREdits[i].SetValue(*(uint32_t *)g_Reg->m_FPR_S[i], DisplayMode::ZeroExtend);
     }
     m_HIEdit.SetValue(g_Reg->m_HI.UDW);
     m_LOEdit.SetValue(g_Reg->m_LO.UDW);
 
-    m_FCSREdit.SetValue(g_Reg->m_FPCR[31], false, true);
+    m_FCSREdit.SetValue(g_Reg->m_FPCR[31], DisplayMode::ZeroExtend);
 
-    m_COP0Edits[0].SetValue(g_Reg->INDEX_REGISTER, false, true);
-    m_COP0Edits[1].SetValue(g_Reg->RANDOM_REGISTER, false, true);
-    m_COP0Edits[2].SetValue(g_Reg->ENTRYLO0_REGISTER, false, true);
-    m_COP0Edits[3].SetValue(g_Reg->ENTRYLO1_REGISTER, false, true);
-    m_COP0Edits[4].SetValue(g_Reg->CONTEXT_REGISTER, false, true);
-    m_COP0Edits[5].SetValue(g_Reg->PAGE_MASK_REGISTER, false, true);
-    m_COP0Edits[6].SetValue(g_Reg->WIRED_REGISTER, false, true);
-    m_COP0Edits[7].SetValue(g_Reg->BAD_VADDR_REGISTER, false, true);
-    m_COP0Edits[8].SetValue(g_Reg->COUNT_REGISTER, false, true);
-    m_COP0Edits[9].SetValue(g_Reg->ENTRYHI_REGISTER, false, true);
-    m_COP0Edits[10].SetValue(g_Reg->COMPARE_REGISTER, false, true);
-    m_COP0Edits[11].SetValue(g_Reg->STATUS_REGISTER, false, true);
-    m_COP0Edits[12].SetValue(g_Reg->CAUSE_REGISTER, false, true);
-    m_COP0Edits[13].SetValue(g_Reg->EPC_REGISTER, false, true);
-    m_COP0Edits[14].SetValue(g_Reg->CONFIG_REGISTER, false, true);
-    m_COP0Edits[15].SetValue(g_Reg->TAGLO_REGISTER, false, true);
-    m_COP0Edits[16].SetValue(g_Reg->TAGHI_REGISTER, false, true);
-    m_COP0Edits[17].SetValue(g_Reg->ERROREPC_REGISTER, false, true);
-    m_COP0Edits[18].SetValue(g_Reg->FAKE_CAUSE_REGISTER, false, true);
+    m_COP0Edits[0].SetValue(g_Reg->INDEX_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[1].SetValue(g_Reg->RANDOM_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[2].SetValue(g_Reg->ENTRYLO0_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[3].SetValue(g_Reg->ENTRYLO1_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[4].SetValue(g_Reg->CONTEXT_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[5].SetValue(g_Reg->PAGE_MASK_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[6].SetValue(g_Reg->WIRED_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[7].SetValue(g_Reg->BAD_VADDR_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[8].SetValue(g_Reg->COUNT_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[9].SetValue(g_Reg->ENTRYHI_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[10].SetValue(g_Reg->COMPARE_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[11].SetValue(g_Reg->STATUS_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[12].SetValue(g_Reg->CAUSE_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[13].SetValue(g_Reg->EPC_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[14].SetValue(g_Reg->CONFIG_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[15].SetValue(g_Reg->TAGLO_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[16].SetValue(g_Reg->TAGHI_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[17].SetValue(g_Reg->ERROREPC_REGISTER, DisplayMode::ZeroExtend);
+    m_COP0Edits[18].SetValue(g_Reg->FAKE_CAUSE_REGISTER, DisplayMode::ZeroExtend);
 
     CAUSE cause;
     cause.intval = g_Reg->CAUSE_REGISTER;
@@ -168,110 +168,110 @@ void CRegisterTabs::RefreshEdits()
     const char* szExceptionCode = ExceptionCodes[cause.exceptionCode];
     m_CauseTip.SetWindowTextA(szExceptionCode);
 
-    m_RDRAMEdits[0].SetValue(g_Reg->RDRAM_CONFIG_REG, false, true); // or device type
-    m_RDRAMEdits[1].SetValue(g_Reg->RDRAM_DEVICE_ID_REG, false, true);
-    m_RDRAMEdits[2].SetValue(g_Reg->RDRAM_DELAY_REG, false, true);
-    m_RDRAMEdits[3].SetValue(g_Reg->RDRAM_MODE_REG, false, true);
-    m_RDRAMEdits[4].SetValue(g_Reg->RDRAM_REF_INTERVAL_REG, false, true);
-    m_RDRAMEdits[5].SetValue(g_Reg->RDRAM_REF_ROW_REG, false, true);
-    m_RDRAMEdits[6].SetValue(g_Reg->RDRAM_RAS_INTERVAL_REG, false, true);
-    m_RDRAMEdits[7].SetValue(g_Reg->RDRAM_MIN_INTERVAL_REG, false, true);
-    m_RDRAMEdits[8].SetValue(g_Reg->RDRAM_ADDR_SELECT_REG, false, true);
-    m_RDRAMEdits[9].SetValue(g_Reg->RDRAM_DEVICE_MANUF_REG, false, true);
+    m_RDRAMEdits[0].SetValue(g_Reg->RDRAM_CONFIG_REG, DisplayMode::ZeroExtend); // or device type
+    m_RDRAMEdits[1].SetValue(g_Reg->RDRAM_DEVICE_ID_REG, DisplayMode::ZeroExtend);
+    m_RDRAMEdits[2].SetValue(g_Reg->RDRAM_DELAY_REG, DisplayMode::ZeroExtend);
+    m_RDRAMEdits[3].SetValue(g_Reg->RDRAM_MODE_REG, DisplayMode::ZeroExtend);
+    m_RDRAMEdits[4].SetValue(g_Reg->RDRAM_REF_INTERVAL_REG, DisplayMode::ZeroExtend);
+    m_RDRAMEdits[5].SetValue(g_Reg->RDRAM_REF_ROW_REG, DisplayMode::ZeroExtend);
+    m_RDRAMEdits[6].SetValue(g_Reg->RDRAM_RAS_INTERVAL_REG, DisplayMode::ZeroExtend);
+    m_RDRAMEdits[7].SetValue(g_Reg->RDRAM_MIN_INTERVAL_REG, DisplayMode::ZeroExtend);
+    m_RDRAMEdits[8].SetValue(g_Reg->RDRAM_ADDR_SELECT_REG, DisplayMode::ZeroExtend);
+    m_RDRAMEdits[9].SetValue(g_Reg->RDRAM_DEVICE_MANUF_REG, DisplayMode::ZeroExtend);
 
-    m_SPEdits[0].SetValue(g_Reg->SP_MEM_ADDR_REG, false, true);
-    m_SPEdits[1].SetValue(g_Reg->SP_DRAM_ADDR_REG, false, true);
-    m_SPEdits[2].SetValue(g_Reg->SP_RD_LEN_REG, false, true);
-    m_SPEdits[3].SetValue(g_Reg->SP_WR_LEN_REG, false, true);
-    m_SPEdits[4].SetValue(g_Reg->SP_STATUS_REG, false, true);
-    m_SPEdits[5].SetValue(g_Reg->SP_DMA_FULL_REG, false, true);
-    m_SPEdits[6].SetValue(g_Reg->SP_DMA_BUSY_REG, false, true);
-    m_SPEdits[7].SetValue(g_Reg->SP_SEMAPHORE_REG, false, true);
-    m_SPPCEdit.SetValue(g_Reg->SP_PC_REG, false, true);
+    m_SPEdits[0].SetValue(g_Reg->SP_MEM_ADDR_REG, DisplayMode::ZeroExtend);
+    m_SPEdits[1].SetValue(g_Reg->SP_DRAM_ADDR_REG, DisplayMode::ZeroExtend);
+    m_SPEdits[2].SetValue(g_Reg->SP_RD_LEN_REG, DisplayMode::ZeroExtend);
+    m_SPEdits[3].SetValue(g_Reg->SP_WR_LEN_REG, DisplayMode::ZeroExtend);
+    m_SPEdits[4].SetValue(g_Reg->SP_STATUS_REG, DisplayMode::ZeroExtend);
+    m_SPEdits[5].SetValue(g_Reg->SP_DMA_FULL_REG, DisplayMode::ZeroExtend);
+    m_SPEdits[6].SetValue(g_Reg->SP_DMA_BUSY_REG, DisplayMode::ZeroExtend);
+    m_SPEdits[7].SetValue(g_Reg->SP_SEMAPHORE_REG, DisplayMode::ZeroExtend);
+    m_SPPCEdit.SetValue(g_Reg->SP_PC_REG, DisplayMode::ZeroExtend);
 
-    m_DPCEdits[0].SetValue(g_Reg->DPC_START_REG, false, true);
-    m_DPCEdits[1].SetValue(g_Reg->DPC_END_REG, false, true);
-    m_DPCEdits[2].SetValue(g_Reg->DPC_CURRENT_REG, false, true);
-    m_DPCEdits[3].SetValue(g_Reg->DPC_STATUS_REG, false, true);
-    m_DPCEdits[4].SetValue(g_Reg->DPC_CLOCK_REG, false, true);
-    m_DPCEdits[5].SetValue(g_Reg->DPC_BUFBUSY_REG, false, true);
-    m_DPCEdits[6].SetValue(g_Reg->DPC_PIPEBUSY_REG, false, true);
-    m_DPCEdits[7].SetValue(g_Reg->DPC_TMEM_REG, false, true);
+    m_DPCEdits[0].SetValue(g_Reg->DPC_START_REG, DisplayMode::ZeroExtend);
+    m_DPCEdits[1].SetValue(g_Reg->DPC_END_REG, DisplayMode::ZeroExtend);
+    m_DPCEdits[2].SetValue(g_Reg->DPC_CURRENT_REG, DisplayMode::ZeroExtend);
+    m_DPCEdits[3].SetValue(g_Reg->DPC_STATUS_REG, DisplayMode::ZeroExtend);
+    m_DPCEdits[4].SetValue(g_Reg->DPC_CLOCK_REG, DisplayMode::ZeroExtend);
+    m_DPCEdits[5].SetValue(g_Reg->DPC_BUFBUSY_REG, DisplayMode::ZeroExtend);
+    m_DPCEdits[6].SetValue(g_Reg->DPC_PIPEBUSY_REG, DisplayMode::ZeroExtend);
+    m_DPCEdits[7].SetValue(g_Reg->DPC_TMEM_REG, DisplayMode::ZeroExtend);
 
-    m_MIEdits[0].SetValue(g_Reg->MI_INIT_MODE_REG, false, true);
-    m_MIEdits[1].SetValue(g_Reg->MI_VERSION_REG, false, true);
-    m_MIEdits[2].SetValue(g_Reg->MI_INTR_REG, false, true);
-    m_MIEdits[3].SetValue(g_Reg->MI_INTR_MASK_REG, false, true);
+    m_MIEdits[0].SetValue(g_Reg->MI_INIT_MODE_REG, DisplayMode::ZeroExtend);
+    m_MIEdits[1].SetValue(g_Reg->MI_VERSION_REG, DisplayMode::ZeroExtend);
+    m_MIEdits[2].SetValue(g_Reg->MI_INTR_REG, DisplayMode::ZeroExtend);
+    m_MIEdits[3].SetValue(g_Reg->MI_INTR_MASK_REG, DisplayMode::ZeroExtend);
 
-    m_VIEdits[0].SetValue(g_Reg->VI_STATUS_REG, false, true);
-    m_VIEdits[1].SetValue(g_Reg->VI_ORIGIN_REG, false, true);
-    m_VIEdits[2].SetValue(g_Reg->VI_WIDTH_REG, false, true);
-    m_VIEdits[3].SetValue(g_Reg->VI_INTR_REG, false, true);
-    m_VIEdits[4].SetValue(g_Reg->VI_CURRENT_REG, false, true);
-    m_VIEdits[5].SetValue(g_Reg->VI_BURST_REG, false, true);
-    m_VIEdits[6].SetValue(g_Reg->VI_V_SYNC_REG, false, true);
-    m_VIEdits[7].SetValue(g_Reg->VI_H_SYNC_REG, false, true);
-    m_VIEdits[8].SetValue(g_Reg->VI_LEAP_REG, false, true);
-    m_VIEdits[9].SetValue(g_Reg->VI_H_START_REG, false, true);
-    m_VIEdits[10].SetValue(g_Reg->VI_V_START_REG, false, true);
-    m_VIEdits[11].SetValue(g_Reg->VI_V_BURST_REG, false, true);
-    m_VIEdits[12].SetValue(g_Reg->VI_X_SCALE_REG, false, true);
-    m_VIEdits[13].SetValue(g_Reg->VI_Y_SCALE_REG, false, true);
+    m_VIEdits[0].SetValue(g_Reg->VI_STATUS_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[1].SetValue(g_Reg->VI_ORIGIN_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[2].SetValue(g_Reg->VI_WIDTH_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[3].SetValue(g_Reg->VI_INTR_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[4].SetValue(g_Reg->VI_CURRENT_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[5].SetValue(g_Reg->VI_BURST_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[6].SetValue(g_Reg->VI_V_SYNC_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[7].SetValue(g_Reg->VI_H_SYNC_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[8].SetValue(g_Reg->VI_LEAP_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[9].SetValue(g_Reg->VI_H_START_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[10].SetValue(g_Reg->VI_V_START_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[11].SetValue(g_Reg->VI_V_BURST_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[12].SetValue(g_Reg->VI_X_SCALE_REG, DisplayMode::ZeroExtend);
+    m_VIEdits[13].SetValue(g_Reg->VI_Y_SCALE_REG, DisplayMode::ZeroExtend);
 
-    m_AIEdits[0].SetValue(g_Reg->AI_DRAM_ADDR_REG, false, true);
-    m_AIEdits[1].SetValue(g_Reg->AI_LEN_REG, false, true);
-    m_AIEdits[2].SetValue(g_Reg->AI_CONTROL_REG, false, true);
-    m_AIEdits[3].SetValue(g_Reg->AI_STATUS_REG, false, true);
-    m_AIEdits[4].SetValue(g_Reg->AI_DACRATE_REG, false, true);
-    m_AIEdits[5].SetValue(g_Reg->AI_BITRATE_REG, false, true);
+    m_AIEdits[0].SetValue(g_Reg->AI_DRAM_ADDR_REG, DisplayMode::ZeroExtend);
+    m_AIEdits[1].SetValue(g_Reg->AI_LEN_REG, DisplayMode::ZeroExtend);
+    m_AIEdits[2].SetValue(g_Reg->AI_CONTROL_REG, DisplayMode::ZeroExtend);
+    m_AIEdits[3].SetValue(g_Reg->AI_STATUS_REG, DisplayMode::ZeroExtend);
+    m_AIEdits[4].SetValue(g_Reg->AI_DACRATE_REG, DisplayMode::ZeroExtend);
+    m_AIEdits[5].SetValue(g_Reg->AI_BITRATE_REG, DisplayMode::ZeroExtend);
 
-    m_PIEdits[0].SetValue(g_Reg->PI_DRAM_ADDR_REG, false, true);
-    m_PIEdits[1].SetValue(g_Reg->PI_CART_ADDR_REG, false, true);
-    m_PIEdits[2].SetValue(g_Reg->PI_RD_LEN_REG, false, true);
-    m_PIEdits[3].SetValue(g_Reg->PI_WR_LEN_REG, false, true);
-    m_PIEdits[4].SetValue(g_Reg->PI_STATUS_REG, false, true);
-    m_PIEdits[5].SetValue(g_Reg->PI_BSD_DOM1_LAT_REG, false, true);
-    m_PIEdits[6].SetValue(g_Reg->PI_BSD_DOM1_PWD_REG, false, true);
-    m_PIEdits[7].SetValue(g_Reg->PI_BSD_DOM1_PGS_REG, false, true);
-    m_PIEdits[8].SetValue(g_Reg->PI_BSD_DOM1_RLS_REG, false, true);
-    m_PIEdits[9].SetValue(g_Reg->PI_BSD_DOM2_LAT_REG, false, true);
-    m_PIEdits[10].SetValue(g_Reg->PI_BSD_DOM2_PWD_REG, false, true);
-    m_PIEdits[11].SetValue(g_Reg->PI_BSD_DOM2_PGS_REG, false, true);
-    m_PIEdits[12].SetValue(g_Reg->PI_BSD_DOM2_RLS_REG, false, true);
+    m_PIEdits[0].SetValue(g_Reg->PI_DRAM_ADDR_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[1].SetValue(g_Reg->PI_CART_ADDR_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[2].SetValue(g_Reg->PI_RD_LEN_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[3].SetValue(g_Reg->PI_WR_LEN_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[4].SetValue(g_Reg->PI_STATUS_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[5].SetValue(g_Reg->PI_BSD_DOM1_LAT_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[6].SetValue(g_Reg->PI_BSD_DOM1_PWD_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[7].SetValue(g_Reg->PI_BSD_DOM1_PGS_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[8].SetValue(g_Reg->PI_BSD_DOM1_RLS_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[9].SetValue(g_Reg->PI_BSD_DOM2_LAT_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[10].SetValue(g_Reg->PI_BSD_DOM2_PWD_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[11].SetValue(g_Reg->PI_BSD_DOM2_PGS_REG, DisplayMode::ZeroExtend);
+    m_PIEdits[12].SetValue(g_Reg->PI_BSD_DOM2_RLS_REG, DisplayMode::ZeroExtend);
 
-    m_RIEdits[0].SetValue(g_Reg->RI_MODE_REG, false, true);
-    m_RIEdits[1].SetValue(g_Reg->RI_CONFIG_REG, false, true);
-    m_RIEdits[2].SetValue(g_Reg->RI_CURRENT_LOAD_REG, false, true);
-    m_RIEdits[3].SetValue(g_Reg->RI_SELECT_REG, false, true);
-    m_RIEdits[4].SetValue(g_Reg->RI_REFRESH_REG, false, true); // or ri count
-    m_RIEdits[5].SetValue(g_Reg->RI_LATENCY_REG, false, true);
-    m_RIEdits[6].SetValue(g_Reg->RI_RERROR_REG, false, true);
-    m_RIEdits[7].SetValue(g_Reg->RI_WERROR_REG, false, true);
+    m_RIEdits[0].SetValue(g_Reg->RI_MODE_REG, DisplayMode::ZeroExtend);
+    m_RIEdits[1].SetValue(g_Reg->RI_CONFIG_REG, DisplayMode::ZeroExtend);
+    m_RIEdits[2].SetValue(g_Reg->RI_CURRENT_LOAD_REG, DisplayMode::ZeroExtend);
+    m_RIEdits[3].SetValue(g_Reg->RI_SELECT_REG, DisplayMode::ZeroExtend);
+    m_RIEdits[4].SetValue(g_Reg->RI_REFRESH_REG, DisplayMode::ZeroExtend); // or ri count
+    m_RIEdits[5].SetValue(g_Reg->RI_LATENCY_REG, DisplayMode::ZeroExtend);
+    m_RIEdits[6].SetValue(g_Reg->RI_RERROR_REG, DisplayMode::ZeroExtend);
+    m_RIEdits[7].SetValue(g_Reg->RI_WERROR_REG, DisplayMode::ZeroExtend);
 
-    m_SIEdits[0].SetValue(g_Reg->SI_DRAM_ADDR_REG, false, true);
-    m_SIEdits[1].SetValue(g_Reg->SI_PIF_ADDR_RD64B_REG, false, true);
-    m_SIEdits[2].SetValue(g_Reg->SI_PIF_ADDR_WR64B_REG, false, true);
-    m_SIEdits[3].SetValue(g_Reg->SI_STATUS_REG, false, true);
+    m_SIEdits[0].SetValue(g_Reg->SI_DRAM_ADDR_REG, DisplayMode::ZeroExtend);
+    m_SIEdits[1].SetValue(g_Reg->SI_PIF_ADDR_RD64B_REG, DisplayMode::ZeroExtend);
+    m_SIEdits[2].SetValue(g_Reg->SI_PIF_ADDR_WR64B_REG, DisplayMode::ZeroExtend);
+    m_SIEdits[3].SetValue(g_Reg->SI_STATUS_REG, DisplayMode::ZeroExtend);
 
-    m_DDEdits[0].SetValue(g_Reg->ASIC_DATA, false, true);
-    m_DDEdits[1].SetValue(g_Reg->ASIC_MISC_REG, false, true);
-    m_DDEdits[2].SetValue(g_Reg->ASIC_STATUS, false, true);
-    m_DDEdits[3].SetValue(g_Reg->ASIC_CUR_TK, false, true);
-    m_DDEdits[4].SetValue(g_Reg->ASIC_BM_STATUS, false, true);
-    m_DDEdits[5].SetValue(g_Reg->ASIC_ERR_SECTOR, false, true);
-    m_DDEdits[6].SetValue(g_Reg->ASIC_SEQ_STATUS, false, true);
-    m_DDEdits[7].SetValue(g_Reg->ASIC_CUR_SECTOR, false, true);
-    m_DDEdits[8].SetValue(g_Reg->ASIC_HARD_RESET, false, true);
-    m_DDEdits[9].SetValue(g_Reg->ASIC_C1_S0, false, true);
-    m_DDEdits[10].SetValue(g_Reg->ASIC_HOST_SECBYTE, false, true);
-    m_DDEdits[11].SetValue(g_Reg->ASIC_C1_S2, false, true);
-    m_DDEdits[12].SetValue(g_Reg->ASIC_SEC_BYTE, false, true);
-    m_DDEdits[13].SetValue(g_Reg->ASIC_C1_S4, false, true);
-    m_DDEdits[14].SetValue(g_Reg->ASIC_C1_S6, false, true);
-    m_DDEdits[15].SetValue(g_Reg->ASIC_CUR_ADDR, false, true);
-    m_DDEdits[16].SetValue(g_Reg->ASIC_ID_REG, false, true);
-    m_DDEdits[17].SetValue(g_Reg->ASIC_TEST_REG, false, true);
-    m_DDEdits[18].SetValue(g_Reg->ASIC_TEST_PIN_SEL, false, true);
+    m_DDEdits[0].SetValue(g_Reg->ASIC_DATA, DisplayMode::ZeroExtend);
+    m_DDEdits[1].SetValue(g_Reg->ASIC_MISC_REG, DisplayMode::ZeroExtend);
+    m_DDEdits[2].SetValue(g_Reg->ASIC_STATUS, DisplayMode::ZeroExtend);
+    m_DDEdits[3].SetValue(g_Reg->ASIC_CUR_TK, DisplayMode::ZeroExtend);
+    m_DDEdits[4].SetValue(g_Reg->ASIC_BM_STATUS, DisplayMode::ZeroExtend);
+    m_DDEdits[5].SetValue(g_Reg->ASIC_ERR_SECTOR, DisplayMode::ZeroExtend);
+    m_DDEdits[6].SetValue(g_Reg->ASIC_SEQ_STATUS, DisplayMode::ZeroExtend);
+    m_DDEdits[7].SetValue(g_Reg->ASIC_CUR_SECTOR, DisplayMode::ZeroExtend);
+    m_DDEdits[8].SetValue(g_Reg->ASIC_HARD_RESET, DisplayMode::ZeroExtend);
+    m_DDEdits[9].SetValue(g_Reg->ASIC_C1_S0, DisplayMode::ZeroExtend);
+    m_DDEdits[10].SetValue(g_Reg->ASIC_HOST_SECBYTE, DisplayMode::ZeroExtend);
+    m_DDEdits[11].SetValue(g_Reg->ASIC_C1_S2, DisplayMode::ZeroExtend);
+    m_DDEdits[12].SetValue(g_Reg->ASIC_SEC_BYTE, DisplayMode::ZeroExtend);
+    m_DDEdits[13].SetValue(g_Reg->ASIC_C1_S4, DisplayMode::ZeroExtend);
+    m_DDEdits[14].SetValue(g_Reg->ASIC_C1_S6, DisplayMode::ZeroExtend);
+    m_DDEdits[15].SetValue(g_Reg->ASIC_CUR_ADDR, DisplayMode::ZeroExtend);
+    m_DDEdits[16].SetValue(g_Reg->ASIC_ID_REG, DisplayMode::ZeroExtend);
+    m_DDEdits[17].SetValue(g_Reg->ASIC_TEST_REG, DisplayMode::ZeroExtend);
+    m_DDEdits[18].SetValue(g_Reg->ASIC_TEST_PIN_SEL, DisplayMode::ZeroExtend);
 }
 
 void CRegisterTabs::RegisterChanged(HWND hDlg, TAB_ID srcTabId, WPARAM wParam)
@@ -817,7 +817,7 @@ void CRegisterTabs::InitRegisterEdits64(CWindow& tab, CEditReg64* edits, const W
 
 void CRegisterTabs::ZeroRegisterEdit(CEditNumber32& edit)
 {
-    edit.SetValue(0, false, true);
+    edit.SetValue(0, DisplayMode::ZeroExtend);
 }
 
 void CRegisterTabs::ZeroRegisterEdits(CEditNumber32* edits, uint32_t ctrlIdsCount)

--- a/Source/Project64/UserInterface/Debugger/Debugger-ViewMemory.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-ViewMemory.cpp
@@ -233,7 +233,7 @@ void CDebugMemoryView::JumpToSelection(void)
     uint32_t startAddress, endAddress;
     bool bHaveSelection = m_HexEditCtrl.GetSelectionRange(&startAddress, &endAddress);
     uint32_t targetAddress = bHaveSelection ? startAddress : m_HexEditCtrl.GetCaretAddress();
-    m_MemAddr.SetValue(targetAddress, false, true);
+    m_MemAddr.SetValue(targetAddress, DisplayMode::ZeroExtend);
 }
 
 bool CDebugMemoryView::GetSafeEditValue(uint32_t address, uint8_t* value)
@@ -340,7 +340,7 @@ LRESULT CDebugMemoryView::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM 
     }
 
     m_MemAddr.SetDisplayType(CEditNumber32::DisplayHex);
-    m_MemAddr.SetValue(0x80000000, false, true);
+    m_MemAddr.SetValue(0x80000000, DisplayMode::ZeroExtend);
 
     m_VirtualCheckbox.SetCheck(BST_CHECKED);
 
@@ -521,19 +521,19 @@ void CDebugMemoryView::OnVScroll(UINT nSBCode, UINT nPos, CScrollBar pScrollBar)
     switch (nSBCode)
     {
     case SB_LINEDOWN:
-        m_MemAddr.SetValue(address < 0xFFFFFFEF ? address + numBytesPerRow : 0xFFFFFFFF, false, true);
+        m_MemAddr.SetValue(address < 0xFFFFFFEF ? address + numBytesPerRow : 0xFFFFFFFF, DisplayMode::ZeroExtend);
         break;
     case SB_LINEUP:
-        m_MemAddr.SetValue(address > (uint32_t)numBytesPerRow ? address - numBytesPerRow : 0, false, true);
+        m_MemAddr.SetValue(address > (uint32_t)numBytesPerRow ? address - numBytesPerRow : 0, DisplayMode::ZeroExtend);
         break;
     case SB_PAGEDOWN:
-        m_MemAddr.SetValue(address < 0xFFFFFEFF ? address + numVisibleBytes : 0xFFFFFFFF, false, true);
+        m_MemAddr.SetValue(address < 0xFFFFFEFF ? address + numVisibleBytes : 0xFFFFFFFF, DisplayMode::ZeroExtend);
         break;
     case SB_PAGEUP:
-        m_MemAddr.SetValue(address >(uint32_t)numVisibleBytes ? address - numVisibleBytes : 0, false, true);
+        m_MemAddr.SetValue(address >(uint32_t)numVisibleBytes ? address - numVisibleBytes : 0, DisplayMode::ZeroExtend);
         break;
     case SB_THUMBPOSITION:
-        m_MemAddr.SetValue((DWORD)nPos << 0x10, false, true);
+        m_MemAddr.SetValue((DWORD)nPos << 0x10, DisplayMode::ZeroExtend);
         break;
     default:
         break;
@@ -951,7 +951,7 @@ LRESULT CDebugMemoryView::OnHxBaseAddrChanged(LPNMHDR /*lpNMHDR*/)
     // address was updated from the control
     uint32_t address = m_HexEditCtrl.GetBaseAddress();
     m_bIgnoreAddressInput = true;
-    m_MemAddr.SetValue(address, false, true);
+    m_MemAddr.SetValue(address, DisplayMode::ZeroExtend);
     m_CmbJump.SetCurSel(GetJumpItemIndex(address, m_bVirtualMemory));
     UpdateCurrentTab(address);
     return FALSE;
@@ -1037,7 +1037,7 @@ void CDebugMemoryView::TabSelChanged(void)
         tab_info_t tabInfo = m_TabData[nItem];
         uint32_t address = tabInfo.address;
         
-        m_MemAddr.SetValue(address, false, true);
+        m_MemAddr.SetValue(address, DisplayMode::ZeroExtend);
 
         if (m_bVirtualMemory != tabInfo.bVirtual)
         {
@@ -1242,6 +1242,6 @@ void CDebugMemoryView::OnJumpComboSelChange(UINT /*uNotifyCode*/, int /*nID*/, C
         address = JumpItems[nItem].paddr;
     }
     
-    m_MemAddr.SetValue(address, false, true);
+    m_MemAddr.SetValue(address, DisplayMode::ZeroExtend);
     m_HexEditCtrl.SetFocus();
 }

--- a/Source/Project64/UserInterface/WTLControls/DisplayMode.h
+++ b/Source/Project64/UserInterface/WTLControls/DisplayMode.h
@@ -1,0 +1,63 @@
+/****************************************************************************
+*                                                                           *
+* Project64 - A Nintendo 64 emulator.                                      *
+* http://www.pj64-emu.com/                                                  *
+* Copyright (C) 2012 Project64. All rights reserved.                        *
+*                                                                           *
+* License:                                                                  *
+* GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
+*                                                                           *
+****************************************************************************/
+#pragma once
+
+#include <type_traits>
+
+enum class DisplayMode
+{
+    None = 0,
+    ShowHexIdent = 1 << 0,
+    ZeroExtend = 1 << 1,
+    AllHex = ShowHexIdent | ZeroExtend,
+};
+
+inline DisplayMode operator |(DisplayMode lhs, DisplayMode rhs)
+{
+    using T = std::underlying_type<DisplayMode>::type;
+    return static_cast<DisplayMode>(static_cast<T>(lhs) | static_cast<T>(rhs));
+}
+
+inline DisplayMode& operator |=(DisplayMode& lhs, DisplayMode rhs)
+{
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+inline DisplayMode operator &(DisplayMode lhs, DisplayMode rhs)
+{
+    using T = std::underlying_type<DisplayMode>::type;
+    return static_cast<DisplayMode>(static_cast<T>(lhs) & static_cast<T>(rhs));
+}
+
+inline DisplayMode& operator &=(DisplayMode& lhs, DisplayMode rhs)
+{
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+inline DisplayMode operator ^(DisplayMode lhs, DisplayMode rhs)
+{
+    using T = std::underlying_type<DisplayMode>::type;
+    return static_cast<DisplayMode>((static_cast<T>(lhs) ^ static_cast<T>(rhs)) & static_cast<T>(DisplayMode::AllHex));
+}
+
+inline DisplayMode& operator ^=(DisplayMode& lhs, DisplayMode rhs)
+{
+    lhs = lhs ^ rhs;
+    return lhs;
+}
+
+inline DisplayMode operator ~(DisplayMode lhs)
+{
+    using T = std::underlying_type<DisplayMode>::type;
+    return static_cast<DisplayMode>(~static_cast<T>(lhs) & static_cast<T>(DisplayMode::AllHex));
+}

--- a/Source/Project64/UserInterface/WTLControls/EditNumber32.cpp
+++ b/Source/Project64/UserInterface/WTLControls/EditNumber32.cpp
@@ -332,7 +332,7 @@ uint32_t CEditNumber32::GetValue(void)
     return Value;
 }
 
-void CEditNumber32::SetValue(uint32_t Value, bool ShowHexIdent, bool ZeroExtend)
+void CEditNumber32::SetValue(uint32_t Value, DisplayMode Display)
 {
     char text[200];
     if (m_DisplayType == DisplayDec)
@@ -341,7 +341,12 @@ void CEditNumber32::SetValue(uint32_t Value, bool ShowHexIdent, bool ZeroExtend)
     }
     else
     {
-        sprintf(text, "%s%0*X", ShowHexIdent ? "0x" : "", ZeroExtend ? 8 : 0, Value);
+        sprintf(
+            text,
+            "%s%0*X",
+            (Display & DisplayMode::ShowHexIdent) == DisplayMode::ShowHexIdent ? "0x" : "",
+            (Display & DisplayMode::ZeroExtend) == DisplayMode::ZeroExtend ? 8 : 0,
+            Value);
     }
     SetWindowText(text);
 }

--- a/Source/Project64/UserInterface/WTLControls/EditNumber32.h
+++ b/Source/Project64/UserInterface/WTLControls/EditNumber32.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <wtl/atlctrls.h>
+#include "DisplayMode.h"
 
 class CEditNumber32 :
     public CWindowImpl<CEditNumber32, CEdit>
@@ -29,7 +30,7 @@ public:
     BOOL AttachToDlgItem(HWND parent, UINT dlgID);
     void SetDisplayType(DisplayType Type);
     uint32_t GetValue(void);
-    void SetValue(uint32_t Value, bool ShowHexIdent = true, bool ZeroExtend = false);
+    void SetValue(uint32_t Value, DisplayMode Display = DisplayMode::ShowHexIdent);
 
 protected:
     enum


### PR DESCRIPTION
This change makes it easier to understand what's going on at the call sites and makes it harder to screw up your intent. If there were changes to formatting (say, adding zero-padding for decimal) in the future, this would also be able to better accommodate the changes.

The defaults seem dubious as well, but those were left alone.