### PR TITLE
[Core] Proper Dezaemon 3D SRAM 96KB save support

### DIFF
--- a/Source/Project64-core/N64System/Mips/Dma.cpp
+++ b/Source/Project64-core/N64System/Mips/Dma.cpp
@@ -146,7 +146,7 @@ void CDMA::PI_DMA_READ()
         return;
     }
 
-    if (g_Reg->PI_CART_ADDR_REG >= 0x08000000 && g_Reg->PI_CART_ADDR_REG <= 0x08010000)
+    if (g_Reg->PI_CART_ADDR_REG >= 0x08000000 && g_Reg->PI_CART_ADDR_REG < 0x08088000)
     {
         if (g_System->m_SaveUsing == SaveChip_Auto)
         {

--- a/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
+++ b/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
@@ -1349,7 +1349,7 @@ void CMipsMemoryVM::Load32CartridgeDomain2Address1(void)
 void CMipsMemoryVM::Load32CartridgeDomain2Address2(void)
 {
     uint32_t offset = (m_MemLookupAddress & 0x1FFFFFFF) - 0x08000000;
-    if (offset > 0x10000)
+    if (offset > 0x88000)
     {
         m_MemLookupValue.UW[0] = ((offset & 0xFFFF) << 16) | (offset & 0xFFFF);
         return;
@@ -1919,7 +1919,7 @@ void CMipsMemoryVM::Write32CartridgeDomain2Address1(void)
 void CMipsMemoryVM::Write32CartridgeDomain2Address2(void)
 {
     uint32_t offset = (m_MemLookupAddress & 0x1FFFFFFF) - 0x08000000;
-    if (g_System->m_SaveUsing == SaveChip_Sram && offset < 0x8000)
+    if (g_System->m_SaveUsing == SaveChip_Sram && offset < 0x88000)
     {
         // Store SRAM
         uint8_t tmp[4] = "";

--- a/Source/Project64/UserInterface/Debugger/DebugMMU.cpp
+++ b/Source/Project64/UserInterface/Debugger/DebugMMU.cpp
@@ -183,7 +183,7 @@ bool CDebugMMU::GetPhysicalByte(uint32_t paddr, uint8_t* value)
     {
         uint32_t saveOffset = paddr & 0x000FFFFF;
 
-        if (g_System->m_SaveUsing == SaveChip_Sram && saveOffset <= 0x7FFF) // SRAM
+        if (g_System->m_SaveUsing == SaveChip_Sram && saveOffset < 0x88000 && (saveOffset & 0x3FFFF) < 0x8000) // SRAM
         {
             uint32_t wordpaddr = paddr & ~3;
             uint8_t data[4];
@@ -257,7 +257,7 @@ bool CDebugMMU::SetPhysicalByte(uint32_t paddr, uint8_t value)
     {
         uint32_t saveOffset = paddr & 0x000FFFFF;
 
-        if (g_System->m_SaveUsing == SaveChip_Sram && saveOffset <= 0x7FFF)
+        if (g_System->m_SaveUsing == SaveChip_Sram && saveOffset < 0x88000 && (saveOffset & 0x3FFFF) < 0x8000)
         {
             uint32_t wordpaddr = paddr & ~3;
             uint8_t data[4];


### PR DESCRIPTION
Project64 supports Dezaemon 3D's 96KB SRAM save type, but only DMA Read code supports it. This makes sure all SRAM read/write code supports larger banks of memory.

### Proposed changes
  - Larger SRAM Memory Space checking
  - Memory Debugger properly recognizes which part of the SRAM is mapped.

### Does this make breaking changes?
I doubt there would be potentially larger SRAM files, but if that's the case, it shouldn't break saves in the slightest.

### Does this version of Project64 compile and run without issue?
Yes. Dezaemon 3D save properly works.