### PR TITLE
Unbreak Jabo plugin write access to config files (rdb/cfg)

### DIFF
--- a/Source/Project64-core/Settings/SettingType/SettingsType-RomDatabase.cpp
+++ b/Source/Project64-core/Settings/SettingType/SettingsType-RomDatabase.cpp
@@ -232,10 +232,6 @@ void CSettingTypeRomDatabase::LoadDefault(uint32_t /*Index*/, std::string & Valu
 // Update the settings
 void CSettingTypeRomDatabase::Save(uint32_t /*Index*/, bool Value)
 {
-    if (!g_Settings->LoadBool(Setting_RdbEditor))
-    {
-        return;
-    }
     if (m_DeleteOnDefault)
     {
         g_Notify->BreakPoint(__FILE__, __LINE__);
@@ -256,10 +252,6 @@ void CSettingTypeRomDatabase::Save(uint32_t /*Index*/, bool Value)
 
 void CSettingTypeRomDatabase::Save(uint32_t Index, uint32_t Value)
 {
-    if (!g_Settings->LoadBool(Setting_RdbEditor))
-    {
-        return;
-    }
     if (m_DeleteOnDefault)
     {
         uint32_t defaultValue = 0;
@@ -286,10 +278,6 @@ void CSettingTypeRomDatabase::Save(uint32_t Index, uint32_t Value)
 
 void CSettingTypeRomDatabase::Save(uint32_t /*Index*/, const std::string & Value)
 {
-    if (!g_Settings->LoadBool(Setting_RdbEditor))
-    {
-        return;
-    }
     if (m_VideoSetting)
     {
         m_VideoIniFile->SaveString(Section(), m_KeyName.c_str(), Value.c_str());
@@ -306,10 +294,6 @@ void CSettingTypeRomDatabase::Save(uint32_t /*Index*/, const std::string & Value
 
 void CSettingTypeRomDatabase::Save(uint32_t /*Index*/, const char * Value)
 {
-    if (!g_Settings->LoadBool(Setting_RdbEditor))
-    {
-        return;
-    }
     if (m_VideoSetting)
     {
         m_VideoIniFile->SaveString(Section(), m_KeyName.c_str(), Value);
@@ -326,10 +310,6 @@ void CSettingTypeRomDatabase::Save(uint32_t /*Index*/, const char * Value)
 
 void CSettingTypeRomDatabase::Delete(uint32_t /*Index*/)
 {
-    if (!g_Settings->LoadBool(Setting_RdbEditor))
-    {
-        return;
-    }
     if (m_VideoSetting)
     {
         m_VideoIniFile->SaveString(Section(), m_KeyName.c_str(), nullptr);


### PR DESCRIPTION
Looks like this was broken for the **longest** time and no one realized till now!
Explaination: Jabo's 1.7 plugins write to both the Project64.cfg and Project64.rdb files to store settings, but in all the versions from 2.0 onwards broke compatibility partly with it. Worked fine in the 1.7.x betas.

### Proposed changes
  - Restore functionality to write to rdb without needing Edit Mode on

### Does this make breaking changes?
_Au contraire_, it unbreaks Jabo 1.7 settings saving.

### Does this version of Project64 compile and run without issue?
Yes.