### PR TITLE
Remove leftovers from boxart being present on DiscordRPC

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -3702,7 +3702,6 @@ Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
-RPC Key=mp1-u
 
 [82380387-DFC744D9-C:50]
 Good Name=Mario Party 2 (E) (M5)
@@ -3727,7 +3726,6 @@ Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
-RPC Key=mp2-u
 
 [C5674160-0F5F453C-C:50]
 Good Name=Mario Party 3 (E) (M4)
@@ -3754,7 +3752,6 @@ Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
-RPC Key=mp3-u
 Save Type=16kbit Eeprom
 
 [3BA7CDDC-464E52A0-C:4A]


### PR DESCRIPTION
This PR removes the keys from the RDB. This was present for showing box art on Project64's Discord RPC. For example a key named mp2-u and a asset uploaded as the Mario Party 2 box art on the discord project64 developer panel would show this box art. This feature was never used and as such it is just nullifying the image. Its a small bug but there is 2 ways you can fix this.

1) Upload the BoxArt and close this Pull Request. The community would probably prefer this approach and it will show the box art of the game you are playing on the status, and possibly other games that Zilmar declares popular.

2) Merge this PR and as such no box art will be shown and possibly the removal of the RPC Key in the code as a cleanup for the 3.0 project.