### PR TITLE
Add Project64.rdb and Project64.rdx entries for Dinosaur Planet

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1415,6 +1415,13 @@ Internal Name=Diddy Kong Racing
 Status=Compatible
 32bit=No
 
+[906C3F77-CE495EA1-C:45]
+Good Name=DINO PLANET
+Internal Name=Dinosaur Planet
+Status=Compatible
+32bit=No
+RDRAM Size=8
+
 [C16C421B-A21580F7-C:45]
 Good Name=Disney's Donald Duck - Goin' Quackers (U) (M4)
 Internal Name=Donald Duck Goin' Qu

--- a/Config/Project64.rdx
+++ b/Config/Project64.rdx
@@ -1,4 +1,4 @@
-﻿// PJ64 v2.2 Official RDX (Rom Database eXtension)
+ï»¿// PJ64 v2.2 Official RDX (Rom Database eXtension)
 // Not for use with PJ64 v1.6 or previous
 // ----------------------------------------------------
 
@@ -1335,6 +1335,12 @@ ReleaseDate=1997/11/24
 Genre=Racing-Misc
 Players=4
 ForceFeedback=Yes
+
+[906C3F77-CE495EA1-C:45]
+Good Name=DINO PLANET
+Developer=Rare
+Genre=Adventure
+Players=1
 
 [C16C421B-A21580F7-C:45]
 Good Name=Disney's Donald Duck - Goin' Quackers (U) [!]
@@ -5223,7 +5229,7 @@ Players=4
 ForceFeedback=Yes
 
 [451ACA0F-7863BC8A-C:44]
-Good Name=Rugrats - Die gro�e Schatzsuche (G)
+Good Name=Rugrats - Die große Schatzsuche (G)
 Developer=Infogrammes
 ReleaseDate=1999/06/01
 Genre=Party

--- a/Config/Project64.rdx
+++ b/Config/Project64.rdx
@@ -1,4 +1,4 @@
-ï»¿// PJ64 v2.2 Official RDX (Rom Database eXtension)
+// PJ64 v2.2 Official RDX (Rom Database eXtension)
 // Not for use with PJ64 v1.6 or previous
 // ----------------------------------------------------
 


### PR DESCRIPTION
Specifically, this is needed to fix the shadow rendering bug described [in this GLideN64 issue,](https://github.com/gonetz/GLideN64/issues/2461) which is now fixed on their end.