### PR TITLE
Fix many warnings

### DIFF
--- a/Source/Common/IniFile.cpp
+++ b/Source/Common/IniFile.cpp
@@ -504,7 +504,9 @@ bool CIniFileBase::DeleteSection(const char * lpSectionName)
         return false;
     }
     m_File.Seek(m_CurrentSectionFilePos, CFileBase::begin);
-    long DeleteSectionStart = m_CurrentSectionFilePos - (strlen(lpSectionName) + strlen(m_LineFeed) + 2);
+    size_t tmp = (strlen(lpSectionName) + strlen(m_LineFeed) + 2);
+    if (tmp != (long)(unsigned long) tmp) return false;
+    long DeleteSectionStart = m_CurrentSectionFilePos - (long)(unsigned long) tmp;
     long NextSectionStart = -1;
 
     {

--- a/Source/Common/Util.h
+++ b/Source/Common/Util.h
@@ -1,6 +1,14 @@
 #pragma once
 #include <stdint.h>
 
+template<class T, class D, class S> static inline T safe_truncate_cast_assign(D*dst, const S&src)
+{
+    #if __cplusplus >= 201103L
+    static_assert(sizeof(T) == sizeof(D), "Type changed, must update cast");
+    #endif
+    return *dst = (D) src; // Should trigger a warning if the D type has changed to something larger than T
+}
+
 class pjutil
 {
 public:

--- a/Source/Common/md5.cpp
+++ b/Source/Common/md5.cpp
@@ -109,7 +109,7 @@ void MD5::update(const unsigned char *input, size_t input_length)
     for (size_t left = input_length, chunk, multi = sizeof(uint4) < sizeof(left);;)
     {
         chunk = multi && left > 0xffffffff ? 0xffffffff : (uint4) left;
-        internal_update(input, chunk);
+        internal_update(input, (uint4) chunk);
         if (!multi || !left) break;
         input += chunk, left -= chunk;
     }

--- a/Source/Common/md5.h
+++ b/Source/Common/md5.h
@@ -93,7 +93,7 @@ public:
     // Methods for controlled operation:
     MD5();  // Simple initializer
     ~MD5();
-    void  update(const unsigned char *input, unsigned int input_length);
+    void  update(const unsigned char *input, size_t input_length);
     void  update(FILE *file);
     void  finalize();
 
@@ -101,7 +101,7 @@ public:
     MD5(CPath File);            // Digest file, finalize
     MD5(const unsigned char *string); // Digest string, finalize
     MD5(FILE *file);            // Digest file, close, finalize
-    MD5(const unsigned char *input, unsigned int input_length);
+    MD5(const unsigned char *input, size_t input_length);
     MD5(const stdstr & string);
 
     // Methods to acquire finalized result
@@ -127,6 +127,7 @@ private:
     // Last, the private methods, mostly static:
     void init();               // Called by all constructors
     void transform(uint1 *buffer);  // Does the real update work. Note that length is implied to be 64.
+    void internal_update(const unsigned char *input, unsigned int input_length);
 
     static void encode(uint1 *dest, uint4 *src, uint4 length);
     static void decode(uint4 *dest, uint1 *src, uint4 length);

--- a/Source/JoinSettings/main.cpp
+++ b/Source/JoinSettings/main.cpp
@@ -30,7 +30,7 @@ struct compareKeyValueItem
                 return i1 < i2;
             }
             char Buffer[40];
-            int number_len = strlen(_itoa(i1, Buffer, 10));
+            size_t number_len = strlen(_itoa(i1, Buffer, 10));
             if (strlen(&a[5 + number_len]) == 0)
             {
                 return true;

--- a/Source/Project64-audio/Driver/OpenSLES.cpp
+++ b/Source/Project64-audio/Driver/OpenSLES.cpp
@@ -360,7 +360,7 @@ void queueCallback(SLAndroidSimpleBufferQueueItf caller, void *context)
 }
 #endif
 
-void OpenSLESDriver::AI_SetFrequency(uint32_t freq, uint32_t BufferSize)
+void OpenSLESDriver::AI_SetFrequency(uint32_t freq, uint32_t /* BufferSize */)
 {
     WriteTrace(TraceAudioInitShutdown, TraceDebug, "Start (freq: %d)", freq);
     if (freq < 4000)

--- a/Source/Project64-audio/Driver/OpenSLES.h
+++ b/Source/Project64-audio/Driver/OpenSLES.h
@@ -19,7 +19,7 @@ class OpenSLESDriver :
 public:
     void AI_Startup(void);
     void AI_Shutdown(void);
-    void AI_SetFrequency(uint32_t freq, uint32_t BufferSize);
+    void AI_SetFrequency(uint32_t freq, uint32_t /* BufferSize */);
     void AI_LenChanged(uint8_t *start, uint32_t length);
     void AI_Update(bool Wait);
 

--- a/Source/Project64-core/3rdParty/7zip.cpp
+++ b/Source/Project64-core/3rdParty/7zip.cpp
@@ -198,7 +198,12 @@ std::wstring C7zip::FileNameIndex(int index)
         // No filename
         return filename;
     }
-    int namelen = SzArEx_GetFileNameUtf16(m_db, index, nullptr);
+#ifdef _WIN64
+    Int64 namelen
+#else
+    int namelen
+#endif
+        = SzArEx_GetFileNameUtf16(m_db, index, nullptr);
     if (namelen <= 0)
     {
         // No filename

--- a/Source/Project64-core/Logging.cpp
+++ b/Source/Project64-core/Logging.cpp
@@ -458,7 +458,7 @@ void CLogging::LogMessage(const char * Message, ...)
 
     strcat(Msg, "\r\n");
 
-    m_hLogFile->Write(Msg, strlen(Msg));
+    m_hLogFile->Write(Msg, (unsigned int) strlen(Msg));
 }
 
 void CLogging::StartLog(void)

--- a/Source/Project64-core/Settings.cpp
+++ b/Source/Project64-core/Settings.cpp
@@ -839,8 +839,8 @@ bool CSettings::LoadStringVal(SettingID Type, char * Buffer, uint32_t BufferSize
     {
         stdstr Value;
         bRes = FindInfo->second->Load(0, Value);
-        int len = BufferSize;
-        if ((Value.length() + 1) < (size_t)len)
+        size_t len = BufferSize;
+        if ((Value.length() + 1) < len)
         {
             len = Value.length() + 1;
         }

--- a/Source/Project64-input/DeviceNotification.cpp
+++ b/Source/Project64-input/DeviceNotification.cpp
@@ -24,7 +24,7 @@ int DeviceNotification::OnCreate(LPCREATESTRUCT /*lpCreateStruct*/)
     return TRUE;
 }
 
-BOOL DeviceNotification::OnDeviceChange(UINT nEventType, DWORD /*dwData*/)
+BOOL DeviceNotification::OnDeviceChange(UINT nEventType, DWORD_PTR /*dwData*/)
 {
     if (g_InputPlugin != nullptr && (nEventType == DBT_DEVICEARRIVAL || nEventType == DBT_DEVICEREMOVECOMPLETE))
     {

--- a/Source/Project64-input/DeviceNotification.h
+++ b/Source/Project64-input/DeviceNotification.h
@@ -19,5 +19,5 @@ public:
 
 private:
     int OnCreate(LPCREATESTRUCT lpCreateStruct);
-    BOOL OnDeviceChange(UINT nEventType, DWORD dwData);
+    BOOL OnDeviceChange(UINT nEventType, DWORD_PTR dwData);
 };

--- a/Source/Project64-input/InputConfigUI.cpp
+++ b/Source/Project64-input/InputConfigUI.cpp
@@ -59,7 +59,7 @@ private:
     void DisplayControllerImage(void);
     void DisplayController(void);
     void ButtonChannged(const BUTTON & Button);
-    void EnablePage(int32_t Present);
+    void EnablePage(size_t Present);
     static void stButtonChanged(size_t data, const BUTTON & Button) { ((CControllerSettings *)data)->ButtonChannged(Button); }
 
     std::wstring m_Title;
@@ -328,7 +328,7 @@ void CControllerSettings::ButtonChannged(const BUTTON & Button)
     CPropertySheetWindow(GetParent()).SetModified(m_hWnd);
 }
 
-void CControllerSettings::EnablePage(int32_t Present)
+void CControllerSettings::EnablePage(size_t Present)
 {
     bool Enable = Present == PRESENT_CONT;
     GetDlgItem(IDC_SLIDE_DEADZONE).EnableWindow(Enable);

--- a/Source/Project64-input/OptionsUI.cpp
+++ b/Source/Project64-input/OptionsUI.cpp
@@ -83,10 +83,11 @@ public:
         }
 
         CComboBox ControllerPak(GetDlgItem(IDC_PAKTYPE));
-        DWORD_PTR Pak = ControllerPak.GetItemData(ControllerPak.GetCurSel());
+        DWORD_PTR PakItemData = ControllerPak.GetItemData(ControllerPak.GetCurSel());
+        int32_t Pak = (int32_t)(PakItemData & 0xFFFFFFFF);
         if (Pak != m_ControlInfo.Plugin)
         {
-            m_ControlInfo.Plugin = (Pak & 0xFFFFFFFF);
+            m_ControlInfo.Plugin = Pak;
             bChanged = true;
         }
 

--- a/Source/Project64-video/Combine.cpp
+++ b/Source/Project64-video/Combine.cpp
@@ -1859,10 +1859,10 @@ static void cc__prim_inter_env_using_enva__mul_shade()
     uint32_t er = (rdp.env_color >> 24) & 0xFF;
     uint32_t eg = (rdp.env_color >> 16) & 0xFF;
     uint32_t eb = (rdp.env_color >> 8) & 0xFF;
-    uint32_t r = minval(255, (uint32_t)(er*ea + pr*ea_i));
-    uint32_t g = minval(255, (uint32_t)(eg*ea + pg*ea_i));
-    uint32_t b = minval(255, (uint32_t)(eb*ea + pb*ea_i));
-    uint32_t col = (r << 24) | (g << 16) | (b << 8) | 0xFF;
+    uint32_t finalr = minval(255, (uint32_t)(er*ea + pr*ea_i));
+    uint32_t finalg = minval(255, (uint32_t)(eg*ea + pg*ea_i));
+    uint32_t finalb = minval(255, (uint32_t)(eb*ea + pb*ea_i));
+    uint32_t col = (finalr << 24) | (finalg << 16) | (finalb << 8) | 0xFF;
     CCMB(GFX_COMBINE_FUNCTION_SCALE_OTHER,
         GFX_COMBINE_FACTOR_LOCAL,
         GFX_COMBINE_LOCAL_ITERATED,
@@ -2203,13 +2203,13 @@ static void cc_t0_add_env_mul_k5()
         GFX_COMBINE_LOCAL_CONSTANT,
         GFX_COMBINE_OTHER_TEXTURE);
     float scale = rdp.K5 / 255.0f;
-    uint8_t r = (uint8_t)(rdp.env_color >> 24) & 0xFF;
-    r = (uint8_t)(r*scale);
-    uint8_t g = (uint8_t)(rdp.env_color >> 16) & 0xFF;
-    g = (uint8_t)(g*scale);
-    uint8_t b = (uint8_t)(rdp.env_color >> 8) & 0xFF;
-    b = (uint8_t)(b*scale);
-    CC((r << 24) | (g << 16) | (b << 8));
+    uint8_t r8 = (uint8_t)(rdp.env_color >> 24) & 0xFF;
+    r8 = (uint8_t)(r8*scale);
+    uint8_t g8 = (uint8_t)(rdp.env_color >> 16) & 0xFF;
+    g8 = (uint8_t)(g8*scale);
+    uint8_t b8 = (uint8_t)(rdp.env_color >> 8) & 0xFF;
+    b8 = (uint8_t)(b8*scale);
+    CC((r8 << 24) | (g8 << 16) | (b8 << 8));
     USE_T0();
 }
 
@@ -5888,13 +5888,13 @@ static void cc__prim_sub_env_mul_t0_add_env__mul_primlod()
         GFX_COMBINE_LOCAL_ITERATED,
         GFX_COMBINE_OTHER_CONSTANT);
     float factor = (float)rdp.prim_lodfrac / 255.0f;
