### PR TITLE
Don't use PROCESS_ALL_ACCESS when it is not required

### DIFF
--- a/Source/Common/Util.cpp
+++ b/Source/Common/Util.cpp
@@ -11,7 +11,9 @@
 static bool IsWinVistaOrLater()
 {
 #ifdef _WIN32
-    return GetProcAddress(LoadLibrary(TEXT("KERNEL32")), "CancelIoEx") != nullptr;
+    OSVERSIONINFO vi;
+    vi.dwOSVersionInfoSize = sizeof(vi);
+    return GetVersionEx(&vi) && vi.dwMajorVersion >= 6;
 #else
     return false;
 #endif

--- a/Source/Common/Util.cpp
+++ b/Source/Common/Util.cpp
@@ -8,17 +8,6 @@
 #include <time.h>
 #endif
 
-static bool IsWinVistaOrLater()
-{
-#ifdef _WIN32
-    OSVERSIONINFO vi;
-    vi.dwOSVersionInfoSize = sizeof(vi);
-    return GetVersionEx(&vi) && vi.dwMajorVersion >= 6;
-#else
-    return false;
-#endif
-}
-
 void pjutil::Sleep(uint32_t timeout)
 {
 #ifdef _WIN32
@@ -47,7 +36,6 @@ bool pjutil::TerminatedExistingExe()
     HANDLE nSearch = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (nSearch != INVALID_HANDLE_VALUE)
     {
-        DWORD processAllAccess = IsWinVistaOrLater() ? (PROCESS_ALL_ACCESS) : (PROCESS_ALL_ACCESS & ~0xF000);
         PROCESSENTRY32 lppe;
 
         memset(&lppe, 0, sizeof(PROCESSENTRY32));
@@ -75,7 +63,7 @@ bool pjutil::TerminatedExistingExe()
                         break;
                     }
                 }
-                HANDLE hHandle = OpenProcess(processAllAccess, FALSE, lppe.th32ProcessID);
+                HANDLE hHandle = OpenProcess(SYNCHRONIZE|PROCESS_TERMINATE, FALSE, lppe.th32ProcessID);
                 if (hHandle != nullptr)
                 {
                     if (TerminateProcess(hHandle, 0))

--- a/Source/Common/Util.cpp
+++ b/Source/Common/Util.cpp
@@ -8,6 +8,15 @@
 #include <time.h>
 #endif
 
+static bool IsWinVistaOrLater()
+{
+#ifdef _WIN32
+    return GetProcAddress(LoadLibrary(TEXT("KERNEL32")), "CancelIoEx") != nullptr;
+#else
+    return false;
+#endif
+}
+
 void pjutil::Sleep(uint32_t timeout)
 {
 #ifdef _WIN32
@@ -36,6 +45,7 @@ bool pjutil::TerminatedExistingExe()
     HANDLE nSearch = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (nSearch != INVALID_HANDLE_VALUE)
     {
+        DWORD processAllAccess = IsWinVistaOrLater() ? (PROCESS_ALL_ACCESS) : (PROCESS_ALL_ACCESS & ~0xF000);
         PROCESSENTRY32 lppe;
 
         memset(&lppe, 0, sizeof(PROCESSENTRY32));
@@ -63,7 +73,7 @@ bool pjutil::TerminatedExistingExe()
                         break;
                     }
                 }
-                HANDLE hHandle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, lppe.th32ProcessID);
+                HANDLE hHandle = OpenProcess(processAllAccess, FALSE, lppe.th32ProcessID);
                 if (hHandle != nullptr)
                 {
                     if (TerminateProcess(hHandle, 0))


### PR DESCRIPTION
The PROCESS_ALL_ACCESS define changes at compile time based on the SDK version and the NTDDI_VERSION define. I don't know if you care about Windows XP anymore but `OpenProcess` fails with invalid parameter if you pass it bits it does not know about. It is better to just ask for the required access.

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Don't know.