### PR TITLE
Add another possible format to Gameshark codes

### DIFF
--- a/Source/Project64-core/N64System/Enhancement/Enhancement.cpp
+++ b/Source/Project64-core/N64System/Enhancement/Enhancement.cpp
@@ -217,6 +217,7 @@ CEnhancement::CEnhancement(const char * Ident, const char * Entry) :
         }
         if (strcmp(TempFormat, "XXXXXXXX XXXX") != 0 &&
             strcmp(TempFormat, "XXXXXXXX XX??") != 0 &&
+            strcmp(TempFormat, "XXXXXXXX ??XX") != 0 &&
             strcmp(TempFormat, "XXXXXXXX ????") != 0 &&
             strcmp(TempFormat, "XXXXXXXX XXXX:XXXX") != 0)
         {


### PR DESCRIPTION
`XXXXXXXX ??XX` seems to be used for some game cheats, such as one in Conker's Bad Fur Day. This should fix #2009.