### PR TITLE
Fix Start Emulation by only skipping StartEmulation when AutoStart is disabled

### DIFF
--- a/Source/Project64-core/N64System/N64Class.cpp
+++ b/Source/Project64-core/N64System/N64Class.cpp
@@ -515,11 +515,7 @@ bool CN64System::RunFileImage(const char * FileLoc)
             g_Settings->SaveString(File_DiskIPLTOOLPath, FileLoc);
     }
 
-    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
-    {
-        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
-        RunLoadedImage();
-    }
+    RunLoadedImage();
     return true;
 }
 
@@ -537,11 +533,7 @@ bool CN64System::RunDiskImage(const char * FileLoc)
     }
 
     g_Settings->SaveBool(Setting_EnableDisk, true);
-    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
-    {
-        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
-        RunLoadedImage();
-    }
+    RunLoadedImage();
     return true;
 }
 
@@ -563,11 +555,7 @@ bool CN64System::RunDiskComboImage(const char * FileLoc, const char * FileLocDis
     }
 
     g_Settings->SaveBool(Setting_EnableDisk, true);
-    if (g_Settings->LoadBool(Setting_AutoStart) != 0)
-    {
-        WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
-        RunLoadedImage();
-    }
+    RunLoadedImage();
     return true;
 }
 
@@ -577,7 +565,11 @@ void CN64System::RunLoadedImage(void)
     g_BaseSystem = new CN64System(g_Plugins, (uint32_t)time(NULL), false, false);
     if (g_BaseSystem)
     {
-        g_BaseSystem->StartEmulation(true);
+        if (g_Settings->LoadBool(Setting_AutoStart) != 0)
+        {
+            WriteTrace(TraceN64System, TraceDebug, "Automattically starting rom");
+            g_BaseSystem->StartEmulation(true);
+        }
     }
     else
     {

--- a/Source/Project64/UserInterface/MainMenu.cpp
+++ b/Source/Project64/UserInterface/MainMenu.cpp
@@ -302,17 +302,12 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
         //Now we have created again, we can start up emulation
         if (g_BaseSystem)
         {
+            if (g_Settings->LoadBool(Setting_AutoStart) == 0)
+            {
+                WriteTrace(TraceN64System, TraceDebug, "Manually starting rom");
+            }
             g_BaseSystem->StartEmulation(true);
         }
-		else if (g_Settings->LoadBool(Setting_AutoStart) == 0)
-		{
-			WriteTrace(TraceN64System, TraceDebug, "Manually starting rom");
-			CN64System::RunLoadedImage();
-			if (g_BaseSystem == NULL) 
-			{
-				g_Notify->BreakPoint(__FILE__, __LINE__);
-			}
-		}
         else
         {
             g_Notify->BreakPoint(__FILE__, __LINE__);

--- a/Source/Project64/UserInterface/MainMenu.cpp
+++ b/Source/Project64/UserInterface/MainMenu.cpp
@@ -304,6 +304,15 @@ bool CMainMenu::ProcessMessage(HWND hWnd, DWORD /*FromAccelerator*/, DWORD MenuI
         {
             g_BaseSystem->StartEmulation(true);
         }
+		else if (g_Settings->LoadBool(Setting_AutoStart) == 0)
+		{
+			WriteTrace(TraceN64System, TraceDebug, "Manually starting rom");
+			CN64System::RunLoadedImage();
+			if (g_BaseSystem == NULL) 
+			{
+				g_Notify->BreakPoint(__FILE__, __LINE__);
+			}
+		}
         else
         {
             g_Notify->BreakPoint(__FILE__, __LINE__);


### PR DESCRIPTION
RunLoadedImage is skipped in the Run*Image methods in CN64System if AutoStart is disabled. If the check for if there is a current g_BaseSystem fails, these changes run RunLoadedImage to create one and StartEmulation.

I'm not sure the extra NULL guard is necessary, but I don't want to skip the first g_BaseSystem check altogether. I added it as a "just in case."

Related: #1835