### PR TITLE
Fix FPS not being limited when Audio muted

### DIFF
--- a/Source/Project64-core/Plugins/PluginClass.cpp
+++ b/Source/Project64-core/Plugins/PluginClass.cpp
@@ -413,6 +413,10 @@ void CPlugins::ConfigPlugin(void* hParent, PLUGIN_TYPE Type)
             }
         }
         m_Audio->DllConfig(hParent);
+		if (g_BaseSystem)
+		{
+			g_BaseSystem->RefreshSyncToAudio();
+		}
         break;
     case PLUGIN_TYPE_CONTROLLER:
         if (m_Control == NULL || m_Control->DllConfig == NULL) { break; }

--- a/Source/Project64-core/Settings/GameSettings.cpp
+++ b/Source/Project64-core/Settings/GameSettings.cpp
@@ -94,5 +94,5 @@ void CGameSettings::SpeedChanged(int SpeedLimit)
 
 void CGameSettings::RefreshSyncToAudio(void)
 {
-	m_bSyncToAudio = g_Settings->LoadBool(Game_SyncViaAudio) && g_Settings->LoadBool(Setting_SyncViaAudioEnabled);
+	m_bSyncToAudio = g_Settings->LoadBool(Game_SyncViaAudio) && g_Settings->LoadBool(Setting_SyncViaAudioEnabled) && g_Settings->LoadBool(Plugin_EnableAudio);
 }


### PR DESCRIPTION
Checks if audio is enabled while setting the SyncToAudio boolean. Also refreshes the SyncToAudio setting after closing the Audio Plugin configuration screen to ensure muting the audio mid-playthrough will also continue to properly limit the FPS.