-    uint8_t r = (uint8_t)((rdp.prim_color >> 24) & 0xFF);
-    r = (uint8_t)((float)r * factor);
-    uint8_t g = (uint8_t)((rdp.prim_color >> 16) & 0xFF);
-    g = (uint8_t)((float)g * factor);
-    uint8_t b = (uint8_t)((rdp.prim_color >> 8) & 0xFF);
-    b = (uint8_t)((float)b * factor);
-    CC((r << 24) | (g << 16) | (b << 8));
+    uint8_t r8 = (uint8_t)((rdp.prim_color >> 24) & 0xFF);
+    r8 = (uint8_t)((float)r8 * factor);
+    uint8_t g8 = (uint8_t)((rdp.prim_color >> 16) & 0xFF);
+    g8 = (uint8_t)((float)g8 * factor);
+    uint8_t b8 = (uint8_t)((rdp.prim_color >> 8) & 0xFF);
+    b8 = (uint8_t)((float)b8 * factor);
+    CC((r8 << 24) | (g8 << 16) | (b8 << 8));
     SETSHADE_ENV();
     MULSHADE_PRIMLOD();
     USE_T0();
@@ -8313,10 +8313,10 @@ static void cc__env_inter_prim_using_prima__mul_shade()
     int envr = (rdp.env_color >> 24) & 0xFF;
     int envg = (rdp.env_color >> 16) & 0xFF;
     int envb = (rdp.env_color >> 8) & 0xFF;
