### PR TITLE
[PJ64-Nrage]the n64 analog stick cannot ever hit 127 and letting it do so breaks some games

### DIFF
--- a/Source/nragev20/XInputController.h
+++ b/Source/nragev20/XInputController.h
@@ -61,7 +61,7 @@ number, ie. first XInput controller is first N64 player, etc.
 #include <xinput.h>
 
 // Defines
-#define N64_ANALOG_MAX 127
+#define N64_ANALOG_MAX 88
 #define XC_ANALOG_MAX 32767
 #define BUTTON_ANALOG_VALUE 60
 


### PR DESCRIPTION
reduces the n64 analog max definition to 88 (from 127)
Fixes #2072

### Does this make breaking changes?

This change should only result in fixing the few games that don't clamp high axis values.