### PR TITLE
Linux fixes

### DIFF
--- a/Source/Common/IniFileClass.cpp
+++ b/Source/Common/IniFileClass.cpp
@@ -1,4 +1,3 @@
-#include "stdafx.h"
 #include <stdlib.h>
 #include <stdarg.h>
 

--- a/Source/Common/IniFileClass.cpp
+++ b/Source/Common/IniFileClass.cpp
@@ -1,3 +1,4 @@
+#include "stdafx.h"
 #include <stdlib.h>
 #include <stdarg.h>
 

--- a/Source/Common/IniFileClass.h
+++ b/Source/Common/IniFileClass.h
@@ -4,6 +4,7 @@
 #include <strings.h>
 #endif
 
+#include "stdafx.h"
 #include "FileClass.h"
 #include "CriticalSection.h"
 #include <string>

--- a/Source/Common/Platform.h
+++ b/Source/Common/Platform.h
@@ -4,6 +4,7 @@
 #include <alloca.h>
 #include <stdarg.h>
 
+#define stricmp strcasecmp
 #define _stricmp strcasecmp
 #define _strnicmp strncasecmp
 #define _snprintf snprintf

--- a/Source/Common/Thread.h
+++ b/Source/Common/Thread.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Common\stdtypes.h>
+#include <Common/stdtypes.h>
 
 class CThread 
 {

--- a/Source/JoinSettings/main.cpp
+++ b/Source/JoinSettings/main.cpp
@@ -1,7 +1,7 @@
-#include <Common\path.h>
-#include <Common\IniFileClass.h>
-#include <Common\StdString.h>
-#include <Project64-core\N64System\Enhancement\EnhancementFile.h>
+#include <Common/path.h>
+#include <Common/IniFileClass.h>
+#include <Common/StdString.h>
+#include <Project64-core/N64System/Enhancement/EnhancementFile.h>
 #include <algorithm>
 #include <set>
 #include <windows.h>

--- a/Source/Project64-core/AppInit.cpp
+++ b/Source/Project64-core/AppInit.cpp
@@ -9,7 +9,7 @@
 #include <Project64-core/Plugins/PluginClass.h>
 #include <Project64-core/N64System/N64RomClass.h>
 #include <Project64-core/N64System/N64DiskClass.h>
-#include <Project64-core\N64System\Enhancement\Enhancements.h>
+#include <Project64-core/N64System/Enhancement/Enhancements.h>
 #include "Settings/SettingType/SettingsType-Application.h"
 
 static void FixDirectories(void);

--- a/Source/Project64-core/N64System/Enhancement/Enhancement.cpp
+++ b/Source/Project64-core/N64System/Enhancement/Enhancement.cpp
@@ -9,10 +9,10 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
-#include <Project64-core\N64System\Enhancement\Enhancement.h>
-#include <Project64-core\Settings\SettingType\SettingsType-GameSetting.h>
-#include <Project64-core\N64System\SystemGlobals.h>
-#include <Project64-core\N64System\N64Class.h>
+#include <Project64-core/N64System/Enhancement/Enhancement.h>
+#include <Project64-core/Settings/SettingType/SettingsType-GameSetting.h>
+#include <Project64-core/N64System/SystemGlobals.h>
+#include <Project64-core/N64System/N64Class.h>
 
 #pragma warning(disable:4996)
 

--- a/Source/Project64-core/N64System/Enhancement/Enhancement.h
+++ b/Source/Project64-core/N64System/Enhancement/Enhancement.h
@@ -9,7 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #pragma once
-#include <Common\stdtypes.h>
+#include <Common/stdtypes.h>
 #include <string>
 #include <vector>
 

--- a/Source/Project64-core/N64System/Enhancement/EnhancementFile.cpp
+++ b/Source/Project64-core/N64System/Enhancement/EnhancementFile.cpp
@@ -9,7 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
-#include <Project64-core\N64System\Enhancement\EnhancementFile.h>
+#include <Project64-core/N64System/Enhancement/EnhancementFile.h>
 
 #pragma warning(disable:4996)
 

--- a/Source/Project64-core/N64System/Enhancement/EnhancementFile.h
+++ b/Source/Project64-core/N64System/Enhancement/EnhancementFile.h
@@ -9,10 +9,10 @@
 *                                                                           *
 ****************************************************************************/
 #pragma once
-#include <Project64-core\N64System\Enhancement\Enhancement.h>
-#include <Project64-core\N64System\Enhancement\EnhancementList.h>
-#include <Common\FileClass.h>
-#include <Common\CriticalSection.h>
+#include <Project64-core/N64System/Enhancement/Enhancement.h>
+#include <Project64-core/N64System/Enhancement/EnhancementList.h>
+#include <Common/FileClass.h>
+#include <Common/CriticalSection.h>
 #include <set>
 #include <string>
 #include <map>

--- a/Source/Project64-core/N64System/Enhancement/EnhancementList.cpp
+++ b/Source/Project64-core/N64System/Enhancement/EnhancementList.cpp
@@ -9,7 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
-#include <Project64-core\N64System\Enhancement\EnhancementList.h>
+#include <Project64-core/N64System/Enhancement/EnhancementList.h>
 
 CEnhancementList::CEnhancementList()
 {

--- a/Source/Project64-core/N64System/Enhancement/EnhancementList.h
+++ b/Source/Project64-core/N64System/Enhancement/EnhancementList.h
@@ -9,6 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #pragma once
+#include <Common/stdafx.h>
 #include <vector>
 #include <string>
 #include <Project64-core/N64System/Enhancement/Enhancement.h>

--- a/Source/Project64-core/N64System/Enhancement/EnhancementList.h
+++ b/Source/Project64-core/N64System/Enhancement/EnhancementList.h
@@ -11,7 +11,7 @@
 #pragma once
 #include <vector>
 #include <string>
-#include <Project64-core\N64System\Enhancement\Enhancement.h>
+#include <Project64-core/N64System/Enhancement/Enhancement.h>
 
 struct EnhancementItemList_compare
 {

--- a/Source/Project64-core/N64System/Enhancement/Enhancements.cpp
+++ b/Source/Project64-core/N64System/Enhancement/Enhancements.cpp
@@ -9,18 +9,18 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
-#include <Project64-core\N64System\Enhancement\Enhancements.h>
-#include <Project64-core\N64System\Enhancement\EnhancementFile.h>
-#include <Project64-core\N64System\Mips\MemoryVirtualMem.h>
-#include <Project64-core\N64System\Recompiler\RecompilerClass.h>
-#include <Project64-core\N64System\SystemGlobals.h>
-#include <Project64-core\Plugins\PluginClass.h>
-#include <Project64-core\Plugins\GFXPlugin.h>
-#include <Project64-core\Plugins\AudioPlugin.h>
-#include <Project64-core\Plugins\RSPPlugin.h>
-#include <Project64-core\Plugins\ControllerPlugin.h>
-#include <Common\path.h>
-#include <Common\Util.h>
+#include <Project64-core/N64System/Enhancement/Enhancements.h>
+#include <Project64-core/N64System/Enhancement/EnhancementFile.h>
+#include <Project64-core/N64System/Mips/MemoryVirtualMem.h>
+#include <Project64-core/N64System/Recompiler/RecompilerClass.h>
+#include <Project64-core/N64System/SystemGlobals.h>
+#include <Project64-core/Plugins/PluginClass.h>
+#include <Project64-core/Plugins/GFXPlugin.h>
+#include <Project64-core/Plugins/AudioPlugin.h>
+#include <Project64-core/Plugins/RSPPlugin.h>
+#include <Project64-core/Plugins/ControllerPlugin.h>
+#include <Common/path.h>
+#include <Common/Util.h>
 
 CEnhancements::CEnhancements() :
     m_ScanFileThread(stScanFileThread),

--- a/Source/Project64-core/N64System/Enhancement/Enhancements.h
+++ b/Source/Project64-core/N64System/Enhancement/Enhancements.h
@@ -9,10 +9,10 @@
 *                                                                           *
 ****************************************************************************/
 #pragma once
-#include <Project64-core\N64System\Enhancement\EnhancementFile.h>
-#include <Project64-core\N64System\Enhancement\EnhancementList.h>
-#include <Common\Thread.h>
-#include <Common\CriticalSection.h>
+#include <Project64-core/N64System/Enhancement/EnhancementFile.h>
+#include <Project64-core/N64System/Enhancement/EnhancementList.h>
+#include <Common/Thread.h>
+#include <Common/CriticalSection.h>
 #include <map>
 #include <string>
 

--- a/Source/Project64-core/RomList/RomList.cpp
+++ b/Source/Project64-core/RomList/RomList.cpp
@@ -155,7 +155,7 @@ void CRomList::FillRomList(strlist & FileList, const char * Directory)
     CPath SearchDir((const char *)m_GameDir, "*");
     SearchDir.AppendDirectory(Directory);
 
-    WriteTrace(TraceRomList, TraceVerbose, "SearchPath: %s", (const char *)SearchPath);
+    WriteTrace(TraceRomList, TraceVerbose, "SearchDir: %s", (const char *)SearchDir);
     if (!SearchDir.FindFirst(CPath::FIND_ATTRIBUTE_ALLFILES))
     {
         WriteTrace(TraceRomList, TraceVerbose, "No files found");
@@ -165,7 +165,7 @@ void CRomList::FillRomList(strlist & FileList, const char * Directory)
 
     do
     {
-        WriteTrace(TraceRomList, TraceVerbose, "Found: \"%s\" m_StopRefresh = %s", (const char *)SearchPath, m_StopRefresh ? "true" : "false");
+        WriteTrace(TraceRomList, TraceVerbose, "Found: \"%s\" m_StopRefresh = %s", (const char *)SearchDir, m_StopRefresh ? "true" : "false");
         if (m_StopRefresh)
         {
             WriteTrace(TraceRomList, TraceVerbose, "stop refresh set, stopping");

--- a/Source/Project64-core/Settings/SettingType/SettingsType-GameSetting.h
+++ b/Source/Project64-core/Settings/SettingType/SettingsType-GameSetting.h
@@ -9,7 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #pragma once
-#include <Project64-core\Settings\SettingType\SettingsType-Application.h>
+#include <Project64-core/Settings/SettingType/SettingsType-Application.h>
 
 class CSettingTypeGame :
     public CSettingTypeApplication

--- a/Source/Project64-core/Settings/SettingType/SettingsType-RDBSaveChip.cpp
+++ b/Source/Project64-core/Settings/SettingType/SettingsType-RDBSaveChip.cpp
@@ -98,6 +98,8 @@ void CSettingTypeRDBSaveChip::Save (uint32_t /*Index*/, bool /*Value*/ )
 
 void CSettingTypeRDBSaveChip::Save (uint32_t /*Index*/, uint32_t Value )
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnarrowing"
     switch (Value)
     {
     case SaveChip_Auto:       m_SettingsIniFile->SaveString(m_SectionIdent->c_str(),m_KeyName.c_str(),"First Save Type"); break;
@@ -108,6 +110,7 @@ void CSettingTypeRDBSaveChip::Save (uint32_t /*Index*/, uint32_t Value )
     default:
         g_Notify->BreakPoint(__FILE__, __LINE__);
     }
+#pragma GCC diagnostic pop
 }
 
 void CSettingTypeRDBSaveChip::Save (uint32_t /*Index*/, const std::string & /*Value*/ )

--- a/Source/Project64-input/Button.h
+++ b/Source/Project64-input/Button.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Common\stdtypes.h>
+#include <Common/stdtypes.h>
 #include <guiddef.h>
 
 enum BtnType

--- a/Source/Project64-input/CProject64Input.h
+++ b/Source/Project64-input/CProject64Input.h
@@ -2,7 +2,7 @@
 #include "ControllerSpec1.1.h"
 #include "DirectInput.h"
 #include "N64Controller.h"
-#include <Common\CriticalSection.h>
+#include <Common/CriticalSection.h>
 #include <memory>
 
 class CProject64Input

--- a/Source/Project64-input/DirectInput.cpp
+++ b/Source/Project64-input/DirectInput.cpp
@@ -1,6 +1,6 @@
 #include "DirectInput.h"
-#include <Common\StdString.h>
-#include <Common\SyncEvent.h>
+#include <Common/StdString.h>
+#include <Common/SyncEvent.h>
 #include <set>
 #include "CProject64Input.h"
 

--- a/Source/Project64-input/DirectInput.h
+++ b/Source/Project64-input/DirectInput.h
@@ -3,7 +3,7 @@
 #include "Button.h"
 #include "DeviceNotification.h"
 #include "N64Controller.h"
-#include <Common\CriticalSection.h>
+#include <Common/CriticalSection.h>
 #define DIRECTINPUT_VERSION 0x0800
 #include <Windows.h>
 #include <dinput.h>

--- a/Source/Project64-input/InputConfigUI.cpp
+++ b/Source/Project64-input/InputConfigUI.cpp
@@ -4,8 +4,8 @@
 #include "wtl-BitmapPicture.h"
 #include "wtl-ScanButton.h"
 #include "OptionsUI.h"
-#include <Common\stdtypes.h>
-#include <Common\StdString.h>
+#include <Common/stdtypes.h>
+#include <Common/StdString.h>
 #include "resource.h"
 
 class CInputConfigUI;

--- a/Source/Project64-input/InputSettings.cpp
+++ b/Source/Project64-input/InputSettings.cpp
@@ -1,5 +1,5 @@
 #include <Settings/Settings.h>
-#include <Common\StdString.h>
+#include <Common/StdString.h>
 #include "InputSettingsID.h"
 #include "InputSettings.h"
 

--- a/Source/Project64-input/InputSettings.h
+++ b/Source/Project64-input/InputSettings.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Common\stdtypes.h>
+#include <Common/stdtypes.h>
 #include <string>
 #include "N64Controller.h"
 #include "ControllerSpec1.1.h"

--- a/Source/Project64-input/OptionsUI.cpp
+++ b/Source/Project64-input/OptionsUI.cpp
@@ -1,7 +1,7 @@
 #include "OptionsUI.h"
 #include "wtl.h"
 #include "resource.h"
-#include <Common\StdString.h>
+#include <Common/StdString.h>
 
 class COptionsDlg :
     public CDialogImpl<COptionsDlg>

--- a/Source/Project64-input/OptionsUI.h
+++ b/Source/Project64-input/OptionsUI.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Common\stdtypes.h>
+#include <Common/stdtypes.h>
 #include "ControllerSpec1.1.h"
 #include "N64Controller.h"
 

--- a/Source/Project64-input/wtl-ScanButton.cpp
+++ b/Source/Project64-input/wtl-ScanButton.cpp
@@ -1,6 +1,6 @@
 #include "wtl-ScanButton.h"
 #include "CProject64Input.h"
-#include <Common\StdString.h>
+#include <Common/StdString.h>
 #include <time.h>
 
 CScanButton::CScanButton(BUTTON & Button, int DisplayCtrlId, int ScanBtnId) :

--- a/Source/Project64-video/TextureEnhancer/tc-1.1+/dxtn.c
+++ b/Source/Project64-video/TextureEnhancer/tc-1.1+/dxtn.c
@@ -17,7 +17,7 @@
 #include <assert.h>
 
 #include <stdio.h>
-#include <Common\stdtypes.h>
+#include <Common/stdtypes.h>
 
 #include "types.h"
 #include "internal.h"

--- a/Source/Project64/UserInterface/CheatClassUI.cpp
+++ b/Source/Project64/UserInterface/CheatClassUI.cpp
@@ -9,7 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #include "stdafx.h"
-#include <Project64-core\N64System\Enhancement\Enhancements.h>
+#include <Project64-core/N64System/Enhancement/Enhancements.h>
 
 CCheatsUI::CCheatsUI(void) :
     m_EditCheat(m_Cheats, m_SelectCheat),

--- a/Source/Project64/UserInterface/CheatClassUI.h
+++ b/Source/Project64/UserInterface/CheatClassUI.h
@@ -10,8 +10,8 @@
 ****************************************************************************/
 #pragma once
 #include <Project64\WTLApp.h>
-#include <Project64-core\N64System\Enhancement\Enhancement.h>
-#include <Project64-core\N64System\Enhancement\EnhancementList.h>
+#include <Project64-core/N64System/Enhancement/Enhancement.h>
+#include <Project64-core/N64System/Enhancement/EnhancementList.h>
 
 class CEditCheat;
 class CCheatsUI;

--- a/Source/Project64/UserInterface/Debugger/Assembler.cpp
+++ b/Source/Project64/UserInterface/Debugger/Assembler.cpp
@@ -16,7 +16,7 @@
 #include "stdafx.h"
 
 #include "Assembler.h"
-#include "Project64-core\N64System\Mips\OpCode.h"
+#include "Project64-core/N64System/Mips/OpCode.h"
 
 ASM_PARSE_ERROR CAssembler::m_ParseError = ERR_NONE;
 uint32_t CAssembler::m_Address = 0;

--- a/Source/Project64/UserInterface/Debugger/Breakpoints.h
+++ b/Source/Project64/UserInterface/Debugger/Breakpoints.h
@@ -9,7 +9,7 @@
 *                                                                           *
 ****************************************************************************/
 #pragma once
-#include <Common\stdtypes.h>
+#include <Common/stdtypes.h>
 #include <map>
 
 class CBreakpoints :

--- a/Source/Project64/UserInterface/Debugger/OpInfo.h
+++ b/Source/Project64/UserInterface/Debugger/OpInfo.h
@@ -12,7 +12,7 @@
 
 #include <stdafx.h>
 
-#include <Project64-core\N64System\Mips\OpCode.h>
+#include <Project64-core/N64System/Mips/OpCode.h>
 
 class COpInfo
 {

--- a/Source/Project64/UserInterface/EnhancementUI.cpp
+++ b/Source/Project64/UserInterface/EnhancementUI.cpp
@@ -10,7 +10,7 @@
 ****************************************************************************/
 #include "stdafx.h"
 #include <Project64\UserInterface\EnhancementUI.h>
-#include <Project64-core\N64System\Enhancement\Enhancements.h>
+#include <Project64-core/N64System/Enhancement/Enhancements.h>
 
 class CEditEnhancement :
     public CDialogImpl < CEditEnhancement >

--- a/Source/Project64/UserInterface/ProjectSupport.cpp
+++ b/Source/Project64/UserInterface/ProjectSupport.cpp
@@ -1,5 +1,5 @@
 #include "stdafx.h"
-#include <Common\md5.h>
+#include <Common/md5.h>
 #include <time.h>
 #include <windows.h>
 #include <Wininet.h>

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Game-Plugin.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Game-Plugin.h
@@ -10,8 +10,8 @@
 ****************************************************************************/
 #pragma once
 
-#include <Project64-core\Plugin.h>
-#include <Project64\Plugins\PluginList.h>
+#include <Project64-core/Plugin.h>
+#include <Project64/Plugins/PluginList.h>
 
 class CGamePluginPage :
     public CSettingsPageImpl<CGamePluginPage>,

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Plugin.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Plugin.h
@@ -10,7 +10,7 @@
 ****************************************************************************/
 #pragma once
 
-#include <Project64-core\Plugin.h>
+#include <Project64-core/Plugin.h>
 
 class COptionPluginPage :
     public CSettingsPageImpl<COptionPluginPage>,

--- a/Source/Project64/UserInterface/WTLControls/GetCWindowText.cpp
+++ b/Source/Project64/UserInterface/WTLControls/GetCWindowText.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 #include "GetCWindowText.h"
-#include <Common\StdString.h>
+#include <Common/StdString.h>
 
 std::string GetCWindowText(const CWindow & window)
 {

--- a/Source/Project64/main.cpp
+++ b/Source/Project64/main.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
-#include <Project64-core\AppInit.h>
-#include "UserInterface\WelcomeScreen.h"
-#include "Settings\UISettings.h"
+#include <Project64-core/AppInit.h>
+#include "UserInterface/WelcomeScreen.h"
+#include "Settings/UISettings.h"
 
 int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR /*lpszArgs*/, int /*nWinMode*/)
 {

--- a/Source/Script/Unix/project64-core.sh
+++ b/Source/Script/Unix/project64-core.sh
@@ -5,6 +5,7 @@ mkdir -p $obj/Multilanguage
 mkdir -p $obj/N64System/Mips
 mkdir -p $obj/N64System/interp
 mkdir -p $obj/N64System/dynarec
+mkdir -p $obj/N64System/enhan
 mkdir -p $obj/Plugins
 mkdir -p $obj/Settings/type
 
@@ -29,7 +30,10 @@ $CC -o $obj/AppInit.asm                 $src/AppInit.cpp $C_FLAGS
 $CC -o $obj/logging.asm                 $src/Logging.cpp $C_FLAGS
 $CC -o $obj/MemoryExceptionFilter.asm   $src/MemoryExceptionFilter.cpp $C_FLAGS
 $CC -o $obj/Multilanguage/LangClass.asm $src/Multilanguage/LanguageClass.cpp $C_FLAGS
-$CC -o $obj/N64System/CheatClass.asm    $src/N64System/CheatClass.cpp $C_FLAGS
+$CC -o $obj/N64System/enhan/Enhance.asm $src/N64System/Enhancement/Enhancement.cpp $C_FLAGS
+$CC -o $obj/N64System/enhan/List.asm    $src/N64System/Enhancement/EnhancementList.cpp $C_FLAGS
+$CC -o $obj/N64System/enhan/File.asm    $src/N64System/Enhancement/EnhancementFile.cpp $C_FLAGS
+$CC -o $obj/N64System/enhan/Enhans.asm  $src/N64System/Enhancement/Enhancements.cpp $C_FLAGS
 $CC -o $obj/N64System/EmuThread.asm     $src/N64System/EmulationThread.cpp $C_FLAGS
 $CC -o $obj/N64System/FPSClass.asm      $src/N64System/FramePerSecondClass.cpp $C_FLAGS
 $CC -o $obj/N64System/interp/CPU.asm    $src/N64System/Interpreter/InterpreterCPU.cpp $C_FLAGS
@@ -67,6 +71,7 @@ $CC -o $obj/N64System/dynarec/Ops.asm   $src/N64System/Recompiler/x86/x86Recompi
 $CC -o $obj/N64System/dynarec/Reg.asm   $src/N64System/Recompiler/x86/x86RegInfo.cpp $C_FLAGS
 $CC -o $obj/N64System/dynarec/Sect.asm  $src/N64System/Recompiler/SectionInfo.cpp $C_FLAGS
 $CC -o $obj/N64System/dynarec/log.asm   $src/N64System/Recompiler/RecompilerCodeLog.cpp $C_FLAGS
+$CC -o $obj/N64System/dynarec/RegB.asm  $src/N64System/Recompiler/RegBase.cpp $C_FLAGS
 $CC -o $obj/N64System/dynarec/x86op.asm $src/N64System/Recompiler/x86/x86ops.cpp $C_FLAGS
 $CC -o $obj/N64System/SpeedLimiter.asm  $src/N64System/SpeedLimiterClass.cpp $C_FLAGS
 $CC -o $obj/N64System/SystemGlobals.asm $src/N64System/SystemGlobals.cpp $C_FLAGS
@@ -82,11 +87,10 @@ $CC -o $obj/Settings/Game.asm           $src/Settings/GameSettings.cpp $C_FLAGS
 $CC -o $obj/Settings/Logging.asm        $src/Settings/LoggingSettings.cpp $C_FLAGS
 $CC -o $obj/Settings/N64System.asm      $src/Settings/N64SystemSettings.cpp $C_FLAGS
 $CC -o $obj/Settings/Recompiler.asm     $src/Settings/RecompilerSettings.cpp $C_FLAGS
-$CC -o $obj/Settings/SettingsClass.asm  $src/Settings/SettingsClass.cpp $C_FLAGS
+$CC -o $obj/Settings.asm                $src/Settings.cpp $C_FLAGS
 $CC -o $obj/Settings/type/App.asm       $src/Settings/SettingType/SettingsType-Application.cpp $C_FLAGS
 $CC -o $obj/Settings/type/AppIndex.asm  $src/Settings/SettingType/SettingsType-ApplicationIndex.cpp $C_FLAGS
 $CC -o $obj/Settings/type/AppPath.asm   $src/Settings/SettingType/SettingsType-ApplicationPath.cpp $C_FLAGS
-$CC -o $obj/Settings/type/Cheats.asm    $src/Settings/SettingType/SettingsType-Cheats.cpp $C_FLAGS
 $CC -o $obj/Settings/type/GSetting.asm  $src/Settings/SettingType/SettingsType-GameSetting.cpp $C_FLAGS
 $CC -o $obj/Settings/type/GSettingX.asm $src/Settings/SettingType/SettingsType-GameSettingIndex.cpp $C_FLAGS
 $CC -o $obj/Settings/type/RDBCpu.asm    $src/Settings/SettingType/SettingsType-RDBCpuType.cpp $C_FLAGS
@@ -110,7 +114,10 @@ $AS -o $obj/AppInit.o                   $obj/AppInit.asm
 $AS -o $obj/logging.o                   $obj/logging.asm
 $AS -o $obj/MemoryExceptionFilter.o     $obj/MemoryExceptionFilter.asm
 $AS -o $obj/Multilanguage/LangClass.o   $obj/Multilanguage/LangClass.asm
-$AS -o $obj/N64System/CheatClass.o      $obj/N64System/CheatClass.asm
+$AS -o $obj/N64System/enhan/Enhance.o   $obj/N64System/enhan/Enhance.asm
+$AS -o $obj/N64System/enhan/List.o      $obj/N64System/enhan/List.asm
+$AS -o $obj/N64System/enhan/File.o      $obj/N64System/enhan/File.asm
+$AS -o $obj/N64System/enhan/Enhans.o    $obj/N64System/enhan/Enhans.asm
 $AS -o $obj/N64System/EmuThread.o       $obj/N64System/EmuThread.asm
 $AS -o $obj/N64System/FPSClass.o        $obj/N64System/FPSClass.asm
 $AS -o $obj/N64System/interp/CPU.o      $obj/N64System/interp/CPU.asm
@@ -148,6 +155,7 @@ $AS -o $obj/N64System/dynarec/Ops.o     $obj/N64System/dynarec/Ops.asm
 $AS -o $obj/N64System/dynarec/Reg.o     $obj/N64System/dynarec/Reg.asm
 $AS -o $obj/N64System/dynarec/Sect.o    $obj/N64System/dynarec/Sect.asm
 $AS -o $obj/N64System/dynarec/log.o     $obj/N64System/dynarec/log.asm
+$AS -o $obj/N64System/dynarec/RegB.o    $obj/N64System/dynarec/RegB.asm
 $AS -o $obj/N64System/dynarec/x86op.o   $obj/N64System/dynarec/x86op.asm
 $AS -o $obj/N64System/SpeedLimiter.o    $obj/N64System/SpeedLimiter.asm
 $AS -o $obj/N64System/SystemGlobals.o   $obj/N64System/SystemGlobals.asm
@@ -163,11 +171,10 @@ $AS -o $obj/Settings/Game.o             $obj/Settings/Game.asm
 $AS -o $obj/Settings/Logging.o          $obj/Settings/Logging.asm
 $AS -o $obj/Settings/N64System.o        $obj/Settings/N64System.asm
 $AS -o $obj/Settings/Recompiler.o       $obj/Settings/Recompiler.asm
-$AS -o $obj/Settings/SettingsClass.o    $obj/Settings/SettingsClass.asm
+$AS -o $obj/Settings.o                  $obj/Settings.asm
 $AS -o $obj/Settings/type/App.o         $obj/Settings/type/App.asm
 $AS -o $obj/Settings/type/AppIndex.o    $obj/Settings/type/AppIndex.asm
 $AS -o $obj/Settings/type/AppPath.o     $obj/Settings/type/AppPath.asm
-$AS -o $obj/Settings/type/Cheats.o      $obj/Settings/type/Cheats.asm
 $AS -o $obj/Settings/type/GSetting.o    $obj/Settings/type/GSetting.asm
 $AS -o $obj/Settings/type/GSettingX.o   $obj/Settings/type/GSettingX.asm
 $AS -o $obj/Settings/type/RDBCpu.o      $obj/Settings/type/RDBCpu.asm
@@ -190,7 +197,10 @@ $obj/AppInit.o \
 $obj/logging.o \
 $obj/MemoryExceptionFilter.o \
 $obj/Multilanguage/LangClass.o \
-$obj/N64System/CheatClass.o \
+$obj/N64System/enhan/Enhance.o \
+$obj/N64System/enhan/List.o \
+$obj/N64System/enhan/File.o \
+$obj/N64System/enhan/Enhans.o \
 $obj/N64System/EmuThread.o \
 $obj/N64System/FPSClass.o \
 $obj/N64System/interp/CPU.o \
@@ -228,6 +238,7 @@ $obj/N64System/dynarec/Ops.o \
 $obj/N64System/dynarec/Reg.o \
 $obj/N64System/dynarec/Sect.o \
 $obj/N64System/dynarec/log.o \
+$obj/N64System/dynarec/RegB.o \
 $obj/N64System/dynarec/x86op.o \
 $obj/N64System/SpeedLimiter.o \
 $obj/N64System/SystemGlobals.o \
@@ -243,11 +254,10 @@ $obj/Settings/Game.o \
 $obj/Settings/Logging.o \
 $obj/Settings/N64System.o \
 $obj/Settings/Recompiler.o \
-$obj/Settings/SettingsClass.o \
+$obj/Settings.o \
 $obj/Settings/type/App.o \
 $obj/Settings/type/AppIndex.o \
 $obj/Settings/type/AppPath.o \
-$obj/Settings/type/Cheats.o \
 $obj/Settings/type/GSetting.o \
 $obj/Settings/type/GSettingX.o \
 $obj/Settings/type/RDBCpu.o \

--- a/Source/UpdateVersion/UpdateVersion.cpp
+++ b/Source/UpdateVersion/UpdateVersion.cpp
@@ -1,8 +1,8 @@
 #include <stdlib.h>
 #include <memory>
-#include <Common\path.h>
-#include <Common\FileClass.h>
-#include <Common\StdString.h>
+#include <Common/path.h>
+#include <Common/FileClass.h>
+#include <Common/StdString.h>
 
 int main()
 {

--- a/Source/nragev20/Interface.cpp
+++ b/Source/nragev20/Interface.cpp
@@ -35,7 +35,7 @@
 #include "PakIO.h"
 #include "Version.h"
 #include "XInputController.h"
-#include <Common\StdString.h>
+#include <Common/StdString.h>
 
 // Prototypes //
 BOOL CALLBACK ControllerTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam );


### PR DESCRIPTION
Trying to fix the build issues with the Unix build script. The issues solved so far:
* Backslashes in include directives are incompatible with `g++`. 
  * They have all been replaced with slashes.
* Build script is out-of-date.
  * New files have been added, old files have been removed.
  * I am unsure if the build order is correct or if I've added all of the relevant files.
    * I believe I've removed the files that need to be removed however, as I am no longer getting missing file errors from the compiler.
* Platform-dependent function definitions are being used without being properly defined for unix-based platforms.
  * This is handled in most places already, but some new ones seems to have appeared.
  * I've included `stdafx.h` or `Common/stdafx.h` to correct those new errors.

Still remaining are the following:
<details><summary>Possible mix up between SearchPath and SearchDir?</summary>

```
In file included from ./../../Project64-core/RomList/../stdafx.h:6,
                 from ./../../Project64-core/RomList/stdafx.h:1,
                 from ./../../Project64-core/RomList/RomList.cpp:11:
./../../Project64-core/RomList/RomList.cpp: In member function ‘void CRomList::FillRomList(strlist&, const char*)’:
./../../Project64-core/RomList/RomList.cpp:158:76: error: ‘SearchPath’ was not declared in this scope
  158 |     WriteTrace(TraceRomList, TraceVerbose, "SearchPath: %s", (const char *)SearchPath);
      |                                                                            ^~~~~~~~~~

./../../Project64-core/RomList/RomList.cpp:168:98: error: ‘SearchPath’ was not declared in this scope
  168 |         WriteTrace(TraceRomList, TraceVerbose, "Found: \"%s\" m_StopRefresh = %s", (const char *)SearchPath, m_StopRefresh ? "true" : "false");
```

This appears to be a Windows SDK method that is not defined for unix-based platforms. A cross-platform solution or a unix-based platform definition should probably be added to imitate it.
</details>

* Corrected variable being used.

<details><summary>Strict Narrowing Conversion Warning Being an Error</summary>

```
./../../Project64-core/Settings/SettingType/SettingsType-RDBSaveChip.cpp: In member function ‘virtual void CSettingTypeRDBSaveChip::Save(uint32_t, uint32_t)’:
./../../Project64-core/Settings/SettingType/SettingsType-RDBSaveChip.cpp:103:10: error: narrowing conversion of ‘SaveChip_Auto’ from ‘int’ to ‘unsigned int’ [-Wnarrowing]
  103 |     case SaveChip_Auto:       m_SettingsIniFile->SaveString(m_SectionIdent->c_str(),m_KeyName.c_str(),"First Save Type"); break;
      |          ^~~~~~~~~~~~~
```

g++ really doesn't like the "-1" value for `SaveChip_Auto` in it's enum. This can be ignored by adding the `-Wno-narrowing` compiler flag, but seems extremely overkill to me.

</details>

* Ignore the error in that area (for now)