### PR TITLE
Settings: Fix titlebar Close button

### DIFF
--- a/Source/Project64/UserInterface/SettingsConfig.cpp
+++ b/Source/Project64/UserInterface/SettingsConfig.cpp
@@ -223,6 +223,7 @@ LRESULT CSettingConfig::OnClicked(WORD /*wNotifyCode*/, WORD wID, HWND, BOOL& /*
         ApplySettings(false);
         EndDialog(1);
         break;
+    case IDCANCEL:
     case IDC_CANCEL:
         EndDialog(0);
         break;


### PR DESCRIPTION
IDCANCEL is still sent by the native Close button in the titlebar and
should still be handled.