### PR TITLE
[Project64-Input] Use non-square for deadzone

### DIFF
--- a/Source/Project64-input/DirectInput.cpp
+++ b/Source/Project64-input/DirectInput.cpp
@@ -423,20 +423,11 @@ void CDirectInput::GetAxis(N64CONTROLLER & Controller, BUTTONS * Keys)
             if (Button.AxisID == AI_AXE_NEGATIVE)
             {
                 fNegInput = !fNegInput;
-
-                b_Value = (l_Value <= -lDeadZoneValue);
-                if (b_Value)
-                {
-                    l_Value = (long)((float)(l_Value + lDeadZoneValue) * fDeadZoneRelation);
-                }
+                b_Value = (l_Value < 0);
             }
             else
             {
-                b_Value = (l_Value >= lDeadZoneValue);
-                if (b_Value)
-                {
-                    l_Value = (long)((float)(l_Value - lDeadZoneValue) * fDeadZoneRelation);
-                }
+                b_Value = (l_Value > 0);
             }
             break;
         case BTNTYPE_KEYBUTTON:
@@ -478,11 +469,24 @@ void CDirectInput::GetAxis(N64CONTROLLER & Controller, BUTTONS * Keys)
         }
     }
 
+    long lAbsoluteX = (lAxisValueX > 0) ? lAxisValueX : -lAxisValueX;
+    long lAbsoluteY = (lAxisValueY > 0) ? lAxisValueY : -lAxisValueY;
+
+
+    if (lAbsoluteX * lAbsoluteX + lAbsoluteY * lAbsoluteY > lDeadZoneValue * lDeadZoneValue)
+    {
+        double dMagnitudeDiagonal = sqrt((double)lAbsoluteX * lAbsoluteX + (double)lAbsoluteY * lAbsoluteY);
+        double dRel = ((dMagnitudeDiagonal - lDeadZoneValue) / dMagnitudeDiagonal * fDeadZoneRelation);
+        lAxisValueX = (long)(lAxisValueX * dRel);
+        lAxisValueY = (long)(lAxisValueY * dRel);
+    }
+    else
+    {
+        lAxisValueX = lAxisValueY = 0;
+    }
+
     if (Controller.RealN64Range && (lAxisValueX || lAxisValueY))
     {
-        long lAbsoluteX = (lAxisValueX > 0) ? lAxisValueX : -lAxisValueX;
-        long lAbsoluteY = (lAxisValueY > 0) ? lAxisValueY : -lAxisValueY;
-
         long lRangeX = lAbsoluteX > lAbsoluteY ? MAX_AXIS_VALUE : MAX_AXIS_VALUE * lAbsoluteX / lAbsoluteY;
         long lRangeY = lAbsoluteX > lAbsoluteY ? MAX_AXIS_VALUE * lAbsoluteY / lAbsoluteX : MAX_AXIS_VALUE;
 


### PR DESCRIPTION
The previous method of calculating the deadzone would create a square deadzone that does not work nicely with diagonal input. Using an uncalibrated GameCube controller was especially painful, and even once calibrated the default 25% deadzone caused issues with the diagonals since the furthest relative position from the deadzone was still beyond what the controller could physically allow for requiring me to reduce it by a fair amount.

This is an attempt at a more circular deadzone, though the maths need to be checked as to whether it is actually a circle. The passed value should still be a relative value so even at an 80% deadzone you can still manage to walk in Ocarina of Time or Mario 64 if you push the analog stick just past the deadzone, and running if pushed all the way. The default 25% now works nicely on diagonal inputs even on an uncalibrated GameCube controller.