### PR TITLE
Update N64System.h copyright header and comments

### DIFF
--- a/Source/Project64/N64System.h
+++ b/Source/Project64/N64System.h
@@ -1,13 +1,8 @@
-/****************************************************************************
-*                                                                           *
-* Project64 - A Nintendo 64 emulator.                                      *
-* http://www.pj64-emu.com/                                                  *
-* Copyright (C) 2012 Project64. All rights reserved.                        *
-*                                                                           *
-* License:                                                                  *
-* GNU/GPLv2 http://www.gnu.org/licenses/gpl-2.0.html                        *
-*                                                                           *
-****************************************************************************/
+// Project64 - A Nintendo 64 emulator
+// http://www.pj64-emu.com/
+// Copyright (C) 2021 Project64. All rights reserved.
+// GNU/GPLv2 licensed: https://gnu.org/licenses/gpl-2.0.html
+
 #pragma once
 
 #include "Support.h"

--- a/Source/Project64/N64System.h
+++ b/Source/Project64/N64System.h
@@ -1,6 +1,6 @@
 // Project64 - A Nintendo 64 emulator
 // http://www.pj64-emu.com/
-// Copyright (C) 2021 Project64. All rights reserved.
+// Copyright (C) 2001-2021 Project64. All rights reserved.
 // GNU/GPLv2 licensed: https://gnu.org/licenses/gpl-2.0.html
 
 #pragma once

--- a/Source/Project64/N64System.h
+++ b/Source/Project64/N64System.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "Support.h"
-#include <string>				//needed for stl string (std::string)
+#include <string>				// Needed for stl string (std::string)
 #include <float.h>
 #include <math.h>
 
@@ -15,7 +15,8 @@
 
 #include <Project64-core/N64System/ProfilingClass.h>
 
-//General Mips Information
+// General MIPS information
+
 #include <Project64-core/N64System/N64RomClass.h>
 #include <Project64-core/N64System/SpeedLimiterClass.h>
 #include <Project64-core/N64System/Mips/OpCode.h>


### PR DESCRIPTION
Switched from block comments to single line comments, updated copyright year, reduced verbosity of license lines, and switched to HTTPS for license link.

This copyright header will also serve as the new copyright header for the rest of the files in the repo, each file will be a separate pull request so changes can be reviewed on a per file basis.