### PR TITLE
[Save State] Add Disk Interface to Save State file

### DIFF
--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -17,6 +17,7 @@
 #include <Project64-core/N64System/Mips/Transferpak.h>
 #include <Project64-core/N64System/Interpreter/InterpreterCPU.h>
 #include <Project64-core/N64System/Mips/OpcodeName.h>
+#include <Project64-core/N64System/Mips/Disk.h>
 #include <Project64-core/N64System/N64DiskClass.h>
 #include <Project64-core/ExceptionHandler.h>
 #include <Project64-core/Logging.h>
@@ -2132,7 +2133,13 @@ bool CN64System::LoadState(const char * FileName)
 
             //Disk Interface Info
             if (Value == SaveID_2)
+            {
                 hExtraInfo.Read(m_Reg.m_DiskInterface, sizeof(uint32_t) * 22);
+
+                //Recover Disk Seek Address (if the save state is done while loading/saving data)
+                if (g_Disk)
+                    DiskBMReadWrite(false);
+            }
 
             //System Timers Info
             m_SystemTimer.LoadData(hExtraInfo);

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -2047,6 +2047,11 @@ bool CN64System::LoadState(const char * FileName)
                 //Extra Info v2 (Project64 2.4)
                 //Disk Interface Info
                 unzReadCurrentFile(file, m_Reg.m_DiskInterface, sizeof(uint32_t) * 22);
+
+                //Recover Disk Seek Address (if the save state is done while loading/saving data)
+                if (g_Disk)
+                    DiskBMReadWrite(false);
+
                 //System Timers Info
                 m_SystemTimer.LoadData(file);
             }

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -1749,10 +1749,10 @@ bool CN64System::SaveState()
         zipOpenNewFileInZip(file, SaveFile.GetNameExtension().c_str(), NULL, NULL, 0, NULL, 0, NULL, Z_DEFLATED, Z_DEFAULT_COMPRESSION);
         zipWriteInFileInZip(file, &SaveID_0, sizeof(SaveID_0));
         zipWriteInFileInZip(file, &RdramSize, sizeof(uint32_t));
-        if (!g_Settings->LoadBool(Setting_EnableDisk))
-            zipWriteInFileInZip(file, g_Rom->GetRomAddress(), 0x40);
-        else
+        if (g_Settings->LoadBool(Setting_EnableDisk) && g_Disk)
             zipWriteInFileInZip(file, g_Disk->GetDiskAddressID(), 0x40);
+        else
+            zipWriteInFileInZip(file, g_Rom->GetRomAddress(), 0x40);
         zipWriteInFileInZip(file, &NextViTimer, sizeof(uint32_t));
         zipWriteInFileInZip(file, &m_Reg.m_PROGRAM_COUNTER, sizeof(m_Reg.m_PROGRAM_COUNTER));
         zipWriteInFileInZip(file, m_Reg.m_GPR, sizeof(int64_t) * 32);
@@ -1806,10 +1806,10 @@ bool CN64System::SaveState()
         hSaveFile.SeekToBegin();
         hSaveFile.Write(&SaveID_0, sizeof(uint32_t));
         hSaveFile.Write(&RdramSize, sizeof(uint32_t));
-        if (!g_Settings->LoadBool(Setting_EnableDisk))
-            hSaveFile.Write(g_Rom->GetRomAddress(), 0x40);
-        else
+        if (g_Settings->LoadBool(Setting_EnableDisk) && g_Disk)
             hSaveFile.Write(g_Disk->GetDiskAddressID(), 0x40);
+        else
+            hSaveFile.Write(g_Rom->GetRomAddress(), 0x40);
         hSaveFile.Write(&NextViTimer, sizeof(uint32_t));
         hSaveFile.Write(&m_Reg.m_PROGRAM_COUNTER, sizeof(m_Reg.m_PROGRAM_COUNTER));
         hSaveFile.Write(m_Reg.m_GPR, sizeof(int64_t) * 32);
@@ -1981,9 +1981,9 @@ bool CN64System::LoadState(const char * FileName)
 
                 uint8_t LoadHeader[64];
                 unzReadCurrentFile(file, LoadHeader, 0x40);