-    int r = (((primr - envr)*prima) / 256) + envr;
-    int g = (((primg - envg)*prima) / 256) + envg;
-    int b = (((primb - envb)*prima) / 256) + envb;
-    cmb.ccolor = (r << 24) | (g << 16) | (b << 8);
+    int finalr = (((primr - envr)*prima) / 256) + envr;
+    int finalg = (((primg - envg)*prima) / 256) + envg;
+    int finalb = (((primb - envb)*prima) / 256) + envb;
+    cmb.ccolor = (finalr << 24) | (finalg << 16) | (finalb << 8);
     CCMB(GFX_COMBINE_FUNCTION_SCALE_OTHER,
         GFX_COMBINE_FACTOR_LOCAL,
         GFX_COMBINE_LOCAL_ITERATED,

--- a/Source/Project64-video/Config.cpp
+++ b/Source/Project64-video/Config.cpp
@@ -174,7 +174,7 @@ private:
         int idTool = ::GetWindowLong(hTool, GWL_ID);
         if (idTool != IDC_STATIC)
         {
-            CToolInfo ToolInfo(pT->m_uToolFlags, hTool, 0, 0, (LPTSTR)idTool);
+            CToolInfo ToolInfo(pT->m_uToolFlags, hTool, 0, 0, (LPTSTR)(SIZE_T)idTool);
             pT->m_TT.AddTool(&ToolInfo);
         }
         return TRUE;
@@ -267,11 +267,12 @@ public:
         m_cbxTextureSettings.SetCheck(g_settings->texenh_options() ? BST_CHECKED : BST_UNCHECKED);
 
         m_cmbFSResolution.Attach(GetDlgItem(IDC_CMB_FS_RESOLUTION));
-        int32_t size = 0;
-        const char ** aRes = getFullScreenResList(&size);
+        int32_t tmpsize = 0;
+        const char ** aRes = getFullScreenResList(&tmpsize);
+        uint32_t size = tmpsize;
         if (aRes && size)
         {
-            for (int r = 0; r < size; r++)
+            for (uint32_t r = 0; r < size; r++)
             {
                 m_cmbFSResolution.AddString(stdstr(aRes[r]).ToUTF16().c_str());
             }

--- a/Source/Project64-video/Renderer/OGLcombiner.cpp
+++ b/Source/Project64-video/Renderer/OGLcombiner.cpp
@@ -1163,7 +1163,7 @@ void gfxTexCombine(gfxChipID_t tmu, gfxCombineFunction_t rgb_function, gfxCombin
         static int last_factor = 0;
         static int last_afunction = 0;
         static int last_afactor = 0;
-        static int last_rgb_invert = 0;
+        static bool last_rgb_invert = 0;
 
         if (last_function == rgb_function && last_factor == rgb_factor &&
             last_afunction == alpha_function && last_afactor == alpha_factor &&
@@ -1188,7 +1188,7 @@ void gfxTexCombine(gfxChipID_t tmu, gfxCombineFunction_t rgb_function, gfxCombin
         static int last_factor = 0;
         static int last_afunction = 0;
         static int last_afactor = 0;
-        static int last_rgb_invert = 0;
+        static bool last_rgb_invert = 0;
 
         if (last_function == rgb_function && last_factor == rgb_factor &&
             last_afunction == alpha_function && last_afactor == alpha_factor &&

--- a/Source/Project64-video/Renderer/OGLgeometry.cpp
+++ b/Source/Project64-video/Renderer/OGLgeometry.cpp
@@ -21,8 +21,8 @@ static int xy_off = offsetof(gfxVERTEX, x);
 static int z_off = offsetof(gfxVERTEX, z);
 static int q_off = offsetof(gfxVERTEX, q);
 static int pargb_off = offsetof(gfxVERTEX, b);
-static int st0_off = offsetof(gfxVERTEX, coord[0]);
-static int st1_off = offsetof(gfxVERTEX, coord[2]);
+static int st0_off = (int)(offsetof(gfxVERTEX, coord[0]));
+static int st1_off = (int)(offsetof(gfxVERTEX, coord[2]));
 static int fog_ext_off = offsetof(gfxVERTEX, f);
 
 int w_buffer_mode;

--- a/Source/Project64-video/Renderer/OGLglitchmain.cpp
+++ b/Source/Project64-video/Renderer/OGLglitchmain.cpp
@@ -1618,7 +1618,7 @@ bool gfxLfbWriteRegion(gfxBuffer_t dst_buffer, uint32_t dst_x, uint32_t dst_y, g
 {
     unsigned char *buf;
     unsigned int i, j;
-    unsigned short *frameBuffer = (unsigned short*)src_data;
+    unsigned short *frameBuf = (unsigned short*)src_data;
     int texture_number;
     unsigned int tex_width = 1, tex_height = 1;
     WriteTrace(TraceGlitch, TraceDebug, "dst_buffer: %d dst_x: %d dst_y: %d src_format: %d src_width: %d src_height: %d pixelPipeline: %d src_stride: %d", dst_buffer, dst_x, dst_y, src_format, src_width, src_height, pixelPipeline, src_stride);
@@ -1655,7 +1655,7 @@ bool gfxLfbWriteRegion(gfxBuffer_t dst_buffer, uint32_t dst_x, uint32_t dst_y, g
             {
                 for (i = 0; i < src_width; i++)
                 {
-                    const unsigned int col = frameBuffer[j*half_stride + i];
+                    const unsigned int col = frameBuf[j*half_stride + i];
                     buf[j*tex_width * 4 + i * 4 + 0] = ((col >> 10) & 0x1F) << 3;
                     buf[j*tex_width * 4 + i * 4 + 1] = ((col >> 5) & 0x1F) << 3;
                     buf[j*tex_width * 4 + i * 4 + 2] = ((col >> 0) & 0x1F) << 3;
@@ -1668,7 +1668,7 @@ bool gfxLfbWriteRegion(gfxBuffer_t dst_buffer, uint32_t dst_x, uint32_t dst_y, g
             {
                 for (i = 0; i < src_width; i++)
                 {
-                    const unsigned int col = frameBuffer[j*half_stride + i];
+                    const unsigned int col = frameBuf[j*half_stride + i];
                     buf[j*tex_width * 4 + i * 4 + 0] = ((col >> 10) & 0x1F) << 3;
                     buf[j*tex_width * 4 + i * 4 + 1] = ((col >> 5) & 0x1F) << 3;
                     buf[j*tex_width * 4 + i * 4 + 2] = ((col >> 0) & 0x1F) << 3;
@@ -1681,7 +1681,7 @@ bool gfxLfbWriteRegion(gfxBuffer_t dst_buffer, uint32_t dst_x, uint32_t dst_y, g
             {
                 for (i = 0; i < src_width; i++)
                 {
-                    const unsigned int col = frameBuffer[j*half_stride + i];
+                    const unsigned int col = frameBuf[j*half_stride + i];
                     buf[j*tex_width * 4 + i * 4 + 0] = ((col >> 11) & 0x1F) << 3;
                     buf[j*tex_width * 4 + i * 4 + 1] = ((col >> 5) & 0x3F) << 2;
                     buf[j*tex_width * 4 + i * 4 + 2] = ((col >> 0) & 0x1F) << 3;
@@ -1708,7 +1708,7 @@ bool gfxLfbWriteRegion(gfxBuffer_t dst_buffer, uint32_t dst_x, uint32_t dst_y, g
     }
     else
     {
-        float *buf = (float*)malloc(src_width*(src_height + (g_viewport_offset)) * sizeof(float));
+        float *fltbuf = (float*)malloc(src_width*(src_height + (g_viewport_offset)) * sizeof(float));
 
         if (src_format != GFX_LFBWRITEMODE_ZA16)
             WriteTrace(TraceGlitch, TraceWarning, "Unknown depth buffer write format:%x", src_format);
@@ -1720,8 +1720,8 @@ bool gfxLfbWriteRegion(gfxBuffer_t dst_buffer, uint32_t dst_x, uint32_t dst_y, g
         {
             for (i = 0; i < src_width; i++)
             {
-                buf[(j + (g_viewport_offset))*src_width + i] =
-                    (frameBuffer[(src_height - j - 1)*(src_stride / 2) + i] / (65536.0f*(2.0f / zscale))) + 1 - zscale / 2.0f;
+                fltbuf[(j + (g_viewport_offset))*src_width + i] =
+                    (frameBuf[(src_height - j - 1)*(src_stride / 2) + i] / (65536.0f*(2.0f / zscale))) + 1 - zscale / 2.0f;
             }
         }
 
@@ -1731,9 +1731,9 @@ bool gfxLfbWriteRegion(gfxBuffer_t dst_buffer, uint32_t dst_x, uint32_t dst_y, g
         glDrawBuffer(GL_BACK);
         glClear(GL_DEPTH_BUFFER_BIT);
         glDepthMask(1);
-        glDrawPixels(src_width, src_height + (g_viewport_offset), GL_DEPTH_COMPONENT, GL_FLOAT, buf);
+        glDrawPixels(src_width, src_height + (g_viewport_offset), GL_DEPTH_COMPONENT, GL_FLOAT, fltbuf);
 
-        free(buf);
+        free(fltbuf);
     }
     glDrawBuffer(current_buffer);
     glPopAttrib();

--- a/Source/Project64-video/TexBuffer.cpp
+++ b/Source/Project64-video/TexBuffer.cpp
@@ -154,7 +154,7 @@ static TBUFF_COLOR_IMAGE * AllocateTextureBuffer(COLOR_IMAGE & cimage)
             rdp.texbufs[i].count++;
             rdp.texbufs[i].clear_allowed = FALSE;
             texbuf.tex_addr = top;
-            rdp.cur_tex_buf = i;
+            rdp.cur_tex_buf = (uint8_t) i;
             texbuf.tmu = rdp.texbufs[i].tmu;
             rdp.texbufs[i].images[rdp.texbufs[i].count - 1] = texbuf;
             return &(rdp.texbufs[i].images[rdp.texbufs[i].count - 1]);
@@ -241,7 +241,7 @@ int OpenTextureBuffer(COLOR_IMAGE & cimage)
                     texbuf->t_mem = 0;
                     texbuf->tile = 0;
                     found = TRUE;
-                    rdp.cur_tex_buf = i;
+                    rdp.cur_tex_buf = (uint8_t) i;
                     rdp.texbufs[i].clear_allowed = FALSE;
                 }
                 else //check intersection

--- a/Source/Project64-video/TexCache.cpp
+++ b/Source/Project64-video/TexCache.cpp
@@ -956,7 +956,7 @@ void LoadTex(int id, gfxChipID_t tmu)
     cache->format = rdp.tiles(td).format;
     cache->size = rdp.tiles(td).size;
     cache->tmem_addr = voodoo.tmem_ptr[tmu];
-    cache->set_by = rdp.timg.set_by;
+    safe_truncate_cast_assign<uint8_t>(&cache->set_by, rdp.timg.set_by);
     cache->texrecting = rdp.texrecting;
     cache->last_used = frame_count;
     cache->uses = rdp.debug_n;
@@ -1537,7 +1537,7 @@ void LoadTex(int id, gfxChipID_t tmu)
                 {
                     texture = (uint8_t *)ghqTexInfo.data;
                     lod = (gfxLOD_t)ghqTexInfo.largeLodLog2;
-                    int splits = cache->splits;
+                    int orgcachesplits = cache->splits;
                     if (ghqTexInfo.is_hires_tex)
                     {
                         if (ghqTexInfo.tiles)
@@ -1548,11 +1548,11 @@ void LoadTex(int id, gfxChipID_t tmu)
                             cache->splitheight = ghqTexInfo.untiled_height;
                             cache->scale_x = 1.0f;
                             cache->scale_y = float(ghqTexInfo.untiled_height*ghqTexInfo.tiles) / float(ghqTexInfo.width);//*sy;
-                            if (splits == 1)
+                            if (orgcachesplits == 1)
                             {
-                                int shift;
-                                for (shift = 9; (1 << shift) < ghqTexInfo.untiled_width; shift++);
-                                float mult = float(1 << shift >> 8);
+                                int shi;
+                                for (shi = 9; (1 << shi) < ghqTexInfo.untiled_width; shi++);
+                                float mult = float(1 << shi >> 8);
                                 cache->c_scl_x *= mult;
                                 cache->c_scl_y *= mult;
                             }
@@ -1590,10 +1590,10 @@ void LoadTex(int id, gfxChipID_t tmu)
                                     cache->scale_x = 1.0f / float(1 << (-ghqTexInfo.aspectRatioLog2));
                                 }
                             }
-                            else if (splits > 1)
+                            else if (orgcachesplits > 1)
                             {
-                                cache->c_scl_x /= splits;
-                                cache->c_scl_y /= splits;
+                                cache->c_scl_x /= orgcachesplits;
+                                cache->c_scl_y /= orgcachesplits;
                             }
                         }
                         if (!g_settings->hacks(CSettings::hack_Zelda))

--- a/Source/Project64-video/TextureEnhancer/TxImage.cpp
+++ b/Source/Project64-video/TextureEnhancer/TxImage.cpp
@@ -227,13 +227,13 @@ TxImage::readPNG(FILE* fp, int* width, int* height, uint16* format)
 }
 
 bool
-TxImage::writePNG(uint8* src, FILE* fp, int width, int height, int rowStride, uint16 format, uint8 *palette)
+TxImage::writePNG(uint8* src, FILE* fp, int width, int height, int rowStride, uint16 format, uint8 /* *palette */)
 {
     png_structp png_ptr;
     png_infop info_ptr;
     png_color_8 sig_bit;
-    png_colorp palette_ptr;
-    png_bytep trans_ptr;//, tex_ptr;
+    png_colorp palette_ptr = nullptr;
+    png_bytep trans_ptr = nullptr;//, tex_ptr;
     int bit_depth, color_type, row_bytes, num_palette;
     int i;
     //uint16 srcfmt, destfmt;

--- a/Source/Project64-video/TextureEnhancer/TxImage.h
+++ b/Source/Project64-video/TextureEnhancer/TxImage.h
@@ -87,7 +87,7 @@ public:
     TxImage() {}
     ~TxImage() {}
     uint8* readPNG(FILE* fp, int* width, int* height, uint16* format);
-    bool writePNG(uint8* src, FILE* fp, int width, int height, int rowStride, uint16 format, uint8 *palette);
+    bool writePNG(uint8* src, FILE* fp, int width, int height, int rowStride, uint16 format, uint8 /* *palette */);
     uint8* readBMP(FILE* fp, int* width, int* height, uint16* format);
     uint8* readDDS(FILE* fp, int* width, int* height, uint16* format);
 };

--- a/Source/Project64-video/TextureEnhancer/TxQuantize.cpp
+++ b/Source/Project64-video/TextureEnhancer/TxQuantize.cpp
@@ -1794,7 +1794,7 @@ TxQuantize::quantize(uint8* src, uint8* dest, int width, int height, uint16 srcf
 
 bool
 TxQuantize::FXT1(uint8 *src, uint8 *dest,
-    int srcwidth, int srcheight, uint16 srcformat,
+    int srcwidth, int srcheight, uint16 /* srcformat */,
     int *destwidth, int *destheight, uint16 *destformat)
 {
     /*

--- a/Source/Project64-video/TextureEnhancer/TxQuantize.h
+++ b/Source/Project64-video/TextureEnhancer/TxQuantize.h
@@ -49,7 +49,7 @@ private:
 
     // Compressors
     bool FXT1(uint8 *src, uint8 *dest,
-        int srcwidth, int srcheight, uint16 srcformat,
+        int srcwidth, int srcheight, uint16 /* srcformat */,
         int *destwidth, int *destheight, uint16 *destformat);
     bool DXTn(uint8 *src, uint8 *dest,
         int srcwidth, int srcheight, uint16 srcformat,

--- a/Source/Project64-video/rdp.h
+++ b/Source/Project64-video/rdp.h
@@ -8,6 +8,9 @@
 
 #include <Project64-video/Renderer/Renderer.h>
 #include <stdint.h>
+#ifdef _WIN32
+#include <Windows.h> // HIWORD/LOWORD
+#endif
 
 extern char out_buf[2048];
 

--- a/Source/Project64-video/ucode08.cpp
+++ b/Source/Project64-video/ucode08.cpp
@@ -242,9 +242,9 @@ void uc8_moveword()
 
     case 0x10:  // moveword coord mod
     {
-        uint8_t n = offset >> 2;
+        uint16_t n = offset >> 2;
 
-        WriteTrace(TraceRDP, TraceDebug, "coord mod:%d, %08lx", n, data);
+        WriteTrace(TraceRDP, TraceDebug, "coord mod:%u, %08lx", n, data);
         if (rdp.cmd0 & 8)
             return;
         uint32_t idx = (rdp.cmd0 >> 1) & 3;

--- a/Source/Project64/UserInterface/CheatUI.cpp
+++ b/Source/Project64/UserInterface/CheatUI.cpp
@@ -226,8 +226,8 @@ LRESULT CCheatList::OnChangeCodeExtension(UINT /*uMsg*/, WPARAM /*wParam*/, LPAR
     }
     std::wstring wName = Name.ToUTF16();
     item.mask = TVIF_TEXT;
-    item.pszText = (LPWSTR)wName.c_str();
-    item.cchTextMax = wName.length();
+    item.pszText = const_cast<LPWSTR>(wName.c_str());
+    item.cchTextMax = (UINT) wName.length();
     m_hCheatTree.SetItem(&item);
     return 0;
 }

--- a/Source/Project64/UserInterface/Debugger/Debugger-Symbols.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Symbols.cpp
@@ -436,7 +436,7 @@ void CDebugSymbols::Refresh()
     m_SymbolsListView.SetItemCountEx(numSymbols, LVSICF_NOSCROLL);
 }
 
-int CDebugSymbols::GetListItemSymbolId(int nItem)
+int CDebugSymbols::GetListItemSymbolId(size_t nItem)
 {
     if (m_bFiltering)
     {

--- a/Source/Project64/UserInterface/Debugger/Debugger-Symbols.h
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Symbols.h
@@ -67,7 +67,7 @@ public:
 
     void Refresh();
     void UpdateFilteredSymbols();
-    int  GetListItemSymbolId(int nItem);
+    int  GetListItemSymbolId(size_t nItem);
     int  ColumnHitTest(POINT& pt);
 
     LRESULT OnInitDialog(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/Source/Project64/UserInterface/Debugger/ScriptAPI/ScriptAPI.cpp
+++ b/Source/Project64/UserInterface/Debugger/ScriptAPI/ScriptAPI.cpp
@@ -768,7 +768,7 @@ bool ScriptAPI::PrivateCallAllowed(duk_context* ctx)
         return false;
     }
 
-    bool bAllowed = duk_get_boolean(ctx, -1);
+    bool bAllowed = duk_get_boolean(ctx, -1) != (duk_bool_t)false;
     duk_pop(ctx);
     return bAllowed;
 }

--- a/Source/Project64/UserInterface/Debugger/ScriptAPI/ScriptAPI_Socket.cpp
+++ b/Source/Project64/UserInterface/Debugger/ScriptAPI/ScriptAPI_Socket.cpp
@@ -47,7 +47,7 @@ duk_ret_t ScriptAPI::js_Socket__constructor(duk_context* ctx)
         if (duk_has_prop_string(ctx, 0, "allowHalfOpen"))
         {
             duk_get_prop_string(ctx, 0, "allowHalfOpen");
-            bAllowHalfOpen = (bool)duk_get_boolean_default(ctx, -1, 0);
+            bAllowHalfOpen = duk_get_boolean_default(ctx, -1, 0) != (duk_bool_t)false;
             duk_pop(ctx);
         }
     }

--- a/Source/Project64/UserInterface/Debugger/ScriptAPI/ScriptAPI_pj64.cpp
+++ b/Source/Project64/UserInterface/Debugger/ScriptAPI/ScriptAPI_pj64.cpp
@@ -64,10 +64,10 @@ duk_ret_t ScriptAPI::js_pj64_close(duk_context* /*ctx*/)
 duk_ret_t ScriptAPI::js_pj64_reset(duk_context* ctx)
 {
     CheckArgs(ctx, { Arg_OptBoolean });
-    bool bSoftReset = (bool)duk_get_boolean_default(ctx, 0, (duk_bool_t)false);
+    LPARAM bSoftReset = duk_get_boolean_default(ctx, 0, (duk_bool_t)false);
 
     HWND hMainWindow = (HWND)g_Plugins->MainWindow()->GetWindowHandle();
-    PostMessage(hMainWindow, WM_JSAPI_ACTION, JSAPI_ACT_RESET, (WPARAM)bSoftReset);
+    PostMessage(hMainWindow, WM_JSAPI_ACTION, JSAPI_ACT_RESET, bSoftReset);
     return 0;
 }
 
@@ -88,7 +88,7 @@ duk_ret_t ScriptAPI::js_pj64_resume(duk_context* /*ctx*/)
 duk_ret_t ScriptAPI::js_pj64_limitfps(duk_context* ctx)
 {
     CheckArgs(ctx, { Arg_Boolean });
-    bool bLimitFps = duk_get_boolean(ctx, 0);
+    bool bLimitFps = duk_get_boolean(ctx, 0) != (duk_bool_t)false;
     g_Settings->SaveBool(GameRunning_LimitFPS, bLimitFps);
     return 0;
 }

--- a/Source/Project64/UserInterface/Debugger/ScriptSystem.cpp
+++ b/Source/Project64/UserInterface/Debugger/ScriptSystem.cpp
@@ -205,7 +205,7 @@ void CScriptSystem::UpdateCpuCbListInfo(volatile JSCpuCbListInfo& info, JSAppCal
 {
     uint32_t minAddrStart = 0;
     uint32_t maxAddrEnd = 0;
-    int numCacheEntries = 0;
+    size_t numCacheEntries = 0;
     bool bCacheExceeded = false;
 
     for (JSAppCallback& callback : callbacks)

--- a/Source/Project64/UserInterface/MainWindow.cpp
+++ b/Source/Project64/UserInterface/MainWindow.cpp
@@ -115,9 +115,9 @@ void CMainGui::AddRecentRom(const char * ImagePath)
     if (HIWORD(ImagePath) == NULL) { return; }
 
     // Get information about the stored ROM list
-    size_t MaxRememberedFiles = UISettingsLoadDword(File_RecentGameFileCount);
+    UINT MaxRememberedFiles = UISettingsLoadDword(File_RecentGameFileCount);
     strlist RecentGames;
-    size_t i;
+    UINT i;
     for (i = 0; i < MaxRememberedFiles; i++)
     {
         stdstr RecentGame = UISettingsLoadStringIndex(File_RecentGameFileIndex, i);
@@ -710,7 +710,7 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
     case WM_SIZE:
         {
             CMainGui * _this = (CMainGui *)GetProp(hWnd, L"Class");
-            if (_this) { _this->Resize(wParam, LOWORD(lParam), HIWORD(lParam)); }
+            if (_this) { _this->Resize((DWORD)wParam, LOWORD(lParam), HIWORD(lParam)); }
             if (_this)
             {
                 if (wParam == SIZE_MAXIMIZED)
@@ -775,7 +775,7 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
                 if (g_BaseSystem)
                 {
                     if (g_Plugins && g_Plugins->Control()->WM_KeyUp) {
-                        g_Plugins->Control()->WM_KeyUp(wParam, lParam);
+                        g_Plugins->Control()->WM_KeyUp((UINT)(SIZE_T)wParam, (UINT)(SIZE_T)lParam);
                     }
                 }
             }
@@ -791,7 +791,7 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
                 {
                     if (g_Plugins && g_Plugins->Control()->WM_KeyDown)
                     {
-                        g_Plugins->Control()->WM_KeyDown(wParam, lParam);
+                        g_Plugins->Control()->WM_KeyDown((UINT)(SIZE_T)wParam, (UINT)(SIZE_T)lParam);
                     }
                 }
             }
@@ -833,7 +833,7 @@ LRESULT CALLBACK CMainGui::MainGui_Proc(HWND hWnd, DWORD uMsg, DWORD wParam, DWO
                     }
 
                     if (g_Plugins && g_Plugins->Control()->WM_KillFocus) {
-                        g_Plugins->Control()->WM_KillFocus(wParam, lParam);
+                        g_Plugins->Control()->WM_KillFocus((UINT)(SIZE_T)wParam, (UINT)(SIZE_T)lParam);
                     }
                 }
             }

--- a/Source/Project64/UserInterface/MenuItem.cpp
+++ b/Source/Project64/UserInterface/MenuItem.cpp
@@ -9,7 +9,7 @@ bool CBaseMenu::AddMenu(HMENU hMenu, MenuItemList Items)
 {
     if (Items.begin() == Items.end()) { return false; }
 
-    UINT ItemID, uFlags;
+    SIZE_T ItemID, uFlags;
     std::wstring Text, String;
     for (MenuItemList::iterator MenuItem = Items.begin(); MenuItem != Items.end(); MenuItem++)
     {
@@ -41,7 +41,7 @@ bool CBaseMenu::AddMenu(HMENU hMenu, MenuItemList Items)
         MenuItemList * SubMenu = (MenuItemList *)MenuItem->SubMenu();
         if (ItemID == SUB_MENU && HIWORD(SubMenu) != 0 && (SubMenu->begin() != SubMenu->end()))
         {
-            ItemID = (UINT)CreatePopupMenu();
+            ItemID = (SIZE_T)CreatePopupMenu();
             uFlags |= MF_POPUP;
 
             AddMenu((HMENU)ItemID, *SubMenu);
@@ -49,14 +49,14 @@ bool CBaseMenu::AddMenu(HMENU hMenu, MenuItemList Items)
 
         if (ItemID == ID_PLUGIN_MENU)
         {
-            ItemID = (UINT)MenuItem->SubMenu();
+            ItemID = (SIZE_T)MenuItem->SubMenu();
             uFlags |= MF_POPUP;
             MENUITEMINFO lpmii;
 
             lpmii.cbSize = sizeof(MENUITEMINFO);
             lpmii.fMask = MIIM_STATE;
             lpmii.fState = 0;
-            SetMenuItemInfo((HMENU)ItemID, (DWORD)MenuItem->SubMenu(), FALSE, &lpmii);
+            SetMenuItemInfo((HMENU)ItemID, (DWORD)MenuItem->SubMenu(), FALSE, &lpmii); // BUGBUG: Truncating 2nd parameter on 64-bit
         }
 
         if (MenuItem->ShortCut().empty() == false)

--- a/Source/Project64/UserInterface/MenuShortCuts.cpp
+++ b/Source/Project64/UserInterface/MenuShortCuts.cpp
@@ -534,7 +534,8 @@ HACCEL CShortCuts::GetAcceleratorTable(void)
     CGuard CS(m_CS);
 
     // Generate an ACCEL list
-    int size = 0, MaxSize = m_ShortCuts.size() * 5;
+    unsigned int size = 0;
+    size_t MaxSize = m_ShortCuts.size() * 5;
     ACCEL * AccelList = new ACCEL[MaxSize];
     CMenuShortCutKey::RUNNING_STATE RunningState = CMenuShortCutKey::RunningState();
 

--- a/Source/Project64/UserInterface/Notification.cpp
+++ b/Source/Project64/UserInterface/Notification.cpp
@@ -171,9 +171,9 @@ void CNotificationImp::AddRecentDir(const char * RomDir)
     if (HIWORD(RomDir) == NULL) { return; }
 
     // Get information about the stored ROM list
-    size_t MaxRememberedDirs = UISettingsLoadDword(Directory_RecentGameDirCount);
+    UINT MaxRememberedDirs = UISettingsLoadDword(Directory_RecentGameDirCount);
     strlist RecentDirs;
-    size_t i;
+    UINT i;
     for (i = 0; i < MaxRememberedDirs; i++)
     {
         stdstr RecentDir = UISettingsLoadStringIndex(Directory_RecentGameDirIndex, i);

--- a/Source/Project64/UserInterface/ProjectSupport.cpp
+++ b/Source/Project64/UserInterface/ProjectSupport.cpp
@@ -161,7 +161,7 @@ bool CProjectSupport::PerformRequest(const wchar_t * Url, const std::string & Po
         return false;
     }
     wchar_t hdheaders[] = _T("Content-Type: application/x-www-form-urlencoded\r\n");
-    BOOL Success = HttpSendRequest(hRequest, hdheaders, _tcslen(hdheaders), (LPVOID)PostData.c_str(), PostData.length());
+    BOOL Success = HttpSendRequest(hRequest, hdheaders, _tcslen(hdheaders), (LPVOID)PostData.c_str(), (DWORD)PostData.length());
     if (!Success)
     {
         InternetCloseHandle(hRequest);
@@ -232,7 +232,7 @@ void CProjectSupport::SaveSupportInfo(void)
     long lResult = RegCreateKeyEx(HKEY_CURRENT_USER, L"SOFTWARE\\Project64", 0, L"", REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, nullptr, &hKeyResults, &Disposition);
     if (lResult == ERROR_SUCCESS)
     {
-        RegSetValueEx(hKeyResults, L"user", 0, REG_BINARY, (BYTE *)OutData.data(), OutData.size());
+        RegSetValueEx(hKeyResults, L"user", 0, REG_BINARY, (BYTE *)OutData.data(), (DWORD) OutData.size());
         RegCloseKey(hKeyResults);
     }
 }
@@ -271,7 +271,7 @@ void CProjectSupport::LoadSupportInfo(void)
             InData[i] ^= 0xAA;
         }
         OutData.resize(sizeof(m_SupportInfo) + 100);
-        uLongf DestLen = OutData.size();
+        uLongf DestLen = (ULONG) OutData.size();
         if (uncompress(OutData.data(), &DestLen, InData.data(), InData.size()) >= 0)
         {
             OutData.resize(DestLen);

--- a/Source/Project64/UserInterface/RomBrowser.cpp
+++ b/Source/Project64/UserInterface/RomBrowser.cpp
@@ -60,7 +60,7 @@ void CRomBrowser::GetFieldInfo(ROMBROWSER_FIELDS_LIST & Fields, bool UseDefault 
     AddField(Fields, "File Format", -1, RB_FileFormat, 100, RB_FILE_FORMAT, UseDefault);
 }
 
-int32_t CRomBrowser::CalcSortPosition(uint32_t lParam)
+int32_t CRomBrowser::CalcSortPosition(SIZE_T lParam)
 {
     int32_t Start = 0;
     int32_t End = ListView_GetItemCount(m_hRomList) - 1;
@@ -82,8 +82,8 @@ int32_t CRomBrowser::CalcSortPosition(uint32_t lParam)
             break;
         }
 
-        size_t index;
-        for (index = 0; index < m_Fields.size(); index++)
+        unsigned int index;
+        for (index = 0; index < (unsigned int) m_Fields.size(); index++)
         {
             if (_stricmp(m_Fields[index].Name(), SortFieldName.c_str()) == 0) { break; }
         }
@@ -113,7 +113,7 @@ int32_t CRomBrowser::CalcSortPosition(uint32_t lParam)
                 return End;
             }
 
-            int32_t Result = RomList_CompareItems(lParam, lvItem.lParam, (uint32_t)&SortFieldInfo);
+            int32_t Result = RomList_CompareItems(lParam, lvItem.lParam, (INT_PTR)&SortFieldInfo);
             if (Result < 0)
             {
                 if (End == TestPos)
@@ -152,7 +152,7 @@ int32_t CRomBrowser::CalcSortPosition(uint32_t lParam)
                         return End;
                     }
 
-                    Result = RomList_CompareItems(lParam, lvItem.lParam, (uint32_t)&SortFieldInfo);
+                    Result = RomList_CompareItems(lParam, lvItem.lParam, (INT_PTR)&SortFieldInfo);
                     if (Result <= 0)
                     {
                         if (Right == NewTestPos)
@@ -185,7 +185,7 @@ int32_t CRomBrowser::CalcSortPosition(uint32_t lParam)
                     lvItem.iItem = NewTestPos;
                     if (!SendMessage(m_hRomList, LVM_GETITEM, 0, (LPARAM)&lvItem)) { return End; }
 
-                    Result = RomList_CompareItems(lParam, lvItem.lParam, (uint32_t)&SortFieldInfo);
+                    Result = RomList_CompareItems(lParam, lvItem.lParam, (INT_PTR)&SortFieldInfo);
                     if (Result >= 0)
                     {
                         if (Left == NewTestPos)
@@ -214,8 +214,8 @@ int32_t CRomBrowser::CalcSortPosition(uint32_t lParam)
             continue;
         }
 
-        size_t index;
-        for (index = 0; index < m_Fields.size(); index++)
+        unsigned int index;
+        for (index = 0; index < (unsigned int)m_Fields.size(); index++)
         {
             if (_stricmp(m_Fields[index].Name(), SortFieldName.c_str()) == 0) { break; }
         }
@@ -231,7 +231,7 @@ int32_t CRomBrowser::CalcSortPosition(uint32_t lParam)
         lvItem.iItem = End;
         if (!SendMessage(m_hRomList, LVM_GETITEM, 0, (LPARAM)&lvItem)) { return End; }
 
-        int32_t Result = RomList_CompareItems(lParam, lvItem.lParam, (uint32_t)&SortFieldInfo);
+        int32_t Result = RomList_CompareItems(lParam, lvItem.lParam, (INT_PTR)&SortFieldInfo);
         if (Result < 0)
         {
             return End;
@@ -253,7 +253,7 @@ void CRomBrowser::RomAddedToList(int32_t ListPos)
     lvItem.lParam = (LPARAM)ListPos;
     lvItem.pszText = LPSTR_TEXTCALLBACK;
 
-    int32_t index = SendMessage(m_hRomList, LVM_INSERTITEM, 0, (LPARAM)&lvItem);
+    int32_t index = (int32_t) SendMessage(m_hRomList, LVM_INSERTITEM, 0, (LPARAM)&lvItem);
     int32_t iItem = ListView_GetNextItem(m_hRomList, -1, LVNI_SELECTED);
 
     // If the last ROM then highlight the item
@@ -464,7 +464,7 @@ void CRomBrowser::RomBrowserMaximize(bool Mazimize)
     UISettingsSaveBool(RomBrowser_Maximized, Mazimize);
 }
 
-bool CRomBrowser::RomListDrawItem(int32_t idCtrl, uint32_t lParam)
+bool CRomBrowser::RomListDrawItem(int32_t idCtrl, LPARAM lParam)
 {
     if (idCtrl != IDC_ROMLIST) { return false; }
     LPDRAWITEMSTRUCT ditem = (LPDRAWITEMSTRUCT)lParam;
@@ -531,7 +531,7 @@ bool CRomBrowser::RomListDrawItem(int32_t idCtrl, uint32_t lParam)
         text = stdstr(pRomInfo->FileName).ToUTF16();
     }
 
-    DrawText(ditem->hDC, text.c_str(), text.length(), &rcDraw, DT_LEFT | DT_SINGLELINE | DT_NOPREFIX | DT_VCENTER | DT_WORD_ELLIPSIS);
+    DrawText(ditem->hDC, text.c_str(), (int)(INT_PTR)text.length(), &rcDraw, DT_LEFT | DT_SINGLELINE | DT_NOPREFIX | DT_VCENTER | DT_WORD_ELLIPSIS);
 
     memset(&lvc, 0, sizeof(lvc));
     lvc.mask = LVCF_FMT | LVCF_WIDTH;
@@ -556,12 +556,12 @@ bool CRomBrowser::RomListDrawItem(int32_t idCtrl, uint32_t lParam)
             text = stdstr(pRomInfo->FileName).ToUTF16();
         }
 
-        DrawText(ditem->hDC, text.c_str(), text.length(), &rcDraw, DT_LEFT | DT_SINGLELINE | DT_NOPREFIX | DT_VCENTER | DT_WORD_ELLIPSIS);
+        DrawText(ditem->hDC, text.c_str(), (int)(INT_PTR)text.length(), &rcDraw, DT_LEFT | DT_SINGLELINE | DT_NOPREFIX | DT_VCENTER | DT_WORD_ELLIPSIS);
     }
     return true;
 }
 
-bool CRomBrowser::RomListNotify(int32_t idCtrl, uint32_t pnmh)
+bool CRomBrowser::RomListNotify(int32_t idCtrl, LPARAM pnmh)
 {
     if (idCtrl != IDC_ROMLIST) { return false; }
     if (!RomBrowserVisible()) { return false; }
@@ -588,7 +588,7 @@ bool CRomBrowser::RomListNotify(int32_t idCtrl, uint32_t pnmh)
     return true;
 }
 
-void CRomBrowser::RomList_ColoumnSortList(uint32_t pnmh)
+void CRomBrowser::RomList_ColoumnSortList(LPARAM pnmh)
 {
     LPNMLISTVIEW pnmv = (LPNMLISTVIEW)pnmh;
     size_t index;
@@ -617,7 +617,7 @@ void CRomBrowser::RomList_ColoumnSortList(uint32_t pnmh)
     RomList_SortList();
 }
 
-int32_t CALLBACK CRomBrowser::RomList_CompareItems(uint32_t lParam1, uint32_t lParam2, uint32_t lParamSort)
+int32_t CALLBACK CRomBrowser::RomList_CompareItems(SIZE_T lParam1, SIZE_T lParam2, INT_PTR lParamSort)
 {
     SORT_FIELD * SortFieldInfo = (SORT_FIELD *)lParamSort;
     CRomBrowser * _this = SortFieldInfo->_this;
@@ -675,7 +675,7 @@ int32_t CALLBACK CRomBrowser::RomList_CompareItems(uint32_t lParam1, uint32_t lP
     return result;
 }
 
-void CRomBrowser::RomList_GetDispInfo(uint32_t pnmh)
+void CRomBrowser::RomList_GetDispInfo(LPARAM pnmh)
 {
     LV_DISPINFO * lpdi = (LV_DISPINFO *)pnmh;
     if (lpdi->item.lParam < 0 || lpdi->item.lParam >= (LPARAM)m_RomInfo.size())
@@ -785,7 +785,7 @@ void CRomBrowser::RomList_GetDispInfo(uint32_t pnmh)
     if (lpdi->item.pszText == nullptr || wcslen(lpdi->item.pszText) == 0) { lpdi->item.pszText = L" "; }
 }
 
-void CRomBrowser::RomList_OpenRom(uint32_t /*pnmh*/)
+void CRomBrowser::RomList_OpenRom(LPARAM /*pnmh*/)
 {
     ROM_INFO * pRomInfo;
     LV_ITEM lvItem;
@@ -825,7 +825,7 @@ void CRomBrowser::RomList_OpenRom(uint32_t /*pnmh*/)
     }
 }
 
-void CRomBrowser::RomList_PopupMenu(uint32_t /*pnmh*/)
+void CRomBrowser::RomList_PopupMenu(LPARAM /*pnmh*/)
 {
     LONG iItem = ListView_GetNextItem(m_hRomList, -1, LVNI_SELECTED);
     m_SelectedRom = "";
@@ -892,11 +892,11 @@ void CRomBrowser::RomList_PopupMenu(uint32_t /*pnmh*/)
             if (GfxMenu)
             {
                 MENUITEMINFO lpmii;
-                InsertMenu(hPopupMenu, 7, MF_POPUP | MF_BYPOSITION, (uint32_t)GfxMenu, wGS(POPUP_GFX_PLUGIN).c_str());
+                InsertMenu(hPopupMenu, 7, MF_POPUP | MF_BYPOSITION, (INT_PTR)GfxMenu, wGS(POPUP_GFX_PLUGIN).c_str());
                 lpmii.cbSize = sizeof(MENUITEMINFO);
                 lpmii.fMask = MIIM_STATE;
                 lpmii.fState = 0;
-                SetMenuItemInfo(hPopupMenu, (uint32_t)GfxMenu, MF_BYCOMMAND, &lpmii);
+                SetMenuItemInfo(hPopupMenu, (UINT)(INT_PTR)GfxMenu, MF_BYCOMMAND, &lpmii); // Note: Truncation of USER32 handles to 32 bits is OK.
             }
         }
     }
@@ -919,8 +919,8 @@ void CRomBrowser::RomList_SortList(void)
     {
         stdstr SortFieldName = UISettingsLoadStringIndex(RomBrowser_SortFieldIndex, count);
 
-        size_t index;
-        for (index = 0; index < m_Fields.size(); index++)
+        unsigned int index;
+        for (index = 0; index < (unsigned int) m_Fields.size(); index++)
         {
             if (_stricmp(m_Fields[index].Name(), SortFieldName.c_str()) == 0) { break; }
         }
@@ -928,7 +928,7 @@ void CRomBrowser::RomList_SortList(void)
         SortFieldInfo._this = this;
         SortFieldInfo.Key = index;
         SortFieldInfo.KeyAscend = UISettingsLoadBoolIndex(RomBrowser_SortAscendingIndex, count) != 0;
-        ListView_SortItems(m_hRomList, RomList_CompareItems, &SortFieldInfo);
+        ListView_SortItems(m_hRomList, RomList_CompareItems, (LPARAM)&SortFieldInfo);
     }
 }
 
@@ -966,7 +966,7 @@ void CRomBrowser::SaveRomListColoumnInfo(void)
     WriteTrace(TraceUserInterface, TraceDebug, "Done");
 }
 
-int32_t CALLBACK CRomBrowser::SelectRomDirCallBack(HWND hwnd, uint32_t uMsg, uint32_t /*lp*/, uint32_t lpData)
+int CALLBACK CRomBrowser::SelectRomDirCallBack(HWND hwnd, UINT uMsg, LPARAM /*lp*/, LPARAM lpData)
 {
     switch (uMsg)
     {
@@ -998,8 +998,8 @@ void CRomBrowser::SelectRomDir(void)
     bi.pszDisplayName = SelectedDir;
     bi.lpszTitle = title.c_str();
     bi.ulFlags = BIF_RETURNFSANCESTORS | BIF_RETURNONLYFSDIRS;
-    bi.lpfn = (BFFCALLBACK)SelectRomDirCallBack;
-    bi.lParam = (uint32_t)RomDir.c_str();
+    bi.lpfn = SelectRomDirCallBack;
+    bi.lParam = (LPARAM)RomDir.c_str();
     WriteTrace(TraceUserInterface, TraceDebug, "2");
     if ((pidl = SHBrowseForFolder(&bi)) != nullptr)
     {
@@ -1007,7 +1007,7 @@ void CRomBrowser::SelectRomDir(void)
         char Directory[_MAX_PATH];
         if (SHGetPathFromIDListA(pidl, Directory))
         {
-            int32_t len = strlen(Directory);
+            size_t len = strlen(Directory);
 
             WriteTrace(TraceUserInterface, TraceDebug, "4");
             if (Directory[len - 1] != '\\')

--- a/Source/Project64/UserInterface/RomBrowser.h
+++ b/Source/Project64/UserInterface/RomBrowser.h
@@ -29,7 +29,9 @@ public:
     {
         if (!UseDefault)
         {
-            m_PosChanged = UISettingsLoadDwordIndex(RomBrowser_PosIndex, m_ID, (uint32_t &)m_Pos);
+            uint32_t tmppos;
+            m_PosChanged = UISettingsLoadDwordIndex(RomBrowser_PosIndex, m_ID, tmppos);
+            m_Pos = tmppos;
             UISettingsLoadDwordIndex(RomBrowser_WidthIndex, m_ID, m_ColWidth);
         }
     }
@@ -48,7 +50,7 @@ public:
     void SetColPos(int Pos)
     {
         m_Pos = Pos;
-        UISettingsSaveDwordIndex(RomBrowser_PosIndex, m_ID, m_Pos);
+        UISettingsSaveDwordIndex(RomBrowser_PosIndex, m_ID, Pos);
         m_PosChanged = true;
     }
     void ResetPos(void)
@@ -84,8 +86,8 @@ public:
     void  RomBrowserToTop(void);
     void  RomBrowserMaximize(bool Mazimize);
     bool  RomBrowserVisible(void);
-    bool  RomListDrawItem(int idCtrl, uint32_t lParam);
-    bool  RomListNotify(int idCtrl, uint32_t pnmh);
+    bool  RomListDrawItem(int idCtrl, LPARAM lParam);
+    bool  RomListNotify(int idCtrl, LPARAM pnmh);
     void  SaveRomListColoumnInfo(void);
     void  SelectRomDir(void);
     void  ShowRomList(void);
@@ -117,15 +119,15 @@ private:
     void  RomListReset(void);
     void  RomListLoaded(void);
     void  RomAddedToList(int32_t ListPos);
-    int   CalcSortPosition(uint32_t lParam);
+    int   CalcSortPosition(SIZE_T lParam);
     void  CreateRomListControl(void);
     void  DeallocateBrushs(void);
     void  FixRomListWindow(void);
     void  MenuSetText(HMENU hMenu, int32_t MenuPos, const wchar_t * Title, char * ShortCut);
-    void  RomList_ColoumnSortList(uint32_t pnmh);
-    void  RomList_GetDispInfo(uint32_t pnmh);
-    void  RomList_OpenRom(uint32_t pnmh);
-    void  RomList_PopupMenu(uint32_t pnmh);
+    void  RomList_ColoumnSortList(LPARAM pnmh);
+    void  RomList_GetDispInfo(LPARAM pnmh);
+    void  RomList_OpenRom(LPARAM pnmh);
+    void  RomList_PopupMenu(LPARAM pnmh);
     void  RomList_SortList(void);
 
     bool RomDirNeedsRefresh(void); // Called from watch thread
@@ -138,8 +140,8 @@ private:
     static void AddField(ROMBROWSER_FIELDS_LIST & Fields, const char * Name, int32_t Pos, int32_t ID, int32_t Width, LanguageStringID LangID, bool UseDefault);
 
     // Callback
-    static int CALLBACK SelectRomDirCallBack(HWND hwnd, uint32_t uMsg, uint32_t lp, uint32_t lpData);
-    static int CALLBACK RomList_CompareItems(uint32_t lParam1, uint32_t lParam2, uint32_t lParamSort);
+    static int CALLBACK SelectRomDirCallBack(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM lpData);
+    static int CALLBACK RomList_CompareItems(SIZE_T lParam1, SIZE_T lParam2, INT_PTR lParamSort);
     
     // Watch directory changed function
     HANDLE m_WatchThread, m_WatchStopEvent;

--- a/Source/Project64/UserInterface/RomInformation.cpp
+++ b/Source/Project64/UserInterface/RomInformation.cpp
@@ -63,10 +63,10 @@ void RomInformation::DisplayInformation(HWND hParent) const
 {
     if (m_FileName.length() == 0) { return; }
 
-    DialogBoxParam(GetModuleHandle(nullptr), MAKEINTRESOURCE(IDD_Rom_Information), hParent, (DLGPROC)RomInfoProc, (DWORD)this);
+    DialogBoxParam(GetModuleHandle(nullptr), MAKEINTRESOURCE(IDD_Rom_Information), hParent, RomInfoProc, (LPARAM)this);
 }
 
-DWORD CALLBACK RomInfoProc(HWND hDlg, DWORD uMsg, DWORD wParam, DWORD lParam)
+INT_PTR CALLBACK RomInfoProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     switch (uMsg)
     {

--- a/Source/Project64/UserInterface/RomInformation.h
+++ b/Source/Project64/UserInterface/RomInformation.h
@@ -8,7 +8,7 @@ class RomInformation
     CN64Rom *     m_pRomInfo;
     CN64Disk *    m_pDiskInfo;
 
-    friend DWORD CALLBACK RomInfoProc(HWND, DWORD, DWORD, DWORD);
+    friend INT_PTR CALLBACK RomInfoProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
 public:
     RomInformation(const char* RomFile);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Directories.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Directories.cpp
@@ -45,7 +45,7 @@ m_InUpdateSettings(false)
     UpdatePageSettings();
 }
 
-int CALLBACK COptionsDirectoriesPage::SelectDirCallBack(HWND hwnd, DWORD uMsg, DWORD /*lp*/, DWORD lpData)
+int CALLBACK COptionsDirectoriesPage::SelectDirCallBack(HWND hwnd, UINT uMsg, LPARAM /*lp*/, LPARAM lpData)
 {
     switch (uMsg)
     {
@@ -74,8 +74,8 @@ void COptionsDirectoriesPage::SelectDirectory(LanguageStringID Title, CModifiedE
     bi.pszDisplayName = Buffer;
     bi.lpszTitle = wTitle.c_str();
     bi.ulFlags = BIF_RETURNFSANCESTORS | BIF_RETURNONLYFSDIRS;
-    bi.lpfn = (BFFCALLBACK)SelectDirCallBack;
-    bi.lParam = (DWORD)InitialDir.c_str();
+    bi.lpfn = SelectDirCallBack;
+    bi.lParam = (LPARAM)InitialDir.c_str();
     if ((pidl = SHBrowseForFolder(&bi)) != nullptr)
     {
         if (SHGetPathFromIDList(pidl, Directory))
@@ -216,7 +216,7 @@ void COptionsDirectoriesPage::UseSelectedClicked(UINT /*Code*/, int id, HWND /*c
 
     if (!Button->IsChanged() || Button->IsReset())
     {
-        if ((int)Button->GetMenu() == id)
+        if ((INT_PTR)Button->GetMenu() == id)
         {
             return;
         }

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Directories.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Directories.h
@@ -61,7 +61,7 @@ private:
     void  ResetDirectory(CModifiedEditBox & EditBox, SettingID Type);
     void  ResetDefaultSelected(CModifiedButton & ButtonDefault, CModifiedButton & ButtonSelected, SettingID Type);
 
-    static int CALLBACK SelectDirCallBack(HWND hwnd, DWORD uMsg, DWORD lp, DWORD lpData);
+    static int CALLBACK SelectDirCallBack(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM lpData);
 
     CPartialGroupBox m_PluginGroup, m_AutoSaveGroup, m_InstantSaveGroup,
         m_ScreenShotGroup, m_TextureGroup;

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Game-Plugin.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Game-Plugin.cpp
@@ -77,7 +77,7 @@ void CGamePluginPage::ShowAboutButton(int id)
     CModifiedComboBox * ComboBox = nullptr;
     for (ComboBoxList::iterator cb_iter = m_ComboBoxList.begin(); cb_iter != m_ComboBoxList.end(); cb_iter++)
     {
-        if ((int)(cb_iter->second->GetMenu()) != id)
+        if ((INT_PTR)(cb_iter->second->GetMenu()) != id)
         {
             continue;
         }
@@ -130,7 +130,7 @@ void CGamePluginPage::PluginItemChanged(int id, int AboutID, bool bSetChanged)
     CModifiedComboBox * ComboBox = nullptr;
     for (ComboBoxList::iterator cb_iter = m_ComboBoxList.begin(); cb_iter != m_ComboBoxList.end(); cb_iter++)
     {
-        if ((int)(cb_iter->second->GetMenu()) != id)
+        if ((INT_PTR)(cb_iter->second->GetMenu()) != id)
         {
             continue;
         }
@@ -296,7 +296,7 @@ void CGamePluginPage::HleGfxChanged(UINT /*Code*/, int id, HWND /*ctl*/)
     for (ButtonList::iterator iter = m_ButtonList.begin(); iter != m_ButtonList.end(); iter++)
     {
         CModifiedButton * Button = iter->second;
-        if ((int)Button->GetMenu() != id)
+        if ((INT_PTR)Button->GetMenu() != id)
         {
             continue;
         }
@@ -319,7 +319,7 @@ void CGamePluginPage::HleAudioChanged(UINT /*Code*/, int id, HWND /*ctl*/)
     for (ButtonList::iterator iter = m_ButtonList.begin(); iter != m_ButtonList.end(); iter++)
     {
         CModifiedButton * Button = iter->second;
-        if ((int)Button->GetMenu() != id)
+        if ((INT_PTR)Button->GetMenu() != id)
         {
             continue;
         }

--- a/Source/Project64/UserInterface/Settings/SettingsPage-GameBrowser.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-GameBrowser.cpp
@@ -41,7 +41,7 @@ void COptionsGameBrowserPage::UpdateFieldList(const ROMBROWSER_FIELDS_LIST & Fie
     m_Using.ResetContent();
 
     m_OrderChanged = false;
-    for (int i = 0, n = Fields.size(); i < n; i++)
+    for (size_t i = 0, n = Fields.size(); i < n; i++)
     {
         if (Fields[i].PosChanged())
         {
@@ -94,7 +94,7 @@ void COptionsGameBrowserPage::AddFieldClicked(UINT /*Code*/, int /*id*/, HWND /*
         return;
     }
     // Remove from list
-    int i = m_Avaliable.GetItemData(index);
+    size_t i = m_Avaliable.GetItemData(index);
     m_Avaliable.DeleteString(index);
 
     // Select next in list
@@ -120,7 +120,7 @@ void COptionsGameBrowserPage::RemoveFieldClicked(UINT /*Code*/, int /*id*/, HWND
         return;
     }
     // Remove from list
-    int i = m_Using.GetItemData(index);
+    size_t i = m_Using.GetItemData(index);
     m_Using.DeleteString(index);
 
     // Select next in list
@@ -145,7 +145,7 @@ void COptionsGameBrowserPage::MoveFieldUpClicked(UINT /*Code*/, int /*id*/, HWND
     {
         return;
     }
-    int i = m_Using.GetItemData(index);
+    size_t i = m_Using.GetItemData(index);
     m_Using.DeleteString(index);
 
     index = m_Using.InsertString(index - 1, wGS(m_Fields[i].LangID()).c_str());
@@ -164,7 +164,7 @@ void COptionsGameBrowserPage::MoveFieldDownClicked(UINT /*Code*/, int /*id*/, HW
     {
         return;
     }
-    int i = m_Using.GetItemData(index);
+    size_t i = m_Using.GetItemData(index);
     m_Using.DeleteString(index);
 
     index = m_Using.InsertString(index + 1, wGS(m_Fields[i].LangID()).c_str());
@@ -202,7 +202,7 @@ void COptionsGameBrowserPage::ApplySettings(bool UpdateScreen)
         size_t Item, listCount = m_Using.GetCount();
         for (Item = 0; Item < listCount; Item++)
         {
-            int Pos = m_Using.GetItemData(Item);
+            size_t Pos = m_Using.GetItemData(Item);
             if (m_OrderReset || m_Fields[Pos].Pos() != Item)
             {
                 m_Fields[Pos].SetColPos(Item);
@@ -213,7 +213,7 @@ void COptionsGameBrowserPage::ApplySettings(bool UpdateScreen)
         listCount = m_Avaliable.GetCount();
         for (Item = 0; Item < listCount; Item++)
         {
-            int Pos = m_Avaliable.GetItemData(Item);
+            size_t Pos = m_Avaliable.GetItemData(Item);
             if (m_OrderReset || m_Fields[Pos].Pos() != -1)
             {
                 m_Fields[Pos].SetColPos(-1);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Plugin.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Plugin.cpp
@@ -69,7 +69,7 @@ void COptionPluginPage::ShowAboutButton(int id)
     CModifiedComboBox * ComboBox = nullptr;
     for (ComboBoxList::iterator cb_iter = m_ComboBoxList.begin(); cb_iter != m_ComboBoxList.end(); cb_iter++)
     {
-        if ((int)(cb_iter->second->GetMenu()) != id)
+        if ((INT_PTR)(cb_iter->second->GetMenu()) != id)
         {
             continue;
         }
@@ -122,7 +122,7 @@ void COptionPluginPage::PluginItemChanged(int id, int AboutID, bool bSetChanged)
     CModifiedComboBox * ComboBox = nullptr;
     for (ComboBoxList::iterator cb_iter = m_ComboBoxList.begin(); cb_iter != m_ComboBoxList.end(); cb_iter++)
     {
-        if ((int)(cb_iter->second->GetMenu()) != id)
+        if ((INT_PTR)(cb_iter->second->GetMenu()) != id)
         {
             continue;
         }
@@ -280,7 +280,7 @@ void COptionPluginPage::HleGfxChanged(UINT /*Code*/, int id, HWND /*ctl*/)
     for (ButtonList::iterator iter = m_ButtonList.begin(); iter != m_ButtonList.end(); iter++)
     {
         CModifiedButton * Button = iter->second;
-        if ((int)Button->GetMenu() != id)
+        if ((INT_PTR)Button->GetMenu() != id)
         {
             continue;
         }
@@ -303,7 +303,7 @@ void COptionPluginPage::HleAudioChanged(UINT /*Code*/, int id, HWND /*ctl*/)
     for (ButtonList::iterator iter = m_ButtonList.begin(); iter != m_ButtonList.end(); iter++)
     {
         CModifiedButton * Button = iter->second;
-        if ((int)Button->GetMenu() != id)
+        if ((INT_PTR)Button->GetMenu() != id)
         {
             continue;
         }

--- a/Source/Project64/UserInterface/Settings/SettingsPage.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage.cpp
@@ -22,9 +22,9 @@ void CConfigSettingSection::AddPage(CSettingsPage * Page)
 	m_Pages.push_back(Page);
 }
 
-CSettingsPage * CConfigSettingSection::GetPage(int PageNo)
+CSettingsPage * CConfigSettingSection::GetPage(size_t PageNo)
 {
-	if (PageNo < 0 || PageNo >= (int)m_Pages.size())
+	if (PageNo >= m_Pages.size())
 	{
 		return nullptr;
 	}

--- a/Source/Project64/UserInterface/Settings/SettingsPage.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage.h
@@ -72,7 +72,7 @@ protected:
         for (ButtonList::iterator iter = m_ButtonList.begin(); iter != m_ButtonList.end(); iter++)
         {
             CModifiedButton * Button = iter->second;
-            if ((int)Button->GetMenu() != id)
+            if ((INT_PTR)Button->GetMenu() != id)
             {
                 continue;
             }
@@ -294,7 +294,7 @@ protected:
         for (ComboBoxTxtList::iterator cbtxt_iter = m_ComboBoxTxtList.begin(); cbtxt_iter != m_ComboBoxTxtList.end(); cbtxt_iter++)
         {
             CModifiedComboBoxTxt * ComboBox = cbtxt_iter->second;
-            if ((int)ComboBox->GetMenu() != id)
+            if ((INT_PTR)ComboBox->GetMenu() != id)
             {
                 continue;
             }
@@ -305,7 +305,7 @@ protected:
         for (ComboBoxList::iterator cb_iter = m_ComboBoxList.begin(); cb_iter != m_ComboBoxList.end(); cb_iter++)
         {
             CModifiedComboBox * ComboBox = cb_iter->second;
-            if ((int)ComboBox->GetMenu() != id)
+            if ((INT_PTR)ComboBox->GetMenu() != id)
             {
                 continue;
             }
@@ -325,7 +325,7 @@ protected:
         for (TextBoxList::iterator eb_iter = m_TxtBoxList.begin(); eb_iter != m_TxtBoxList.end(); eb_iter++)
         {
             CModifiedEditBox * EditBox = eb_iter->second;
-            if ((int)EditBox->GetMenu() != id)
+            if ((INT_PTR)EditBox->GetMenu() != id)
             {
                 continue;
             }
@@ -553,7 +553,7 @@ public:
     LPCWSTR GetPageTitle(void) const { return m_PageTitle.c_str(); }
     void    AddPage(CSettingsPage * Page);
     size_t  GetPageCount(void) const { return m_Pages.size(); }
-    CSettingsPage * GetPage(int PageNo);
+    CSettingsPage * GetPage(size_t PageNo);
 };
 
 #include "SettingsPage-AdvancedOptions.h"

--- a/Source/Project64/UserInterface/SettingsConfig.cpp
+++ b/Source/Project64/UserInterface/SettingsConfig.cpp
@@ -65,8 +65,8 @@ void CSettingConfig::UpdateAdvanced(bool AdvancedMode, HTREEITEM hItem)
         }
         else if (AdvancedMode && Page == m_GeneralOptionsPage)
         {
-            m_PagesTreeList.InsertItem(TVIF_TEXT | TVIF_PARAM, wGS(m_AdvancedPage->PageTitle()).c_str(), 0, 0, 0, 0, (ULONG)m_AdvancedPage, hItem, TVI_FIRST);
-            m_PagesTreeList.InsertItem(TVIF_TEXT | TVIF_PARAM, wGS(m_DefaultsPage->PageTitle()).c_str(), 0, 0, 0, 0, (ULONG)m_DefaultsPage, hItem, TVI_FIRST);
+            m_PagesTreeList.InsertItem(TVIF_TEXT | TVIF_PARAM, wGS(m_AdvancedPage->PageTitle()).c_str(), 0, 0, 0, 0, (LPARAM)m_AdvancedPage, hItem, TVI_FIRST);
+            m_PagesTreeList.InsertItem(TVIF_TEXT | TVIF_PARAM, wGS(m_DefaultsPage->PageTitle()).c_str(), 0, 0, 0, 0, (LPARAM)m_DefaultsPage, hItem, TVI_FIRST);
             break;
         }
 		else
@@ -191,14 +191,14 @@ LRESULT	CSettingConfig::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*
             }
             if (i == 0)
             {
-                hSectionItem = m_PagesTreeList.InsertItem(TVIF_TEXT | TVIF_PARAM, Section->GetPageTitle(), 0, 0, 0, 0, (ULONG)Page, TVI_ROOT, TVI_LAST);
+                hSectionItem = m_PagesTreeList.InsertItem(TVIF_TEXT | TVIF_PARAM, Section->GetPageTitle(), 0, 0, 0, 0, (LPARAM)Page, TVI_ROOT, TVI_LAST);
                 continue;
             }
             if (hSectionItem == nullptr)
             {
                 continue;
             }
-            m_PagesTreeList.InsertItem(TVIF_TEXT | TVIF_PARAM, wGS(Page->PageTitle()).c_str(), 0, 0, 0, 0, (ULONG)Page, hSectionItem, TVI_LAST);
+            m_PagesTreeList.InsertItem(TVIF_TEXT | TVIF_PARAM, wGS(Page->PageTitle()).c_str(), 0, 0, 0, 0, (LPARAM)Page, hSectionItem, TVI_LAST);
         }
         if (bFirstItem && hSectionItem != nullptr)
         {

--- a/Source/Project64/UserInterface/SupportEnterCode.cpp
+++ b/Source/Project64/UserInterface/SupportEnterCode.cpp
@@ -67,7 +67,7 @@ LRESULT CSupportEnterCode::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM
         hFont = (HFONT)::GetStockObject(SYSTEM_FONT);
     }
     hDC.SelectFont(hFont);
-    if (hDC.DrawText(DescriptionText.c_str(), DescriptionText.length(), &rcWin, DT_LEFT | DT_CALCRECT | DT_WORDBREAK | DT_NOCLIP) > 0)
+    if (hDC.DrawText(DescriptionText.c_str(), (int)(INT_PTR)DescriptionText.length(), &rcWin, DT_LEFT | DT_CALCRECT | DT_WORDBREAK | DT_NOCLIP) > 0)
     {
         hDescription.SetWindowPos(nullptr, 0, 0, rcWin.right, rcWin.bottom, SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOOWNERZORDER);
     }

--- a/Source/Project64/UserInterface/SupportWindow.cpp
+++ b/Source/Project64/UserInterface/SupportWindow.cpp
@@ -82,7 +82,7 @@ LRESULT CSupportWindow::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*
         hFont = (HFONT)::GetStockObject(SYSTEM_FONT);
     }
     hDC.SelectFont(hFont);
-    if (hDC.DrawText(InfoText.c_str(),InfoText.length(),&rcWin,DT_LEFT | DT_CALCRECT | DT_WORDBREAK | DT_NOCLIP) > 0)
+    if (hDC.DrawText(InfoText.c_str(),(int)(INT_PTR)InfoText.length(),&rcWin,DT_LEFT | DT_CALCRECT | DT_WORDBREAK | DT_NOCLIP) > 0)
     {
         hInfo.SetWindowPos(nullptr,0,0,rcWin.right, rcWin.bottom,SWP_NOACTIVATE|SWP_NOMOVE|SWP_NOOWNERZORDER);
     }

--- a/Source/Project64/UserInterface/WTLControls/HexEditCtrl.cpp
+++ b/Source/Project64/UserInterface/WTLControls/HexEditCtrl.cpp
@@ -509,8 +509,8 @@ bool CHexEditCtrl::UpdateCaretUI(bool bEnsureVisible, bool bTop)
 void CHexEditCtrl::Text(int x, int y, const char *text, COLORREF bg, COLORREF fg, CRect *rcOut)
 {
     std::wstring textOuput = stdstr(text).ToUTF16(CP_ACP);
-    size_t length = textOuput.length();
-    int calcWidth = length * m_CharWidth;
+    size_t length = textOuput.length(), tmpW = length * m_CharWidth;
+    int imax = 0x7fffffff, calcWidth = tmpW <= imax ? (LONG) tmpW : imax;
 
     CRect rc(x, y, 0, 0);
     COLORREF orgBg = ::SetBkColor(m_BackDC, bg);
@@ -1095,8 +1095,8 @@ void CHexEditCtrl::OnChar(UINT nChar, UINT /*nRepCnt*/, UINT /*nFlags*/)
 
 void CHexEditCtrl::Paste(bool bAdvanceCaret)
 {
-    uint32_t targetAddress = m_bHaveRealSel ? m_RealSelStartAddress : m_CaretAddress;
-    int retLength = NotifyPaste(targetAddress);
+    address_type targetAddress = m_bHaveRealSel ? m_RealSelStartAddress : m_CaretAddress;
+    int retLength = (address_type) NotifyPaste(targetAddress);
 
     if (retLength != 0)
     {

--- a/Source/Project64/UserInterface/WTLControls/HexEditCtrl.h
+++ b/Source/Project64/UserInterface/WTLControls/HexEditCtrl.h
@@ -123,6 +123,7 @@ class CHexEditCtrl :
     public CWindowImpl<CHexEditCtrl>
 {
 public:
+    typedef uint32_t address_type;
     CHexEditCtrl(void);
     ~CHexEditCtrl(void);
     DECLARE_WND_CLASS(_T("HexEditCtrl"))

--- a/Source/Project64/UserInterface/WTLControls/wtl-BitmapPicture.cpp
+++ b/Source/Project64/UserInterface/WTLControls/wtl-BitmapPicture.cpp
@@ -56,7 +56,7 @@ bool CBitmapPicture::SetIcon(LPCWSTR lpszResourceName, uint32_t nWidth, uint32_t
 	}
 	if (IS_INTRESOURCE(lpszResourceName))
 	{
-		m_nResourceID = (int)lpszResourceName;
+		m_nResourceID = (int)(INT_PTR)lpszResourceName;
 	}
 	else
 	{
@@ -78,7 +78,7 @@ void CBitmapPicture::SetBitmap(LPCWSTR lpszResourceName)
 {
     if (IS_INTRESOURCE(lpszResourceName))
     {
-        m_nResourceID = (int)lpszResourceName;
+        m_nResourceID = (int)(INT_PTR)lpszResourceName;
     }
     else
     {

--- a/Source/Project64/UserInterface/WelcomeScreen.cpp
+++ b/Source/Project64/UserInterface/WelcomeScreen.cpp
@@ -19,8 +19,8 @@ void WelcomeScreen::SelectGameDir(UINT /*Code*/, int /*id*/, HWND /*ctl*/)
     bi.pszDisplayName = Buffer;
     bi.lpszTitle = wTitle.c_str();
     bi.ulFlags = BIF_RETURNFSANCESTORS | BIF_RETURNONLYFSDIRS;
-    bi.lpfn = (BFFCALLBACK)SelectDirCallBack;
-    bi.lParam = (DWORD)InitialDir.c_str();
+    bi.lpfn = SelectDirCallBack;
+    bi.lParam = (LPARAM)InitialDir.c_str();
     if ((pidl = SHBrowseForFolder(&bi)) != nullptr)
     {
         if (SHGetPathFromIDList(pidl, Directory))
@@ -114,7 +114,7 @@ LRESULT WelcomeScreen::OnOkCmd(WORD /*wNotifyCode*/, WORD /*wID*/, HWND /*hWndCt
     return TRUE;
 }
 
-int CALLBACK WelcomeScreen::SelectDirCallBack(HWND hwnd, DWORD uMsg, DWORD /*lp*/, DWORD lpData)
+int CALLBACK WelcomeScreen::SelectDirCallBack(HWND hwnd, UINT uMsg, LPARAM /*lp*/, LPARAM lpData)
 {
     switch (uMsg)
     {

--- a/Source/Project64/UserInterface/WelcomeScreen.h
+++ b/Source/Project64/UserInterface/WelcomeScreen.h
@@ -30,7 +30,7 @@ private:
     BOOL OnEraseBackground(CDCHandle dc);
     LRESULT OnOkCmd(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL & bHandled);
 
-    static int CALLBACK SelectDirCallBack(HWND hwnd, DWORD uMsg, DWORD lp, DWORD lpData);
+    static int CALLBACK SelectDirCallBack(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM lpData);
 
     CBitmapPicture m_Logo;
 };

--- a/Source/RSP/Cpu.c
+++ b/Source/RSP/Cpu.c
@@ -167,7 +167,7 @@ DWORD RunRecompilerCPU (DWORD Cycles);
 
 #define MI_INTR_SP				0x01		/* Bit 0: SP intr */
 
-__declspec(dllexport) DWORD DoRspCycles ( DWORD Cycles )
+__declspec(dllexport) uint32_t DoRspCycles ( uint32_t Cycles )
 {
     extern Boolean AudioHle, GraphicsHle;
 	DWORD TaskType = *(DWORD*)(RSPInfo.DMEM + 0xFC0);

--- a/Source/RSP/Main.cpp
+++ b/Source/RSP/Main.cpp
@@ -230,7 +230,7 @@ filled by the function. (see def above)
 Output: None
 */
 
-EXPORT void GetRspDebugInfo(RSPDEBUG_INFO * DebugInfo)
+EXPORT void GetRspDebugInfo(RSPDEBUG_INFO * OutDI)
 {
 #ifdef _WIN32
 	if (hRSPMenu == NULL)
@@ -238,22 +238,22 @@ EXPORT void GetRspDebugInfo(RSPDEBUG_INFO * DebugInfo)
 		hRSPMenu = LoadMenu((HINSTANCE)hinstDLL,MAKEINTRESOURCE(RspMenu));
 		FixMenuState();
 	}
-	DebugInfo->hRSPMenu = hRSPMenu;
+	OutDI->hRSPMenu = hRSPMenu;
 #endif
-	DebugInfo->ProcessMenuItem = ProcessMenuItem;
+	OutDI->ProcessMenuItem = ProcessMenuItem;
 
-	DebugInfo->UseBPoints = TRUE;
-	sprintf(DebugInfo->BPPanelName," RSP ");
-	DebugInfo->Add_BPoint = Add_BPoint;
-	DebugInfo->CreateBPPanel = CreateBPPanel;
-	DebugInfo->HideBPPanel = HideBPPanel;
-	DebugInfo->PaintBPPanel = PaintBPPanel;
-	DebugInfo->RefreshBpoints = RefreshBpoints;
-	DebugInfo->RemoveAllBpoint = RemoveAllBpoint;
-	DebugInfo->RemoveBpoint = RemoveBpoint;
-	DebugInfo->ShowBPPanel = ShowBPPanel;
+	OutDI->UseBPoints = TRUE;
+	sprintf(OutDI->BPPanelName," RSP ");
+	OutDI->Add_BPoint = Add_BPoint;
+	OutDI->CreateBPPanel = CreateBPPanel;
+	OutDI->HideBPPanel = HideBPPanel;
+	OutDI->PaintBPPanel = PaintBPPanel;
+	OutDI->RefreshBpoints = RefreshBpoints;
+	OutDI->RemoveAllBpoint = RemoveAllBpoint;
+	OutDI->RemoveBpoint = RemoveBpoint;
+	OutDI->ShowBPPanel = ShowBPPanel;
 
-	DebugInfo->Enter_RSP_Commands_Window = Enter_RSP_Commands_Window;
+	OutDI->Enter_RSP_Commands_Window = Enter_RSP_Commands_Window;
 }
 
 /*

--- a/Source/RSP/RSP Command.c
+++ b/Source/RSP/RSP Command.c
@@ -267,12 +267,12 @@ void DrawRSPCommand ( LPARAM lParam )
 	if (strchr(Command,'\t'))
 	{
 		p1 = strchr(Command,'\t');
-		printed_offset = sprintf(Offset, "%.*s", p1 - Command, Command);
+		printed_offset = sprintf(Offset, "%.*s", (int)(INT_PTR)(p1 - Command), Command);
 		p1++;
 		if (strchr(p1,'\t'))
 		{
 			p2 = strchr(p1,'\t');
-			printed_instruction = sprintf(Instruction, "%.*s", p2 - p1, p1);
+			printed_instruction = sprintf(Instruction, "%.*s", (int)(INT_PTR)(p2 - p1), p1);
 			printed_arguments   = sprintf(Arguments, "%s", p2 + 1);
 		}
 		else

--- a/Source/RSP/Recompiler CPU.c
+++ b/Source/RSP/Recompiler CPU.c
@@ -24,8 +24,9 @@
 #define X86_RECOMP_VERBOSE
 #define BUILD_BRANCHLABELS_VERBOSE
 
-DWORD CompilePC, JumpTableSize, BlockID = 0;
+DWORD BlockID = 0;
 DWORD dwBuffer = MainBuffer;
+uint32_t CompilePC, JumpTableSize;
 Boolean ChangedPC;
 
 RSP_BLOCK CurrentBlock;

--- a/Source/RSP/X86.c
+++ b/Source/RSP/X86.c
@@ -406,6 +406,9 @@ void X86BreakPoint (LPCSTR FileName, int LineNumber) {
 #if defined(_M_IX86)
 	PushImm32("FileName",(DWORD)FileName);
 #else
+	#ifdef UNREFERENCED_PARAMETER
+		UNREFERENCED_PARAMETER(FileName);
+	#endif
 	DisplayError("PushImm64\nUnimplemented.");
 #endif
 	Call_Direct(BreakPointNotification,"BreakPointNotification");

--- a/Source/nragev20/FileAccess.cpp
+++ b/Source/nragev20/FileAccess.cpp
@@ -1030,9 +1030,7 @@ bool BrowseFolders( HWND hwndParent, TCHAR *pszHeader, TCHAR *pszDirectory )
     brInfo.ulFlags = BIF_RETURNONLYFSDIRS;
     brInfo.lpfn = NULL;
 
-    ITEMIDLIST *piList;
-
-    piList = SHBrowseForFolder( &brInfo );
+    LPITEMIDLIST piList = SHBrowseForFolder( &brInfo );
     if( piList )
     {
         SHGetPathFromIDList( (const LPITEMIDLIST)piList, pszDirectory );
@@ -1475,6 +1473,12 @@ inline void GUIDtoStringA( char * szGUIDbuf, const GUID guid )
 
 inline bool StringtoGUIDA( LPGUID guid, const char * szGUIDbuf )
 {
+    // Instead of trying to figure out if the CRT supports %hhX, just ignore the warning since the code is already aware that %hX will write a short.
+    #if defined(_MSC_VER) && _MSC_VER >= 1200
+    #pragma warning( push )
+    #pragma warning( disable : 4477 )
+    #endif
+
     short unsigned int lastbyte;
     int blah = sscanf(szGUIDbuf, "{%08lX-%04hX-%04hX-%02hX%02hX-%02hX%02hX%02hX%02hX%02hX%02hX}", &guid->Data1, &guid->Data2, &guid->Data3, &guid->Data4[0], &guid->Data4[1], &guid->Data4[2], &guid->Data4[3], &guid->Data4[4], &guid->Data4[5], &guid->Data4[6], &lastbyte);
     if (blah == 11)
@@ -1484,6 +1488,10 @@ inline bool StringtoGUIDA( LPGUID guid, const char * szGUIDbuf )
     }
     else
         return false;
+
+    #if defined(_MSC_VER) && _MSC_VER >= 1200
+    #pragma warning( pop )
+    #endif
 }
 
 // Takes in a file to dump to, and an 'int i' telling which controller's settings to dump. Does not dump buttons or modifiers.

--- a/Source/nragev20/Interface.cpp
+++ b/Source/nragev20/Interface.cpp
@@ -73,7 +73,7 @@ BOOL CALLBACK MainDlgProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
     static HWND hTabControl;
     HWND hDlgItem;
-    long i,j;
+    LONG_PTR i,j;
 
     switch(uMsg)
     {
@@ -363,7 +363,7 @@ BOOL CALLBACK ControllerTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 
     CONTROLLER *pcController = &g_ivConfig->Controllers[g_ivConfig->ChosenTab];;
     HWND hDlgItem;
-    long i,j;
+    LONG_PTR i,j;
 
     switch(uMsg)
     {
@@ -1044,7 +1044,7 @@ BOOL CALLBACK DevicesTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam
 BOOL CALLBACK MoveModifierDialog( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
 {
     HWND hDlgItem;
-    long i,j;
+    LONG_PTR i,j;
     DWORD dwValue;
     TCHAR szBuffer[DEFAULT_BUFFER], szTemp[DEFAULT_BUFFER];
 
@@ -1080,13 +1080,13 @@ BOOL CALLBACK MoveModifierDialog( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lP
         case IDC_XMODIFIER:
             i = SendMessage( (HWND)lParam, TBM_GETPOS, 0, 0 );
             LoadString( g_hResourceDLL, IDS_M_MOVEVALUE, szTemp, DEFAULT_BUFFER );
-            wsprintf( szBuffer, szTemp, i );
+            wsprintf( szBuffer, szTemp, (long)i );
             SendMessage( GetDlgItem( hDlg, IDT_XMODIFIER ), WM_SETTEXT , 0, (LPARAM)szBuffer );
             return TRUE;
         case IDC_YMODIFIER:
             i = SendMessage( (HWND)lParam, TBM_GETPOS, 0, 0 );
             LoadString( g_hResourceDLL, IDS_M_MOVEVALUE, szTemp, DEFAULT_BUFFER );
-            wsprintf( szBuffer, szTemp, i );
+            wsprintf( szBuffer, szTemp, (long)i );
             SendMessage( GetDlgItem( hDlg, IDT_YMODIFIER ), WM_SETTEXT , 0, (LPARAM)szBuffer );
             return TRUE;
         default:
@@ -1110,7 +1110,7 @@ BOOL CALLBACK MoveModifierDialog( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lP
             CheckDlgButton( hDlg, IDC_XNEGATE, BST_UNCHECKED );
         SendMessage( GetDlgItem( hDlg, IDC_XMODIFIER ), TBM_SETPOS, TRUE, i );
         LoadString( g_hResourceDLL, IDS_M_MOVEVALUE, szTemp, DEFAULT_BUFFER );
-        wsprintf( szBuffer, szTemp, i );
+        wsprintf( szBuffer, szTemp, (long)i );
         SendMessage( GetDlgItem( hDlg, IDT_XMODIFIER ), WM_SETTEXT , 0, (LPARAM)szBuffer );
 
         i = (short)((dwValue >> 16) & 0x0000FFFF);
@@ -1124,7 +1124,7 @@ BOOL CALLBACK MoveModifierDialog( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lP
             CheckDlgButton( hDlg, IDC_YNEGATE, BST_UNCHECKED );
         SendMessage( GetDlgItem( hDlg, IDC_YMODIFIER ), TBM_SETPOS, TRUE, i );
         LoadString( g_hResourceDLL, IDS_M_MOVEVALUE, szTemp, DEFAULT_BUFFER );
-        wsprintf( szBuffer, szTemp, i );
+        wsprintf( szBuffer, szTemp, (long)i );
         SendMessage( GetDlgItem( hDlg, IDT_YMODIFIER ), WM_SETTEXT , 0, (LPARAM)szBuffer );
         return TRUE;
 
@@ -1430,7 +1430,7 @@ BOOL CALLBACK ModifierTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
 
     TCHAR szBuffer[40];
     HWND hDlgItem;
-    long i;
+    LONG_PTR i;
     BYTE bByte;
 
     switch(uMsg)
@@ -1685,7 +1685,7 @@ BOOL CALLBACK ModifierTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPara
                 lvItem.iItem = lvItem.lParam;
                 i = ListView_InsertItem( hDlgItem, &lvItem );
 
-                ModDescription( hDlgItem, i, &pcController->pModifiers[lvItem.lParam] );
+                ModDescription( hDlgItem, (int)i, &pcController->pModifiers[lvItem.lParam] );
             }
             if( iSelectedMod >= 0 && iSelectedMod < ListView_GetItemCount( hDlgItem ))
 
@@ -1823,7 +1823,7 @@ BOOL CALLBACK ControllerPakTabProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM 
     static bool bAdaptoidInList;
     static BYTE bCurrentPak;
     HWND hDlgItem;
-    long i,j;
+    LONG_PTR i,j;
     BYTE bByte;
     TCHAR tszMsg[DEFAULT_BUFFER];
 
@@ -2053,7 +2053,7 @@ BOOL CALLBACK MemPakProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam )
     TCHAR szBuffer[MAX_PATH+1], szTemp[MAX_PATH+1];
 
     HWND hDlgItem;
-    long i,j;
+    LONG_PTR i,j;
 
     switch(uMsg)
     {
@@ -2435,7 +2435,7 @@ BOOL CALLBACK RumblePakProc( HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam 
     CONTROLLER *pcController = &g_ivConfig->Controllers[g_ivConfig->ChosenTab];
     TCHAR szBuffer[DEFAULT_BUFFER], szTemp[DEFAULT_BUFFER];
     HWND hDlgItem;
-    long i = 0,j;
+    LONG_PTR i = 0,j;
 
     switch(uMsg)
     {

--- a/Source/nragev20/PakIO.cpp
+++ b/Source/nragev20/PakIO.cpp
@@ -965,7 +965,7 @@ int ReverseNotesA( LPCSTR Text, LPBYTE Note )
         TextPos++;
         Note++;
     }
-    return TextPos - Text;
+    return (UINT)(SIZE_T)(TextPos - Text);
 }
 
 WORD ShowMemPakContent( const unsigned char * bMemPakBinary, HWND hListWindow )

--- a/Source/nragev20/XInputController.cpp
+++ b/Source/nragev20/XInputController.cpp
@@ -182,7 +182,7 @@ void GetXInputControllerKeys( const int indexController, LPDWORD Keys )
     DWORD result;
     XINPUT_STATE state;
 
-    ULONGLONG time = GetTickCount() / 1000;
+    ULONG time = GetTickCount() / 1000;
     if (g_pcControllers[indexController].XcheckTime != NULL && (time - g_pcControllers[indexController].XcheckTime) < 3)
         return;
 
@@ -663,14 +663,14 @@ void StoreAnalogConfig( LPXCONTROLLER gController, int ComboBox, int index )
 
 void StoreXInputControllerKeys( HWND hDlg, LPXCONTROLLER gController )
 {
-    LRESULT index = -1;
+    int index = -1;
     DWORD value = 0;
 
     ResetXInputControllerKeys( gController );
 
     for( int i = IDC_XC_A; i <= IDC_XC_RTS; i++ )
     {
-        index = SendDlgItemMessage( hDlg, i, CB_GETCURSEL, 0, 0 );
+        index = (int)(INT_PTR) SendDlgItemMessage( hDlg, i, CB_GETCURSEL, 0, 0 );
         value = GetComboBoxXInputKey( i );
         if( value == 0 )
             continue;


### PR DESCRIPTION
This tries to fix a bunch of compiler warnings, many of them related to 64-bit. I tried to stay away from the CPU/emulation and video stuff but there are many warnings left there that need attention.

### Does this make breaking changes?
Hopefully not but I can't rule it out with this many changes. There are a couple of cases where local variables shadowed some global variables and I renamed the local. It would perhaps be better if some of the globals could be renamed with a `g_` prefix, especially the ones with short names like r, g, b and buf but I really don't want to risk breaking any emulation related code. I realize the `safe_truncate_cast_assign` function is very ugly but I don't really have a better idea of how to truncate without a warning but not potentially break code if the destination becomes larger in the future. I only used it in one place for now in case you don't like it. The point of it is to retain the speed of `dest = (smaller int cast) source` without just a cast to silence the compiler. If dest becomes larger than the cast the warning should come back automatically or `static_assert` if available.

### Does this version of Project64 compile and run without issue?
Don't know.