### PR TITLE
Fix WelcomeScreen setting Default_GFX_Plugin

### DIFF
--- a/Source/Project64-core/Settings.cpp
+++ b/Source/Project64-core/Settings.cpp
@@ -375,7 +375,8 @@ void CSettings::AddHowToHandleSetting(const char * BaseDirectory)
 #ifdef _WIN32
     AddHandler(Plugin_RSP_Current, new CSettingTypeApplication("Plugin", "RSP Dll", "RSP\\RSP 1.7.dll"));
 #ifdef _DEBUG
-	AddHandler(Plugin_GFX_Current, new CSettingTypeApplication("Plugin", "Graphics Dll", "GFX\\Project64-Video_d.dll"));
+    AddHandler(Plugin_GFX_Default, new CSettingTypeApplication("Plugin", "Graphics Dll Default", "GFX\\Project64-Video_d.dll"));
+	AddHandler(Plugin_GFX_Current, new CSettingTypeApplication("Plugin", "Graphics Dll", Plugin_GFX_Default));
 	AddHandler(Plugin_AUDIO_Current, new CSettingTypeApplication("Plugin", "Audio Dll", "Audio\\Project64-Audio_d.dll"));
     AddHandler(Plugin_CONT_Current, new CSettingTypeApplication("Plugin", "Controller Dll", "Input\\Project64-Input_d.dll"));
 #else

--- a/Source/Project64/UserInterface/WelcomeScreen.cpp
+++ b/Source/Project64/UserInterface/WelcomeScreen.cpp
@@ -104,7 +104,12 @@ LRESULT WelcomeScreen::OnOkCmd(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCt
         Notify().AddRecentDir(GameDir);
     }
 
-    g_Settings->SaveString(Plugin_GFX_Default, CButton(GetDlgItem(IDC_RADIO_GLIDEN64)).GetCheck() == BST_CHECKED ? "GFX\\GLideN64\\GLideN64.dll" : "GFX\\Project64-Video.dll");
+    string Project64VideoPluginPath = g_Settings->LoadStringVal(Plugin_GFX_Default);
+    if (Project64VideoPluginPath.find("Project64-Video") == string::npos) {
+        Project64VideoPluginPath = "GFX\\Project64-Video.dll";
+    }
+    g_Settings->SaveString(Plugin_GFX_Default, CButton(GetDlgItem(IDC_RADIO_GLIDEN64)).GetCheck() == BST_CHECKED ? "GFX\\GLideN64\\GLideN64.dll" : Project64VideoPluginPath);
+    g_Settings->SaveString(Plugin_GFX_Current, g_Settings->LoadStringVal(Plugin_GFX_Default));
     EndDialog(0);
     return TRUE;
 }


### PR DESCRIPTION
Settings.cpp - Was missing a value for the new SettingID while running a
Debug build causing breakpoint to be handled when clicking OK. A new
handler with a default value has been added.

WelcomeScreen.cpp - Would set the Default_GFX_Plugin value and the value
would be used when launching a game or viewing the Plugins menu in
Options and set the Current_GFX_Plugin, but if a user were to try to
configure their Graphics Plugin prior to launching a game, they would
always open the Project64 Video config screen, even if they had chosen
GLideN64 as the default plugin. The Current_GFX_Plugin is now set with
the value of the Default_GFX_Plugin to ensure the correct configuration
dialog is opened.

WelcomeScreen.cpp - String value would always load the non-debug version
of Project64 Video after the above changes. The string to use is now
loaded from the Default_GFX_Plugin so if the default has never been set
the proper default value should now be used. If it has been set before
and is not a Project64 Video plugin, the value will be set to Project64
Video (non-debug) to keep the dialog accurate.