### PR TITLE
Change CRC for 64DD Disks + better ROM Browser support for 64DD

### DIFF
--- a/Config/Cheats/Mario Artist Paint Studio (J).cht
+++ b/Config/Cheats/Mario Artist Paint Studio (J).cht
@@ -1,4 +1,4 @@
-[D06F15D7-2F90EA28-C:4A]
+[0E652C21-F19AD3DE-C:4A]
 Name=Mario Artist Paint Studio (J)
 
 $Unlock All Jurassic World Dinosaurs

--- a/Config/Cheats/Mario Artist Polygon Studio (J) [T+Eng].cht
+++ b/Config/Cheats/Mario Artist Polygon Studio (J) [T+Eng].cht
@@ -1,5 +1,5 @@
-[D889EB0F-277614F0-C:4A]
-Name=Mario Artist Polygon Studio (J)
+[D889EB0F-277614F0-C:45]
+Name=Mario Artist Polygon Studio (J) [T+Eng]
 
 $Unlock All ? Blocks
 50001C04 0000

--- a/Config/Cheats/Sim City 64 (J).cht
+++ b/Config/Cheats/Sim City 64 (J).cht
@@ -1,4 +1,4 @@
-[7BD92DC6-8426D239-C:4A]
+[9C40016E-63BFFE91-C:4A]
 Name=Sim City 64 (J)
 
 $All Bonus Buildings

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -7898,80 +7898,80 @@ Good Name=64DD TOOL IPL (JPN)
 Status=Compatible
 Fixed Audio=0
 
-[D06F15D7-2F90EA28-C:4A]
+[0E652C21-F19AD3DE-C:4A]
 Good Name=Mario Artist Paint Studio (J)
 Status=Compatible
 Fixed Audio=0
 
-[56A227D6-A95DD829-C:4A]
+[A2569512-5DA96AED-C:4A]
 Good Name=Mario Artist Talent Studio (J)
 Status=Compatible
 Fixed Audio=0
 
-[30B9A412-CF465BED-C:4A]
+[4D0319BD-B2FCE642-C:4A]
 Good Name=Mario Artist Communication Kit (J)
 Status=Compatible
 Fixed Audio=0
 
-[2E91FFC8-D16E0037-C:4A]
+[D889EB0F-277614F0-C:4A]
 Good Name=Mario Artist Polygon Studio (J)
 Status=Issues (plugin)
 Fixed Audio=0
 
-[7BD92DC6-8426D239-C:4A]
+[9C40016E-63BFFE91-C:4A]
 Good Name=Sim City 64 (J)
 Status=Issues (plugin)
 Linking=Off
 
-[905063EB-6FAF9C14-C:4A]
+[65E02B30-9A1FD4CF-C:4A]
 Good Name=Nihon Pro Golf Tour 64 (J)
 Status=Compatible
 Counter Factor=1
 Fixed Audio=0
 
-[A11940D1-5EE6BF2E-C:4A]
+[E0125D56-1FEDA2A9-C:4A]
 Good Name=Kyojin no Doshin 1 (J)
 Status=Compatible
 Fixed Audio=0
 
-[A1193471-5EE6CB8E-C:4A]
+[F4D293CC-0B2D6C33-C:4A]
 Good Name=Kyojin no Doshin 1 (J) (Store Demo)
 Status=Compatible
 Fixed Audio=0
 
-[8EFB4B2D-7104B4D2-C:4A]
+[45FD11C0-BA02EE3F-C:4A]
 Good Name=Randnet Disk (J) [Rev. 00]
 Status=Only intro/part OK
 Fixed Audio=0
 
-[8EFC7632-710389CD-C:4A]
+[8DBCAE69-72435196-C:4A]
 Good Name=Randnet Disk (J) [Rev. 01]
 Status=Only intro/part OK
 Fixed Audio=0
 
-[B75CBC4E-48A343B1-C:4A]
+[0890ED9D-F76F1262-C:4A]
 Good Name=Kyojin no Doshin - Kaihou Sensen Chibikkochikko Dai Shuugou (J)
 Status=Compatible
 Fixed Audio=0
 
-[CD999CC9-32666336-C:4A]
+[32A47D0F-CD5B82F0-C:4A]
 Good Name=F-ZERO X Expansion Kit (J)
 Status=Compatible
 Culling=1
 Fixed Audio=0
 
-[41252DA2-BEDAD25D-C:0]
+[6974573F-968BA8C0-C:0]
 Good Name=Super Mario 64 Disk Version (J) (Spaceworld 1996 Demo)
 Status=Compatible
 Fixed Audio=0
 
