### PR TITLE
Fix Opening 7zip files

### DIFF
--- a/Source/Project64-core/N64System/N64RomClass.cpp
+++ b/Source/Project64-core/N64System/N64RomClass.cpp
@@ -744,6 +744,7 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
 
             if (!AllocateRomImage(RomFileSize))
             {
+                WriteTrace(TraceN64System, TraceDebug, "Done (res: false)");
                 return false;
             }
 
@@ -752,6 +753,7 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
             if (!ZipFile.GetFile(i, m_ROMImage, RomFileSize))
             {
                 SetError(MSG_FAIL_IMAGE_IPL);
+                WriteTrace(TraceN64System, TraceDebug, "Done (res: false)");
                 return false;
             }
 
@@ -763,6 +765,7 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
                     continue;
                 }
                 SetError(MSG_FAIL_IMAGE_IPL);
+                WriteTrace(TraceN64System, TraceDebug, "Done (res: false)");
                 return false;
             }
             g_Notify->DisplayMessage(5, MSG_BYTESWAP);
@@ -776,6 +779,7 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
         if (!Loaded7zFile)
         {
             SetError(MSG_7Z_FILE_NOT_FOUND);
+            WriteTrace(TraceN64System, TraceDebug, "Done (res: false)");
             return false;
         }
     }

--- a/Source/Project64-core/N64System/N64RomClass.cpp
+++ b/Source/Project64-core/N64System/N64RomClass.cpp
@@ -510,18 +510,16 @@ bool CN64Rom::LoadN64Image(const char * FileLoc, bool LoadBootCodeOnly)
 
         //this should be a 7zip file
         char * SubFile = strstr(const_cast<char*>(FullPath.c_str()), "?");
-        if (SubFile == NULL)
-        {
-            //Pop up a dialog and select file
-            //allocate memory for sub name and copy selected file name to var
-            WriteTrace(TraceN64System, TraceDebug, "Done (res: false)");
-            return false; //remove once dialog is done
-        }
-        else
+        if (SubFile != NULL)
         {
             *SubFile = '\0';
             SubFile += 1;
         }
+    	//else load first found file until dialog is implemented
+        //{
+	        //Pop up a dialog and select file
+	        //allocate memory for sub name and copy selected file name to var
+        //}
 
         C7zip ZipFile(FullPath.c_str());
         ZipFile.SetNotificationCallback((C7zip::LP7ZNOTIFICATION)NotificationCB, this);
@@ -565,6 +563,11 @@ bool CN64Rom::LoadN64Image(const char * FileLoc, bool LoadBootCodeOnly)
 
             if (!IsValidRomImage(m_ROMImage))
             {
+            	if (i < ZipFile.NumFiles() - 1)
+            	{
+                    UnallocateRomImage();
+                    continue;
+            	}
                 SetError(MSG_FAIL_IMAGE);
                 WriteTrace(TraceN64System, TraceDebug, "Done (res: false)");
                 return false;
@@ -703,17 +706,16 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
 
         //this should be a 7zip file
         char * SubFile = strstr(const_cast<char*>(FullPath.c_str()), "?");
-        if (SubFile == NULL)
-        {
-            //Pop up a dialog and select file
-            //allocate memory for sub name and copy selected file name to var
-            return false; //remove once dialog is done
-        }
-        else
+        if (SubFile != NULL)
         {
             *SubFile = '\0';
             SubFile += 1;
         }
+        //else load first found file until dialog is implemented
+        //{
+            //Pop up a dialog and select file
+            //allocate memory for sub name and copy selected file name to var
+        //}
 
         C7zip ZipFile(FullPath.c_str());
         ZipFile.SetNotificationCallback((C7zip::LP7ZNOTIFICATION)NotificationCB, this);
@@ -755,6 +757,11 @@ bool CN64Rom::LoadN64ImageIPL(const char * FileLoc, bool LoadBootCodeOnly)
 
             if (!IsValidRomImage(m_ROMImage))
             {
+                if (i < ZipFile.NumFiles() - 1)
+                {
+                    UnallocateRomImage();
+                    continue;
+                }
                 SetError(MSG_FAIL_IMAGE_IPL);
                 return false;
             }

--- a/Source/Project64-core/RomList/RomList.cpp
+++ b/Source/Project64-core/RomList/RomList.cpp
@@ -231,7 +231,7 @@ void CRomList::FillRomList(strlist & FileList, const char * Directory)
                         }
                         WriteTrace(TraceUserInterface, TraceDebug, "7");
                         memset(&RomInfo, 0, sizeof(ROM_INFO));
-                        stdstr_f zipFileName("%s?%s", (LPCSTR)SearchPath, FileName.c_str());
+                        stdstr_f zipFileName("%s?%s", (LPCSTR)SearchDir, FileName.c_str());
                         ZipFile.SetNotificationCallback((C7zip::LP7ZNOTIFICATION)NotificationCB, this);
 
                         strncpy(RomInfo.szFullFileName, zipFileName.c_str(), sizeof(RomInfo.szFullFileName) - 1);

--- a/Source/Project64-core/RomList/RomList.cpp
+++ b/Source/Project64-core/RomList/RomList.cpp
@@ -310,7 +310,7 @@ void CRomList::FillRomList(strlist & FileList, const char * Directory)
                 }
                 catch (...)
                 {
-                    WriteTrace(TraceUserInterface, TraceError, "exception processing %s", (LPCSTR)SearchPath);
+                    WriteTrace(TraceUserInterface, TraceError, "exception processing %s", (LPCSTR)SearchDir);
                 }
             }
 #endif


### PR DESCRIPTION
Was also mistakenly using the Windows API `SearchPath` define. Part of #2001 is corrected by this.