### PR TITLE
Added Vector2, Vector3, and Vector4 to symbols and memory view

### DIFF
--- a/Source/Project64/UserInterface/Debugger/Debugger-Symbols.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Symbols.cpp
@@ -29,6 +29,9 @@ const CSetValueDlg::ComboItem CDebugSymbols::ModalChangeTypeItems[] = {
     { "int64",  SYM_S64 },
     { "float",  SYM_FLOAT },
     { "double", SYM_DOUBLE },
+    { "v2", SYM_VECTOR2 },
+    { "v3", SYM_VECTOR3 },
+    { "v4", SYM_VECTOR4 },
     { NULL, 0 }
 };
 
@@ -189,7 +192,9 @@ LRESULT    CDebugSymbols::OnListDblClicked(NMHDR* pNMHDR)
         }
         break;
     case SymbolsListView_Col_Value:
-        char szValue[64];
+        char szValue[256];
+        char* x;
+        char* y;
         m_Debugger->SymbolTable()->GetValueString(szValue, &symbol);
         if (m_SetValueDlg.DoModal("Change value", "New value:", szValue))
         {
@@ -225,6 +230,51 @@ LRESULT    CDebugSymbols::OnListDblClicked(NMHDR* pNMHDR)
             case SYM_DOUBLE:
                 m_Debugger->DebugStore_VAddr<double>(symbol.m_Address, atof(m_SetValueDlg.GetEnteredString()));
                 break;
+            case SYM_VECTOR2:
+                x = m_SetValueDlg.GetEnteredString();
+                y = strchr(x, ',');
+                memcpy(szValue, x, y - x);
+                m_Debugger->DebugStore_VAddr<float>(symbol.m_Address, atof(szValue));
+
+                x = x + (y - x) + 1;
+                memcpy(szValue, x, strlen(x));
+                m_Debugger->DebugStore_VAddr<float>(symbol.m_Address + sizeof(float), atof(szValue));
+                break;
+            case SYM_VECTOR3:
+                x = m_SetValueDlg.GetEnteredString();
+                y = strchr(x, ',');
+                memcpy(szValue, x, y - x);
+                m_Debugger->DebugStore_VAddr<float>(symbol.m_Address, atof(szValue));
+
+                x = x + (y - x) + 1;
+                y = strchr(x, ',');
+                memcpy(szValue, x, y - x);
+                m_Debugger->DebugStore_VAddr<float>(symbol.m_Address + sizeof(float), atof(szValue));
+
+                x = x + (y - x) + 1;
+                memcpy(szValue, x, strlen(x));
+                m_Debugger->DebugStore_VAddr<float>(symbol.m_Address + (sizeof(float) * 2), atof(szValue));
+                break;
+            case SYM_VECTOR4:
+                x = m_SetValueDlg.GetEnteredString();
+                y = strchr(x, ',');
+                memcpy(szValue, x, y - x);
+                m_Debugger->DebugStore_VAddr<float>(symbol.m_Address, atof(szValue));
+
+                x = x + (y - x) + 1;
+                y = strchr(x, ',');
+                memcpy(szValue, x, y - x);
+                m_Debugger->DebugStore_VAddr<float>(symbol.m_Address + sizeof(float), atof(szValue));
+
+                x = x + (y - x) + 1;
+                y = strchr(x, ',');
+                memcpy(szValue, x, y - x);
+                m_Debugger->DebugStore_VAddr<float>(symbol.m_Address + (sizeof(float) * 2), atof(szValue));
+
+                x = x + (y - x) + 1;
+                memcpy(szValue, x, strlen(x));
+                m_Debugger->DebugStore_VAddr<float>(symbol.m_Address + (sizeof(float) * 3), atof(szValue));
+                break;
             }
         }
         break;
@@ -258,7 +308,7 @@ void CDebugSymbols::Refresh()
 
     while (m_Debugger->SymbolTable()->GetSymbolByIndex(nItem, &symbol))
     {
-        char szValue[64];
+        char szValue[256];
         m_Debugger->SymbolTable()->GetValueString(szValue, &symbol);
 
         stdstr strAddr = stdstr_f("%08X", symbol.m_Address);
@@ -296,7 +346,7 @@ void CDebugSymbols::RefreshValues()
             break;
         }
 
-        char szValue[64];
+        char szValue[256];
         m_Debugger->SymbolTable()->GetValueString(szValue, &symbol);
 
         m_SymbolsListView.SetItemText(i, 3, szValue);

--- a/Source/Project64/UserInterface/Debugger/Symbols.cpp
+++ b/Source/Project64/UserInterface/Debugger/Symbols.cpp
@@ -44,6 +44,9 @@ symbol_type_info_t CSymbolTable::m_SymbolTypes[] = {
     { SYM_S64,    "s64",    8 },
     { SYM_FLOAT,  "float",  4 },
     { SYM_DOUBLE, "double", 8 },
+    { SYM_VECTOR2, "v2", 8 },
+    { SYM_VECTOR3, "v3", 12 },
+    { SYM_VECTOR4, "v4", 16 },
     { SYM_INVALID, NULL,    0 }
 };
 
@@ -310,6 +313,7 @@ void CSymbolTable::GetValueString(char* dst, CSymbol* symbol)
 
     uint32_t address = symbol->m_Address;
 
+    float xyzw[4];
     switch (symbol->m_Type)
     {
     case SYM_CODE:
@@ -355,6 +359,27 @@ void CSymbolTable::GetValueString(char* dst, CSymbol* symbol)
     case SYM_DOUBLE:
         m_Debugger->DebugLoad_VAddr(address, value.f64);
         sprintf(dst, "%f", value.f64);
+        break;
+    case SYM_VECTOR2:
+        for (int i = 0; i < 2; i++) {
+            m_Debugger->DebugLoad_VAddr(address, value.f32);
+            xyzw[i] = value.f32;
+        }
+        sprintf(dst, "%f, %f", xyzw[0], xyzw[2]);
+        break;
+    case SYM_VECTOR3:
+        for (int i = 0; i < 3; i++) {
+            m_Debugger->DebugLoad_VAddr(address, value.f32);
+            xyzw[i] = value.f32;
+        }
+        sprintf(dst, "%f, %f, %f", xyzw[0], xyzw[2], xyzw[3]);
+        break;
+    case SYM_VECTOR4:
+        for (int i = 0; i < 4; i++) {
+            m_Debugger->DebugLoad_VAddr(address, value.f32);
+            xyzw[i] = value.f32;
+        }
+        sprintf(dst, "%f, %f, %f, %f", xyzw[0], xyzw[2], xyzw[3], xyzw[4]);
         break;
     default:
         g_Notify->BreakPoint(__FILE__, __LINE__);

--- a/Source/Project64/UserInterface/Debugger/Symbols.h
+++ b/Source/Project64/UserInterface/Debugger/Symbols.h
@@ -27,6 +27,9 @@ typedef enum {
     SYM_S64,
     SYM_FLOAT,
     SYM_DOUBLE,
+    SYM_VECTOR2,
+    SYM_VECTOR3,
+    SYM_VECTOR4,
     NUM_SYM_TYPES
 } symbol_type_id_t;
 


### PR DESCRIPTION
When documenting a large amount of information, I found that the symbols window would become unreadable in large part due to the fact that storing x, y, z, w values individually takes that much more space. This modification has greatly improved readability for me, and I think that others would be interested in having it as well. Furthermore, on this note, are there any other data-types that could be useful to have?