### PR TITLE
Enforce a standard issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -38,7 +38,7 @@
 
 ### Please make sure you are using the inlcuded plugins before opening an issue:
 
-- [ ] I can confirm I am on the default RSP, audio, and graphics plugins
+- [ ] I can confirm I am on the default RSP, audio, input, and graphics plugins
 
 ### Plugins used while the issue occurred:
 

--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -16,7 +16,7 @@
   1.
   1.
 
-### Error messages you received
+### Error messages you received (if any)
 - 
 - 
 - 
@@ -39,6 +39,13 @@
 ### Plugins used while the issue occurred:
 
   - Graphics plugin (and HLE or LLE):
-  - Sound plugin:
+  - Audio plugin:
   - Input plugin:
   - RSP plugin:
+
+### FAQ's and a warning:
+
+  - If you are having issues with a plugin that isn't included with and supported by the Project64 team, we cannot support you other then pointing you to the developer of those plugins.
+  - Please join the Discord first and ask questions and ask for support there first. If the issue should require an open GitHub issue, somebody will ask you to open one. We have a lot of people in the Discord who are more then happy to help you with any issues you may be having!
+  - Please avoid opening issues if you do not meet the minimum requirements for Project64. These are outlined in the README for this repository.
+  

--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -36,6 +36,10 @@
   - Windows version (include version and OS build number using WinVer):
   - Project64 version (include commit version number and whether you are using the 32-bit or 64-bit version):
 
+### Please make sure you are using the inlcuded plugins before opening an issue:
+
+- [ ] I can confirm I am on the default RSP, audio, and graphics plugins
+
 ### Plugins used while the issue occurred:
 
   - Graphics plugin (and HLE or LLE):

--- a/.github/ISSUE_TEMPLATE/FEATURE.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE.md
@@ -1,3 +1,5 @@
+### Please inlcude [Feature request] at the beginning of the title
+
 ### Feature desired:
 - 
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Project64 Community Support
     url: https://discord.gg/Cg3zquF
-    about: Please ask and answer questions on our Discord!
+    about: For general questions and support please join the Discord!

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Project64 is a free and open-source emulator for the Nintendo 64 and Nintendo 64
 ## System Requirements
 
 * Operating System
-  * Windows XP/Vista/7/8/10
+  * Windows XP and later
 * CPU
-  * Intel or AMD processor with SSE2 support
+  * Intel or AMD processor with at least SSE2 support
 * RAM
   * 512MB or more
 * Graphics card
@@ -30,7 +30,7 @@ AppVeyor (Windows x86/x64): [![Build status](https://ci.appveyor.com/api/project
 
 ## Support
 
-[**Join the official Project64 Discord server**](https://discord.gg/Cg3zquF) to seek help from Project64 developers, contributors, and the community!
+[**Join the official Project64 Discord server**](https://discord.gg/Cg3zquF) to seek help from Project64 developers, contributors, and the community! Please ask questions here first and see if you should open an issue.
 
 ### Compiling
 
@@ -38,17 +38,17 @@ AppVeyor (Windows x86/x64): [![Build status](https://ci.appveyor.com/api/project
 Visual Studio Community
 ```
 
-Load .sln project file and compile
+Load .sln project file and compile.
 
 See the [BUILDING.md](https://github.com/project64/project64/blob/develop/BUILDING.md) file for details.
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](https://github.com/project64/project64/blob/develop/.github/CONTRIBUTING.md) before contributing.
+Please read [CONTRIBUTING.md](https://github.com/project64/project64/blob/develop/.github/CONTRIBUTING.md) before contributing, opening issues or pull requests, or for other contributions.
 
 ## Versioning
 
-We use semantic versioning for Project64. For the versions available, see the [tags on this repository](https://github.com/project64/project64/tags)
+We use semantic versioning for Project64. For the versions available, see the [tags on this repository](https://github.com/project64/project64/tags).
 
 ## Author / Contributors
 
@@ -61,4 +61,4 @@ See also the list of [contributors](https://github.com/project64/project64/contr
 
 ## License
 
-This project is licensed under the GPLv2 License - see the [LICENSE.md](https://github.com/project64/project64/blob/develop/license.md) file for details
+This project is licensed under the GPLv2 License - see the [LICENSE.md](https://github.com/project64/project64/blob/develop/license.md) file for details.


### PR DESCRIPTION
This will enforce a standard issue template, and will force the user to make sure they are creating the issue with all of the info the developers and contributors need to help the user.

Also updates the README to be less confusing and also a bit more broad in some cases.

### Proposed changes
  - Enforce a standard issue template
  - Adjust wording of README and other templates to match
  - Push users to the Discord for general help and support
  - Make sure users understand the plugins developed outside of this repository are not under our control and therefore we can't do much to help them in regards to fixing bugs and adding features

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Yes.