### PR TITLE
Fix controller settings not saving the Controller Pak plugin

### DIFF
--- a/Source/Project64-input/InputConfigUI.cpp
+++ b/Source/Project64-input/InputConfigUI.cpp
@@ -171,6 +171,7 @@ LRESULT CControllerSettings::OnApply()
     Controller.DeadZone = (uint8_t)m_DeadZone.GetPos();
     CONTROL & ControlInfo = g_InputPlugin->ControlInfo(m_ControllerNumber);
     ControlInfo.Present = (m_PluggedIn.GetCheck() == BST_CHECKED) ? 1 : 0;
+    ControlInfo.Plugin = m_ControlInfo.Plugin;
     return g_InputPlugin->SaveController(m_ControllerNumber) ? PSNRET_NOERROR : PSNRET_INVALID_NOCHANGEPAGE;
 }
 


### PR DESCRIPTION
This fixes issue #2019

When the controller settings UI attempts to save the controller settings (via `OnApply()`), the UI passes its controller info `Plugin` value over to the `CProject64Input` controller info before saving. Previously, it was not passing that data over, so the controller was always being saved with the default value (0x02: Mem Pak).

Fixes #2019 

### Proposed changes
  - Save controller plugin value when applying controller setting changes.

### Does this make breaking changes?
No

### Does this version of Project64 compile and run without issue?
Yes