### PR TITLE
[Project64-Input] Fix inverted axis when checking pressed buttons

### DIFF
--- a/Source/Project64-input/DirectInput.cpp
+++ b/Source/Project64-input/DirectInput.cpp
@@ -365,7 +365,7 @@ bool CDirectInput::IsButtonPressed(BUTTON & Button)
         return JoyPadPovPressed((AI_POV)Button.AxisID, ((uint32_t *)&Device.State.Joy)[Button.Offset]);
     case BTNTYPE_JOYSLIDER:
     case BTNTYPE_JOYAXE:
-        return Button.AxisID ? ((uint32_t *)&Device.State.Joy)[Button.Offset] < AXIS_TOP_VALUE : ((uint32_t *)&Device.State.Joy)[Button.Offset] > AXIS_BOTTOM_VALUE;
+        return Button.AxisID ? ((uint32_t*)&Device.State.Joy)[Button.Offset] > AXIS_BOTTOM_VALUE : ((uint32_t *)&Device.State.Joy)[Button.Offset] < AXIS_TOP_VALUE;
     }
     return false;
 }


### PR DESCRIPTION
When checking if a button was pressed when mapped to the joysticks the axes are checked inverted to their expected value. Mapping to Z Axis + would instead check for Z Axis - and so on. This is especially noticeable on GameCube controllers since the triggers and bumpers are a combined button, and trying to map to the L or R bumper often maps the L or R trigger instead, which would cause the game to think the trigger was always pressed unless it was pressed.