### PR TITLE
[Disk] Introduce Seek Times

### DIFF
--- a/Source/Project64-core/N64System/Mips/Disk.cpp
+++ b/Source/Project64-core/N64System/Mips/Disk.cpp
@@ -108,7 +108,7 @@ void DiskCommand()
     if (isSeek)
     {
         //Emulate Seek Times, send interrupt later
-        uint32_t seektime = 0x179200;
+        uint32_t seektime = 0;
 
         //Start Motor, can take half a second, delay the response
         if (g_Reg->ASIC_STATUS & DD_STATUS_MTR_N_SPIN)
@@ -133,35 +133,26 @@ void DiskCommand()
             }
         }
 
-        //Add delay depending on the zone
+        //Add seek delay depending on the zone (this is inaccurate timing, but close enough)
+        seektime += 0x179200;
+
         switch (zone)
         {
         case 0:
-        default:
-            break;
         case 1:
-            seektime += 0x1900;
+        default:
+            seektime += track * 38;
             break;
         case 2:
-            seektime += 0x2A00;
-            break;
         case 3:
-            seektime += 0x4500;
-            break;
         case 4:
-            seektime += 0x5E00;
-            break;
         case 5:
-            seektime += 0x7A00;
-            break;
         case 6:
-            seektime += 0x9700;
-            break;
         case 7:
-            seektime += 0xAF00;
+            seektime += 0x13C * 38 + (track - 0x13C) * 46;
             break;
         case 8:
-            seektime += 0xCC00;
+            seektime += 0x13C * 38 + 0x2E9 * 46 + (track - 0x425) * 58;
             break;
         }
 

--- a/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
+++ b/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
@@ -2157,9 +2157,6 @@ void CMipsMemoryVM::Write32CartridgeDomain2Address1(void)
         case 0x05000508:
             g_Reg->ASIC_CMD = m_MemLookupValue.UW[0];
             DiskCommand();
-            g_Reg->ASIC_STATUS |= DD_STATUS_MECHA_INT;
-            g_Reg->FAKE_CAUSE_REGISTER |= CAUSE_IP3;
-            g_Reg->CheckInterrupts();
             break;
         case 0x05000510:
             //ASIC_BM_STATUS_CTL

--- a/Source/Project64-core/N64System/Mips/SystemTiming.cpp
+++ b/Source/Project64-core/N64System/Mips/SystemTiming.cpp
@@ -221,6 +221,16 @@ void CSystemTimer::TimerDone()
         m_Reg.MI_INTR_REG |= MI_INTR_PI;
         m_Reg.CheckInterrupts();
         break;
+    case CSystemTimer::DDSeekTimer:
+        g_SystemTimer->StopTimer(CSystemTimer::DDSeekTimer);
+        g_Reg->ASIC_STATUS |= DD_STATUS_MECHA_INT;
+        g_Reg->FAKE_CAUSE_REGISTER |= CAUSE_IP3;
+        g_Reg->CheckInterrupts();
+        break;
+    case CSystemTimer::DDMotorTimer:
+        g_SystemTimer->StopTimer(CSystemTimer::DDMotorTimer);
+        g_Reg->ASIC_STATUS &= ~DD_STATUS_MTR_N_SPIN;
+        break;
     case CSystemTimer::ViTimer:
         try
         {

--- a/Source/Project64-core/N64System/Mips/SystemTiming.cpp
+++ b/Source/Project64-core/N64System/Mips/SystemTiming.cpp
@@ -229,7 +229,7 @@ void CSystemTimer::TimerDone()
         break;
     case CSystemTimer::DDMotorTimer:
         g_SystemTimer->StopTimer(CSystemTimer::DDMotorTimer);
-        g_Reg->ASIC_STATUS &= ~DD_STATUS_MTR_N_SPIN;
+        g_Reg->ASIC_STATUS |= DD_STATUS_MTR_N_SPIN;
         break;
     case CSystemTimer::ViTimer:
         try

--- a/Source/Project64-core/N64System/Mips/SystemTiming.h
+++ b/Source/Project64-core/N64System/Mips/SystemTiming.h
@@ -32,6 +32,8 @@ public:
         RspTimer,
         RSPTimerDlist,
         DDPiTimer,
+        DDSeekTimer,
+        DDMotorTimer,
         MaxTimer
     };
 

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -985,7 +985,9 @@ void CN64System::InitRegisters(bool bPostPif, CMipsMemoryVM & MMU)
     m_Reg.STATUS_REGISTER = 0x34000000;
 
     //64DD Registers
-    m_Reg.ASIC_STATUS = DD_STATUS_RST_STATE;
+
+    //Start 64DD in Reset State and Motor Not Spinning
+    m_Reg.ASIC_STATUS = DD_STATUS_RST_STATE | DD_STATUS_MTR_N_SPIN;
     m_Reg.ASIC_ID_REG = 0x00030000;
     if (g_DDRom && (g_DDRom->CicChipID() == CIC_NUS_DDTL || (g_Disk && g_Disk->GetCountry() == Country::UnknownCountry)))
         m_Reg.ASIC_ID_REG = 0x00040000;

--- a/Source/Project64-core/N64System/Recompiler/x86/x86RecompilerOps.cpp
+++ b/Source/Project64-core/N64System/Recompiler/x86/x86RecompilerOps.cpp
@@ -11784,18 +11784,6 @@ void CX86RecompilerOps::SW_Register(x86Reg Reg, uint32_t VAddr)
                 m_RegWorkingSet.BeforeCallDirect();
                 Call_Direct(AddressOf(&DiskCommand), "DiskCommand");
                 m_RegWorkingSet.AfterCallDirect();
-                OrConstToVariable((uint32_t)DD_STATUS_MECHA_INT, &g_Reg->ASIC_STATUS, "ASIC_STATUS");
-                OrConstToVariable((uint32_t)CAUSE_IP3, &g_Reg->FAKE_CAUSE_REGISTER, "FAKE_CAUSE_REGISTER");
-                m_RegWorkingSet.BeforeCallDirect();
-#ifdef _MSC_VER
-                MoveConstToX86reg((uint32_t)g_Reg, x86_ECX);
-                Call_Direct(AddressOf(&CRegisters::CheckInterrupts), "CRegisters::CheckInterrupts");
-#else
-                PushImm32((uint32_t)g_Reg);
-                Call_Direct(AddressOf(&CRegisters::CheckInterrupts), "CRegisters::CheckInterrupts");
-                AddConstToX86Reg(x86_ESP, 4);
-#endif
-                m_RegWorkingSet.AfterCallDirect();
                 break;
             }
             case 0x05000510:


### PR DESCRIPTION
I have introduced two timers, one for seek times, the other for Motor management to introduce more delay when the motor is stopped.

This means that 64DD games will have some extra load times like real hardware. This is NOT accurate however.

I have also put the interrupt management in DiskCommand() instead of directly in Interpreter and Recompiler for this feature.