### PR TITLE
Add missing argument to mem.setblock

### DIFF
--- a/Source/Project64/UserInterface/Debugger/ScriptAPI/ScriptAPI_mem.cpp
+++ b/Source/Project64/UserInterface/Debugger/ScriptAPI/ScriptAPI_mem.cpp
@@ -211,7 +211,7 @@ duk_ret_t ScriptAPI::js_mem_getstring(duk_context *ctx)
 
 duk_ret_t ScriptAPI::js_mem_setblock(duk_context *ctx)
 {
-    CheckArgs(ctx, { Arg_Number, Arg_OptNumber });
+    CheckArgs(ctx, { Arg_Number, Arg_Any, Arg_OptNumber });
     CScriptInstance *inst = GetInstance(ctx);
     CDebuggerUI *debugger = inst->Debugger();
 


### PR DESCRIPTION
According to the documentation, `mem.setblock` should take an address, data, and an optional length. Currently, `mem.setblock` can only take two numbers, so using the example in the documentation results in:

`TypeError: argument 1 invalid, expected number`

### Proposed changes
  - Add `Arg_Any` to `mem.setblock` arguments so it works as intended

### Does this make breaking changes?
No

### Does this version of Project64 compile and run without issue?
Yes