-[87FAF438-78050BC7-C:41]
+[6E059418-91FA6BE7-C:41]
 Good Name=Dezaemon 3D Expansion Disk (J) (Proto)
 Status=Compatible
 32bit=Yes
 Save Type=Sram
 
-[D06E3B75-2F91C48A-C:54]
+[63BBA730-9C4458CF-C:54]
 Good Name=Mario Artist Paint Studio (J) (1999-02-11 Proto)
 Status=Compatible
 Counter Factor=1
@@ -9412,6 +9412,8 @@ Status=Issues (core)
 32bit=Yes
 CPU Type=Interpreter
 
+//================  N64 FAN TRANSLATIONS  ================
+
 [002FE030-FFD01FCF-C:45]
 Good Name=Zelda 64 Dawn & Dusk - Expansion Disk (U)
 Status=Compatible
@@ -9444,16 +9446,25 @@ SMM-PI DMA=0
 SMM-Protect=1
 SMM-TLB=0
 
-[CD999CC9-32666336-C:45]
-Good Name=F-ZERO X Expansion Kit (U)
+[32A47D0F-CD5B82F0-C:45]
+Good Name=F-ZERO X Expansion Kit (J) [T+Eng]
 Status=Compatible
 Culling=1
 Fixed Audio=0
 
-[2E91FFC8-D16E0037-C:45]
-Good Name=Mario Artist Polygon Studio (U)
+[D889EB0F-277614F0-C:45]
+Good Name=Mario Artist Polygon Studio (J) [T+Eng]
 Status=Issues (plugin)
 Fixed Audio=0
+
+[5BA2BBC0-4C9C0D28-C:45]
+Good Name=Mario no Photopi (J) [T+Eng]
+Internal Name=ÏØµÉÌ«ÄËß°
+Status=Issues (plugin)
+32bit=Yes
+HLE GFX=No
+RDRAM Size=4
+RSP-SemaphoreExit=1
 
 //================  N64 HACKS/MODS  ================
 

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -7971,6 +7971,12 @@ Status=Compatible
 32bit=Yes
 Save Type=Sram
 
+[BB7CD63F-448329C0-C:41]
+Good Name=Dezaemon 3D Expansion Disk (J) (Proto) [a1]
+Status=Compatible
+32bit=Yes
+Save Type=Sram
+
 [63BBA730-9C4458CF-C:54]
 Good Name=Mario Artist Paint Studio (J) (1999-02-11 Proto)
 Status=Compatible

