### PR TITLE
Chose correct default Windows SDK

### DIFF
--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -2,8 +2,8 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Globals">
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND $(PlatformToolsetVersion) >= 142">10.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolsetVersion)' != '' AND $(PlatformToolsetVersion) >= 142">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolsetVersion)' != ''AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 

--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -2,14 +2,21 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Globals">
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND $(PlatformToolsetVersion) >= 142">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolset)' == 'v142'">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
+  <Target Name="erasme">
+    <Message Text="VisualStudioVersion: [$(VisualStudioVersion)]" />
+    <Message Text="PlatformToolset: [$(PlatformToolset)]" />
+    <Message Text="WindowsTargetPlatformVersion: [$(WindowsTargetPlatformVersion)]" />
+    <Message Text="WindowsTargetPlatformMinVersion: [$(WindowsTargetPlatformMinVersion)]" />
+  </Target>
+
   <PropertyGroup Label="Configuration">
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND $(PlatformToolsetVersion)&lt;142">$(DefaultPlatformToolset)_xp</PlatformToolset>
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'>='v142'">$(DefaultPlatformToolset)</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(DefaultPlatformToolset)'!='v142'">$(DefaultPlatformToolset)_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'=='v142'">$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
 

--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -1,6 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup Label="Globals">
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolset)' == 'v142'">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
+  </PropertyGroup>
+
+  <Target Name="erasme">
+    <Message Text="VisualStudioVersion: [$(VisualStudioVersion)]" />
+    <Message Text="PlatformToolset: [$(PlatformToolset)]" />
+    <Message Text="WindowsTargetPlatformVersion: [$(WindowsTargetPlatformVersion)]" />
+    <Message Text="WindowsTargetPlatformMinVersion: [$(WindowsTargetPlatformMinVersion)]" />
+  </Target>
+
   <PropertyGroup Label="Configuration">
     <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(DefaultPlatformToolset)'!='v142'">$(DefaultPlatformToolset)_xp</PlatformToolset>
     <PlatformToolset Condition="'$(DefaultPlatformToolset)'=='v142'">$(DefaultPlatformToolset)</PlatformToolset>

--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -2,21 +2,14 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Globals">
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolset)' == 'v142'">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND $(PlatformToolsetVersion) >= 142">10.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
-  <Target Name="erasme">
-    <Message Text="VisualStudioVersion: [$(VisualStudioVersion)]" />
-    <Message Text="PlatformToolset: [$(PlatformToolset)]" />
-    <Message Text="WindowsTargetPlatformVersion: [$(WindowsTargetPlatformVersion)]" />
-    <Message Text="WindowsTargetPlatformMinVersion: [$(WindowsTargetPlatformMinVersion)]" />
-  </Target>
-
   <PropertyGroup Label="Configuration">
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(DefaultPlatformToolset)'!='v142'">$(DefaultPlatformToolset)_xp</PlatformToolset>
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'=='v142'">$(DefaultPlatformToolset)</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND $(PlatformToolsetVersion)&lt;142">$(DefaultPlatformToolset)_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'>='v142'">$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
 

--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -2,8 +2,8 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Globals">
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolsetVersion)' != '' AND $(PlatformToolsetVersion) >= 142">10.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolsetVersion)' != ''AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND $(PlatformToolsetVersion) >= 142">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 

--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -3,13 +3,13 @@
 
   <PropertyGroup Label="Globals">
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolsetVersion)' != '' AND $(PlatformToolsetVersion) >= 142">10.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolsetVersion)' != ''AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolsetVersion)' != '' AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND $(PlatformToolsetVersion)&lt;142">$(DefaultPlatformToolset)_xp</PlatformToolset>
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'>='v142'">$(DefaultPlatformToolset)</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(PlatformToolsetVersion)' != '' AND $(PlatformToolsetVersion)&lt;142">$(DefaultPlatformToolset)_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(PlatformToolsetVersion)' != '' AND $(PlatformToolsetVersion) >= 142">$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
 

--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -3,13 +3,13 @@
 
   <PropertyGroup Label="Globals">
     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolsetVersion)' != '' AND $(PlatformToolsetVersion) >= 142">10.0</WindowsTargetPlatformVersion>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolsetVersion)' != '' AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' AND '$(PlatformToolsetVersion)' != ''AND '$(VisualStudioVersion)' >= 16.0">10.0.19041.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>8.1</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration">
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(PlatformToolsetVersion)' != '' AND $(PlatformToolsetVersion)&lt;142">$(DefaultPlatformToolset)_xp</PlatformToolset>
-    <PlatformToolset Condition="'$(PlatformToolsetVersion)' != '' AND $(PlatformToolsetVersion) >= 142">$(DefaultPlatformToolset)</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND $(PlatformToolsetVersion)&lt;142">$(DefaultPlatformToolset)_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'>='v142'">$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
 


### PR DESCRIPTION
When using an older MSVC compiler toolset than the default for the Visual Studio version, build fails to select or find the correct Windows SDK installation.

Example:
Visual Studio 2019 can install the VS 2015 (MSVC  `v140`) compilers, but that compiler version assumes the installation of Windows SDK version 8.1.

## Proposed Changes

  - Explicitly set the minimum target Windows SDK version (8.1)
  - Allow MSBuild to select the  most likely Windows SDK installation, based on the Visual Studio version:
    - When using MSVC `v142`, using `10.0` will select the highest available `10.0.*` instance.
    - When using VS2019 but an older MSVC (i.e. `v140`), which can not use the `10.0` metavalue, use the default SDK version provided by Visual Studio as of the current release (`10.0.19041.0`).
    - Any other scenario will default the SDK version to `8.1`, which is available in VS 2017 and VS 2015.
