### PR TITLE
Enable Visual Studio 2022 support

### DIFF
--- a/PropertySheets/Platform.props
+++ b/PropertySheets/Platform.props
@@ -2,8 +2,8 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="Configuration">
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(DefaultPlatformToolset)'!='v142'">$(DefaultPlatformToolset)_xp</PlatformToolset>
-    <PlatformToolset Condition="'$(DefaultPlatformToolset)'=='v142'">$(DefaultPlatformToolset)</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset)'!='' AND '$(DefaultPlatformToolset.Substring(1))'&lt;'142'">$(DefaultPlatformToolset)_xp</PlatformToolset>
+    <PlatformToolset Condition="'$(DefaultPlatformToolset.Substring(1))'&gt;='142'">$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
 


### PR DESCRIPTION
Allows building with Visual studio 2022 out of the box.

Fixes #

### Proposed changes
  - Detect the default platform toolset by version range instead of direct comparison (i.e. `>=142` instead of `="v142"`.

### Does this make breaking changes?
NO

### Does this version of Project64 compile and run without issue?
YES