--- a/Source/Project64-core/N64System/N64Disk.cpp
+++ b/Source/Project64-core/N64System/N64Disk.cpp
@@ -572,8 +572,8 @@ void CN64Disk::UnallocateDiskImage()
 uint32_t CN64Disk::CalculateCrc()
 {
     // Custom CRC
-    int crc = 0;
-    for (int i = 0; i < 0x200; i += 4)
+    uint32_t crc = 0;
+    for (int i = 0; i < 0x4D08; i += 4)
     {
         crc += *(uint32_t*)(&GetDiskAddressRom()[i]);
     }

--- a/Source/Project64-core/N64System/N64Disk.h
+++ b/Source/Project64-core/N64System/N64Disk.h
@@ -21,6 +21,7 @@ public:
     uint8_t *  GetDiskAddressID() { return m_DiskImage + m_DiskIDAddress; }
     uint8_t *  GetDiskAddressRom() { return m_DiskImage + m_DiskRomAddress; }
     uint8_t *  GetDiskAddressRam() { return m_DiskImage + m_DiskRamAddress; }
+    uint32_t GetDiskSize() const { return m_DiskFileSize; }
     uint8_t *  GetDiskHeader() { return m_DiskHeader; }
     void    SetDiskAddressBuffer(uint32_t address) { m_DiskBufAddress = address; }
     uint32_t   GetDiskAddressBlock(uint16_t head, uint16_t track, uint16_t block, uint16_t sector, uint16_t sectorsize);

--- a/Source/Project64-core/RomList/RomList.cpp
+++ b/Source/Project64-core/RomList/RomList.cpp
@@ -455,7 +455,7 @@ bool CRomList::LoadDataFromRomFile(const char * FileName, uint8_t * Data, int32_
                 return false;
             }
             File.Seek(romdataoffset, CFileBase::begin);
-            if (!File.Read(Data + 0x200, 0x200))
+            if (!File.Read(Data + 0x200, 0x4D08))
             {
                 return false;
             }
@@ -484,7 +484,7 @@ bool CRomList::LoadDataFromRomFile(const char * FileName, uint8_t * Data, int32_
                 return false;
             }
             File.Seek(romdataoffset, CFileBase::begin);
-            if (!File.Read(Data + 0x200, 0x200))
+            if (!File.Read(Data + 0x200, 0x4D08))
             {
                 return false;
             }
@@ -503,7 +503,7 @@ bool CRomList::LoadDataFromRomFile(const char * FileName, uint8_t * Data, int32_
 
 bool CRomList::FillRomInfo(ROM_INFO * pRomInfo)
 {
-    uint8_t RomData[0x1000];
+    uint8_t RomData[0x4F08];
 
     if (LoadDataFromRomFile(pRomInfo->szFullFileName, RomData, sizeof(RomData), &pRomInfo->RomSize, pRomInfo->FileFormat))
     {
@@ -543,13 +543,13 @@ bool CRomList::FillRomInfo(ROM_INFO * pRomInfo)
             char InternalName[22];
             memcpy(InternalName, (void *)(RomData + 0x100), 4);
             strcpy(pRomInfo->InternalName, InternalName);
-            pRomInfo->CartID[0] = *(RomData + 0x100);
+            pRomInfo->CartID[0] = *(RomData + 0x102);
             pRomInfo->CartID[1] = *(RomData + 0x101);
-            pRomInfo->CartID[2] = *(RomData + 0x102);
-            pRomInfo->Media = '\0';
+            pRomInfo->CartID[2] = '\0';
+            pRomInfo->Media = *(RomData + 0x103);
             pRomInfo->Country = *(RomData + 0x100);
             pRomInfo->CRC1 = 0;
-            for (uint32_t i = 0; i < 0x200; i += 4)
+            for (uint32_t i = 0; i < 0x4D08; i += 4)
             {
                 pRomInfo->CRC1 += *(uint32_t *)(&RomData[0x200 + i]);
             }

--- a/Source/Project64/UserInterface/RomBrowser.cpp
+++ b/Source/Project64/UserInterface/RomBrowser.cpp
@@ -706,6 +706,8 @@ void CRomBrowser::RomList_GetDispInfo(uint32_t pnmh)
         switch (pRomInfo->Media)
         {
         case 'C':wcsncpy(lpdi->item.pszText, L"N64 Cartridge (Disk Compatible)", lpdi->item.cchTextMax / sizeof(wchar_t)); break;
+        case 'D':wcsncpy(lpdi->item.pszText, L"64DD Disk", lpdi->item.cchTextMax / sizeof(wchar_t)); break;
+        case 'E':wcsncpy(lpdi->item.pszText, L"64DD Disk (Expansion)", lpdi->item.cchTextMax / sizeof(wchar_t)); break;
         case 'N':wcsncpy(lpdi->item.pszText, L"N64 Cartridge", lpdi->item.cchTextMax / sizeof(wchar_t)); break;
         case 'Z':wcsncpy(lpdi->item.pszText, L"Aleck64", lpdi->item.cchTextMax / sizeof(wchar_t)); break;
         case 0:  wcsncpy(lpdi->item.pszText, L"None", lpdi->item.cchTextMax / sizeof(wchar_t)); break;

--- a/Source/Project64/UserInterface/RomInformation.cpp
+++ b/Source/Project64/UserInterface/RomInformation.cpp
@@ -166,14 +166,14 @@ DWORD CALLBACK RomInfoProc(HWND hDlg, DWORD uMsg, DWORD wParam, DWORD lParam)
             SetDlgItemText(hDlg, IDC_ROM_NAME, wGS(INFO_ROM_NAME_TEXT).c_str());
             SetDlgItemText(hDlg, IDC_FILE_NAME, wGS(INFO_FILE_NAME_TEXT).c_str());
             SetDlgItemText(hDlg, IDC_LOCATION, wGS(INFO_LOCATION_TEXT).c_str());
-            //SetDlgItemText(hDlg, IDC_ROM_MD5, wGS(INFO_MD5_TEXT).c_str());
-            //SetDlgItemText(hDlg, IDC_ROM_SIZE, wGS(INFO_SIZE_TEXT).c_str());
+            SetDlgItemText(hDlg, IDC_ROM_MD5, wGS(INFO_MD5_TEXT).c_str());
+            SetDlgItemText(hDlg, IDC_ROM_SIZE, wGS(INFO_SIZE_TEXT).c_str());
             SetDlgItemText(hDlg, IDC_CART_ID, wGS(INFO_CART_ID_TEXT).c_str());
-            //SetDlgItemText(hDlg, IDC_MEDIA, wGS(INFO_MEDIA_TEXT).c_str());
+            SetDlgItemText(hDlg, IDC_MEDIA, wGS(INFO_MEDIA_TEXT).c_str());
             SetDlgItemText(hDlg, IDC_COUNTRY, wGS(INFO_COUNTRY_TEXT).c_str());
-            //SetDlgItemText(hDlg, IDC_CRC1, wGS(INFO_CRC1_TEXT).c_str());
-            //SetDlgItemText(hDlg, IDC_CRC2, wGS(INFO_CRC2_TEXT).c_str());
-            //SetDlgItemText(hDlg, IDC_CIC_CHIP, wGS(INFO_CIC_CHIP_TEXT).c_str());
+            SetDlgItemText(hDlg, IDC_CRC1, wGS(INFO_CRC1_TEXT).c_str());
+            SetDlgItemText(hDlg, IDC_CRC2, wGS(INFO_CRC2_TEXT).c_str());
+            SetDlgItemText(hDlg, IDC_CIC_CHIP, wGS(INFO_CIC_CHIP_TEXT).c_str());
             SetDlgItemText(hDlg, IDC_CLOSE_BUTTON, wGS(BOTTOM_CLOSE).c_str());
 
             SetDlgItemText(hDlg, IDC_INFO_ROMNAME, _this->m_pDiskInfo->GetRomName().ToUTF16(stdstr::CODEPAGE_932).c_str());
@@ -182,18 +182,18 @@ DWORD CALLBACK RomInfoProc(HWND hDlg, DWORD uMsg, DWORD wParam, DWORD lParam)
             SetDlgItemText(hDlg, IDC_INFO_LOCATION, stdstr(CPath(_this->m_pDiskInfo->GetFileName()).GetDriveDirectory()).ToUTF16(CP_ACP).c_str());
 
             //SetDlgItemText(hDlg, IDC_INFO_MD5, _this->m_pRomInfo->GetRomMD5().ToUTF16().c_str());
-            //SetDlgItemText(hDlg, IDC_INFO_ROMSIZE, stdstr_f("%.1f MBit", (float)_this->m_pDiskInfo->GetRomSize() / 0x20000).ToUTF16().c_str());
+            SetDlgItemText(hDlg, IDC_INFO_ROMSIZE, stdstr_f("%.1f MBit", (float)_this->m_pDiskInfo->GetDiskSize() / 0x20000).ToUTF16().c_str());
 
             BYTE * DiskHeader = _this->m_pDiskInfo->GetDiskAddressID();
             SetDlgItemText(hDlg, IDC_INFO_CARTID, stdstr_f("%c%c", DiskHeader[0x02], DiskHeader[0x01]).ToUTF16().c_str());
 
-            /*switch (DiskHeader[0x00])
+            switch (DiskHeader[0x03])
             {
             case 'D': SetDlgItemText(hDlg, IDC_INFO_MEDIA, L"64DD Disk"); break;
-            case 'E': SetDlgItemText(hDlg, IDC_INFO_MEDIA, L"64DD Disk Expansion"); break;
+            case 'E': SetDlgItemText(hDlg, IDC_INFO_MEDIA, L"64DD Disk (Expansion)"); break;
             case 0:   SetDlgItemText(hDlg, IDC_INFO_MEDIA, L"None"); break;
             default:  SetDlgItemText(hDlg, IDC_INFO_MEDIA, L"(Unknown)"); break;
-            }*/
+            }
 
             switch (DiskHeader[0x00])
             {


### PR DESCRIPTION
This changes the CRC calculation to a full disk block instead of just 0x200 bytes, while providing better ROM Browser support for 64DD games.
Changes 64DD RDB and Cheats Idents as needed.

### Proposed changes
  - Change CRC Calculation for 64DD Disks
  - ROM Browser recognizes more info about 64DD Disks.
  - Change Identification for 64DD games with new CRC in RDB and Cheats
  - Add Mario no Photopie English Translation to RDB
  - Add Mario Artist Polygon Studio English Cheats

### Does this make breaking changes?
 - This only changes RDB, Cheats Identifications, and then ROM Browser / ROM Information recognition.
 - Changing the CRC breaks all user configuration for 64DD titles in the CFG file.

### Does this version of Project64 compile and run without issue?
Yes. Tested with 64DD dumps.