-                if (!g_Settings->LoadBool(Setting_EnableDisk))
+                if (g_Settings->LoadBool(Setting_EnableDisk) && g_Disk)
                 {
-                    if (memcmp(LoadHeader, g_Rom->GetRomAddress(), 0x40) != 0 &&
+                    if (memcmp(LoadHeader, g_Disk->GetDiskAddressID(), 0x40) != 0 &&
                         !g_Notify->AskYesNoQuestion(g_Lang->GetString(MSG_SAVE_STATE_HEADER).c_str()))
                     {
                         return false;
@@ -1991,7 +1991,7 @@ bool CN64System::LoadState(const char * FileName)
                 }
                 else
                 {
-                    if (memcmp(LoadHeader, g_Disk->GetDiskAddressID(), 0x40) != 0 &&
+                    if (memcmp(LoadHeader, g_Rom->GetRomAddress(), 0x40) != 0 &&
                         !g_Notify->AskYesNoQuestion(g_Lang->GetString(MSG_SAVE_STATE_HEADER).c_str()))
                     {
                         return false;
@@ -2060,9 +2060,9 @@ bool CN64System::LoadState(const char * FileName)
         //Check header
         uint8_t LoadHeader[64];
         hSaveFile.Read(LoadHeader, 0x40);
-        if (!g_Settings->LoadBool(Setting_EnableDisk))
+        if (g_Settings->LoadBool(Setting_EnableDisk) && g_Disk)
         {
-            if (memcmp(LoadHeader, g_Rom->GetRomAddress(), 0x40) != 0 &&
+            if (memcmp(LoadHeader, g_Disk->GetDiskAddressID(), 0x40) != 0 &&
                 !g_Notify->AskYesNoQuestion(g_Lang->GetString(MSG_SAVE_STATE_HEADER).c_str()))
             {
                 return false;
@@ -2070,7 +2070,7 @@ bool CN64System::LoadState(const char * FileName)
         }
         else
         {
-            if (memcmp(LoadHeader, g_Disk->GetDiskAddressID(), 0x40) != 0 &&
+            if (memcmp(LoadHeader, g_Rom->GetRomAddress(), 0x40) != 0 &&
                 !g_Notify->AskYesNoQuestion(g_Lang->GetString(MSG_SAVE_STATE_HEADER).c_str()))
             {
                 return false;

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -1750,9 +1750,15 @@ bool CN64System::SaveState()
         zipWriteInFileInZip(file, &SaveID_0, sizeof(SaveID_0));
         zipWriteInFileInZip(file, &RdramSize, sizeof(uint32_t));
         if (g_Settings->LoadBool(Setting_EnableDisk) && g_Disk)
-            zipWriteInFileInZip(file, g_Disk->GetDiskAddressID(), 0x40);
+        {
+            //Keep Base ROM Information (64DD IPL / Compatible Game ROM)
+            zipWriteInFileInZip(file, &g_Rom->GetRomAddress()[0x10], 0x20);
+            zipWriteInFileInZip(file, g_Disk->GetDiskAddressID(), 0x20);
+        }
         else
+        {
             zipWriteInFileInZip(file, g_Rom->GetRomAddress(), 0x40);
+        }
         zipWriteInFileInZip(file, &NextViTimer, sizeof(uint32_t));
         zipWriteInFileInZip(file, &m_Reg.m_PROGRAM_COUNTER, sizeof(m_Reg.m_PROGRAM_COUNTER));
         zipWriteInFileInZip(file, m_Reg.m_GPR, sizeof(int64_t) * 32);
@@ -1814,9 +1820,15 @@ bool CN64System::SaveState()
         hSaveFile.Write(&SaveID_0, sizeof(uint32_t));
         hSaveFile.Write(&RdramSize, sizeof(uint32_t));
         if (g_Settings->LoadBool(Setting_EnableDisk) && g_Disk)
-            hSaveFile.Write(g_Disk->GetDiskAddressID(), 0x40);
+        {
+            //Keep Base ROM Information (64DD IPL / Compatible Game ROM)
+            hSaveFile.Write(&g_Rom->GetRomAddress()[0x10], 0x20);
+            hSaveFile.Write(g_Disk->GetDiskAddressID(), 0x20);
+        }
         else
+        {
             hSaveFile.Write(g_Rom->GetRomAddress(), 0x40);
+        }
         hSaveFile.Write(&NextViTimer, sizeof(uint32_t));
         hSaveFile.Write(&m_Reg.m_PROGRAM_COUNTER, sizeof(m_Reg.m_PROGRAM_COUNTER));
         hSaveFile.Write(m_Reg.m_GPR, sizeof(int64_t) * 32);
@@ -1990,7 +2002,9 @@ bool CN64System::LoadState(const char * FileName)
                 unzReadCurrentFile(file, LoadHeader, 0x40);
                 if (g_Settings->LoadBool(Setting_EnableDisk) && g_Disk)
                 {
-                    if (memcmp(LoadHeader, g_Disk->GetDiskAddressID(), 0x40) != 0 &&
+                    //Base ROM Information (64DD IPL / Compatible Game ROM) & Disk Info Check
+                    if (memcmp(LoadHeader, &g_Rom->GetRomAddress()[0x10], 0x20) != 0 &&
+                        memcmp(&LoadHeader[0x20], g_Disk->GetDiskAddressID(), 0x20) != 0 &&
                         !g_Notify->AskYesNoQuestion(g_Lang->GetString(MSG_SAVE_STATE_HEADER).c_str()))
                     {
                         return false;
@@ -2083,7 +2097,9 @@ bool CN64System::LoadState(const char * FileName)
         hSaveFile.Read(LoadHeader, 0x40);
         if (g_Settings->LoadBool(Setting_EnableDisk) && g_Disk)
         {
-            if (memcmp(LoadHeader, g_Disk->GetDiskAddressID(), 0x40) != 0 &&
+            //Base ROM Information (64DD IPL / Compatible Game ROM) & Disk Info Check
+            if (memcmp(LoadHeader, &g_Rom->GetRomAddress()[0x10], 0x20) != 0 &&
+                memcmp(&LoadHeader[0x20], g_Disk->GetDiskAddressID(), 0x20) != 0 &&
                 !g_Notify->AskYesNoQuestion(g_Lang->GetString(MSG_SAVE_STATE_HEADER).c_str()))
             {
                 return false;

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -1767,6 +1767,7 @@ bool CN64System::SaveState()
         zipWriteInFileInZip(file, m_Reg.m_Peripheral_Interface, sizeof(uint32_t) * 13);
         zipWriteInFileInZip(file, m_Reg.m_RDRAM_Interface, sizeof(uint32_t) * 8);
         zipWriteInFileInZip(file, m_Reg.m_SerialInterface, sizeof(uint32_t) * 4);
+        zipWriteInFileInZip(file, m_Reg.m_DiskInterface, sizeof(uint32_t) * 22);
         zipWriteInFileInZip(file, (void *const)&m_TLB.TlbEntry(0), sizeof(CTLB::TLB_ENTRY) * 32);
         zipWriteInFileInZip(file, m_MMU_VM.PifRam(), 0x40);
         zipWriteInFileInZip(file, m_MMU_VM.Rdram(), RdramSize);
@@ -1820,6 +1821,7 @@ bool CN64System::SaveState()
         hSaveFile.Write(m_Reg.m_Peripheral_Interface, sizeof(uint32_t) * 13);
         hSaveFile.Write(m_Reg.m_RDRAM_Interface, sizeof(uint32_t) * 8);
         hSaveFile.Write(m_Reg.m_SerialInterface, sizeof(uint32_t) * 4);
+        hSaveFile.Write(m_Reg.m_DiskInterface, sizeof(uint32_t) * 22);
         hSaveFile.Write(&m_TLB.TlbEntry(0), sizeof(CTLB::TLB_ENTRY) * 32);
         hSaveFile.Write(g_MMU->PifRam(), 0x40);
         hSaveFile.Write(g_MMU->Rdram(), RdramSize);
@@ -2000,6 +2002,7 @@ bool CN64System::LoadState(const char * FileName)
                 unzReadCurrentFile(file, m_Reg.m_Peripheral_Interface, sizeof(uint32_t) * 13);
                 unzReadCurrentFile(file, m_Reg.m_RDRAM_Interface, sizeof(uint32_t) * 8);
                 unzReadCurrentFile(file, m_Reg.m_SerialInterface, sizeof(uint32_t) * 4);
+                unzReadCurrentFile(file, m_Reg.m_DiskInterface, sizeof(uint32_t) * 22);
                 unzReadCurrentFile(file, (void *const)&m_TLB.TlbEntry(0), sizeof(CTLB::TLB_ENTRY) * 32);
                 unzReadCurrentFile(file, m_MMU_VM.PifRam(), 0x40);
                 unzReadCurrentFile(file, m_MMU_VM.Rdram(), SaveRDRAMSize);
@@ -2067,6 +2070,7 @@ bool CN64System::LoadState(const char * FileName)
         hSaveFile.Read(m_Reg.m_Peripheral_Interface, sizeof(uint32_t) * 13);
         hSaveFile.Read(m_Reg.m_RDRAM_Interface, sizeof(uint32_t) * 8);
         hSaveFile.Read(m_Reg.m_SerialInterface, sizeof(uint32_t) * 4);
+        hSaveFile.Read(m_Reg.m_DiskInterface, sizeof(uint32_t) * 22);
         hSaveFile.Read((void *const)&m_TLB.TlbEntry(0), sizeof(CTLB::TLB_ENTRY) * 32);
         hSaveFile.Read(m_MMU_VM.PifRam(), 0x40);
         hSaveFile.Read(m_MMU_VM.Rdram(), SaveRDRAMSize);

--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -2003,8 +2003,8 @@ bool CN64System::LoadState(const char * FileName)
                 if (g_Settings->LoadBool(Setting_EnableDisk) && g_Disk)
                 {
                     //Base ROM Information (64DD IPL / Compatible Game ROM) & Disk Info Check
-                    if (memcmp(LoadHeader, &g_Rom->GetRomAddress()[0x10], 0x20) != 0 &&
-                        memcmp(&LoadHeader[0x20], g_Disk->GetDiskAddressID(), 0x20) != 0 &&
+                    if ((memcmp(LoadHeader, &g_Rom->GetRomAddress()[0x10], 0x20) != 0 ||
+                        memcmp(&LoadHeader[0x20], g_Disk->GetDiskAddressID(), 0x20) != 0) &&
                         !g_Notify->AskYesNoQuestion(g_Lang->GetString(MSG_SAVE_STATE_HEADER).c_str()))
                     {
                         return false;
@@ -2098,8 +2098,8 @@ bool CN64System::LoadState(const char * FileName)
         if (g_Settings->LoadBool(Setting_EnableDisk) && g_Disk)
         {
             //Base ROM Information (64DD IPL / Compatible Game ROM) & Disk Info Check
-            if (memcmp(LoadHeader, &g_Rom->GetRomAddress()[0x10], 0x20) != 0 &&
-                memcmp(&LoadHeader[0x20], g_Disk->GetDiskAddressID(), 0x20) != 0 &&
+            if ((memcmp(LoadHeader, &g_Rom->GetRomAddress()[0x10], 0x20) != 0 ||
+                memcmp(&LoadHeader[0x20], g_Disk->GetDiskAddressID(), 0x20) != 0) &&
                 !g_Notify->AskYesNoQuestion(g_Lang->GetString(MSG_SAVE_STATE_HEADER).c_str()))
             {
                 return false;

--- a/Source/Project64-core/N64System/N64Class.h
+++ b/Source/Project64-core/N64System/N64Class.h
@@ -184,4 +184,9 @@ private:
 
     //list of function that have been called .. used in profiling
     FUNC_CALLS m_FunctionCalls;
+
+    //list of Save State File IDs
+    const uint32_t SaveID_0 = 0x23D8A6C8;   //Main Save State Info (*.pj)
+    const uint32_t SaveID_1 = 0x56D2CD23;   //Extra Data v1 (System Timing) Info (*.dat)
+    const uint32_t SaveID_2 = 0x750A6BEB;   //Extra Data v2 (Timing + Disk Registers) (*.dat)
 };


### PR DESCRIPTION
I noticed 64DD games don't really play well with save states. I noticed that I forgot to add the registers to the save states.

I don't know if you're satisfied with this, as this breaks the Save State format, maybe you'd prefer putting the Disk Registers at the end of the file?
@project64