### PR TITLE
[OoT Randomizer] Remove greedy Good Name

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -5813,7 +5813,6 @@ RDRAM Size=8
 Alt Identifier=11223344-55667788-C:45
 
 [11223344-55667788-C:45]
-Good Name=The Legend of Zelda - Ocarina of Time (U) (Randomizer)
 Internal Name=THE LEGEND OF ZELDA
 Status=Compatible
 32bit=No


### PR DESCRIPTION
Removes the Good Name from the greedy THE LEGEND OF ZELDA rdb entry.
Settings still seem to be retained between all relevant ROMs and
changing an option in one will change the option for all of them.

This is preferable as the file name is the only way to distinguish
randomizer ROMs in the first place. It also won't override unrelated
rom hacks with the wrong name. This should reduce user confusion for
both of these cases.