### PR TITLE
[Core] Set GameRunning_InReset=false after reset

### DIFF
--- a/Source/Project64-core/N64System/N64System.cpp
+++ b/Source/Project64-core/N64System/N64System.cpp
@@ -890,7 +890,7 @@ void CN64System::Reset(bool bInitReg, bool ClearMenory)
     {
         m_SyncCPU->Reset(bInitReg, ClearMenory);
     }
-    g_Settings->SaveBool(GameRunning_InReset, true);
+    g_Settings->SaveBool(GameRunning_InReset, false);
 
     WriteTrace(TraceN64System, TraceDebug, "Done");
 }


### PR DESCRIPTION
Prevents the debugger's GameReset callback from firing twice