### PR TITLE
Update the current RDB with some minor fixes and improvements

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -204,7 +204,7 @@ Status=Compatible
 [B98BA456-5B2B76AF-C:4A]
 Good Name=64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (J)
 Internal Name=ÐÝÅÃÞÀÏºÞ¯ÁÜ°ÙÄÞ
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -547,7 +547,7 @@ RDRAM Size=4
 [E73C7C4F-AF93B838-C:4A]
 Good Name=Baku Bomberman 2 (J)
 Internal Name=BAKUBOMB2
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -878,7 +878,7 @@ RDRAM Size=4
 [237E73B4-D63B6B37-C:45]
 Good Name=Bomberman 64 - The Second Attack! (U)
 Internal Name=BOMBERMAN64U2
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 SMM-Cache=0
 SMM-FUNC=0
@@ -1459,14 +1459,14 @@ Save Type=16kbit Eeprom
 [D1A78A07-52A3DD3E-C:50]
 Good Name=CyberTiger (E)
 Internal Name=CyberTiger
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [E8FC8EA1-9F738391-C:45]
 Good Name=CyberTiger (U)
 Internal Name=CyberTiger
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -1481,7 +1481,7 @@ RDRAM Size=4
 [7ED67CD4-B4415E6D-C:50]
 Good Name=Dark Rift (E)
 Internal Name=DARK RIFT
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Culling=1
 RDRAM Size=4
@@ -1489,7 +1489,7 @@ RDRAM Size=4
 [A4A52B58-23759841-C:45]
 Good Name=Dark Rift (U)
 Internal Name=DARK RIFT
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Culling=1
 RDRAM Size=4
@@ -1561,7 +1561,7 @@ RDRAM Size=4
 [76712159-35666812-C:0]
 Good Name=Dexanoid R1 by Protest Design (PD)
 Internal Name=Dexanoid - ProtestDe
-Status=Needs video plugin
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -1888,7 +1888,7 @@ Status=Compatible
 [0DED0568-1502515E-C:4A]
 Good Name=Eikou no Saint Andrews (J)
 Internal Name=´²º³É¾ÝÄ±ÝÄÞØ­°½
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -1908,8 +1908,8 @@ RDRAM Size=4
 
 [02B1538F-C94B88D0-C:45]
 Good Name=Elmo's Number Journey (U)
-Internal Name=Elmo's Number Journe
-Status=Issues (core)
+Internal Name=Elmo's Number Journey
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -2339,21 +2339,21 @@ Status=Compatible
 [D543BCD6-2BA5E256-C:50]
 Good Name=Gauntlet Legends (E)
 Internal Name=GAUNTLET LEGENDS
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 RSP-Mfc0Count=10
 
 [70B0260E-6716D04C-C:4A]
 Good Name=Gauntlet Legends (J)
 Internal Name=GAUNTLET LEGENDS
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 RSP-Mfc0Count=10
 
 [729B5E32-B728D980-C:45]
 Good Name=Gauntlet Legends (U)
 Internal Name=GAUNTLET LEGENDS
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 Culling=1
 RSP-Mfc0Count=10
@@ -3281,7 +3281,7 @@ Save Type=16kbit Eeprom
 [4A997C74-E2087F99-C:50]
 Good Name=Knife Edge - Nose Gunner (E)
 Internal Name=KNIFE EDGE
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 Culling=1
 RDRAM Size=4
@@ -3289,7 +3289,7 @@ RDRAM Size=4
 [931AEF3F-EF196B90-C:4A]
 Good Name=Knife Edge - Nose Gunner (J)
 Internal Name=KNIFE EDGE
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 Culling=1
 RDRAM Size=4
@@ -3574,14 +3574,14 @@ RDRAM Size=4
 [CDB998BE-1024A5C8-C:50]
 Good Name=Major League Baseball Featuring Ken Griffey Jr. (E)
 Internal Name=MLB FEATURING K G JR
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [80C1C05C-EA065EF4-C:45]
 Good Name=Major League Baseball Featuring Ken Griffey Jr. (U)
 Internal Name=MLB FEATURING K G JR
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -3788,21 +3788,21 @@ Save Type=FlashRam
 [839F3AD5-406D15FA-C:50]
 Good Name=Mario Tennis (E)
 Internal Name=MarioTennis
-Status=Issues (plugin)
+Status=Compatible
 Culling=1
 Save Type=16kbit Eeprom
 
 [5001CF4F-F30CB3BD-C:45]
 Good Name=Mario Tennis (U)
 Internal Name=MarioTennis
-Status=Issues (plugin)
+Status=Compatible
 Culling=1
 Save Type=16kbit Eeprom
 
 [3A6C42B5-1ACADA1B-C:4A]
 Good Name=Mario Tennis 64 (J)
 Internal Name=MarioTennis64
-Status=Issues (plugin)
+Status=Compatible
 Save Type=16kbit Eeprom
 
 [27C985A8-ED7CE5C6-C:0]
@@ -3871,7 +3871,7 @@ Culling=1
 [E4B35E4C-1AC45CC9-C:45]
 Good Name=Midway's Greatest Arcade Hits Volume 1 (U)
 Internal Name=MGAH VOL1
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -4108,7 +4108,7 @@ RDRAM Size=4
 [1938525C-586E9656-C:45]
 Good Name=Ms. Pac-Man Maze Madness (U)
 Internal Name=MS. PAC-MAN MM
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -4165,7 +4165,7 @@ Status=Compatible
 [DF331A18-5FD4E044-C:45]
 Good Name=NASCAR 2000 (U)
 Internal Name=NASCAR 2000
-Status=Issues (plugin)
+Status=Compatible
 Clear Frame=2
 Counter Factor=1
 Culling=1
@@ -4173,7 +4173,7 @@ Culling=1
 [AE4992C9-9253B253-C:50]
 Good Name=NASCAR 99 (E) (M3)
 Internal Name=NASCAR 99
-Status=Issues (plugin)
+Status=Compatible
 Clear Frame=2
 Counter Factor=1
 
@@ -4196,14 +4196,14 @@ Save Type=FlashRam
 [C788DCAE-BD03000A-C:50]
 Good Name=NBA Hangtime (E)
 Internal Name=NBA HANGTIME
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [4E69B487-FE18E290-C:45]
 Good Name=NBA Hangtime (U)
 Internal Name=NBA HANGTIME
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -4320,7 +4320,7 @@ RDRAM Size=4
 [3FFE80F4-A7C15F7E-C:45]
 Good Name=NBA Showtime - NBA on NBC (U)
 Internal Name=NBA SHOWTIME
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 Audio Signal=Yes
 Counter Factor=1
@@ -4481,7 +4481,7 @@ ViRefresh=2200
 [CD3C3CDF-317793FA-C:4A]
 Good Name=Nintama Rantarou 64 Game Gallery (J)
 Internal Name=NINTAMAGAMEGALLERY64
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -4549,14 +4549,14 @@ RDRAM Size=4
 [812289D0-C2E53296-C:50]
 Good Name=Off Road Challenge (E)
 Internal Name=OFFROAD
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [319093EC-0FC209EF-C:45]
 Good Name=Off Road Challenge (U)
 Internal Name=OFFROAD
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -4623,7 +4623,7 @@ RDRAM Size=4
 [2655BB70-667D9925-C:45]
 Good Name=O.D.T (Or Die Trying) (U) (M3) (Unreleased Final)
 Internal Name=O.D.T
-Status=Region issue (core)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -4774,7 +4774,7 @@ RDRAM Size=4
 [B54CE881-BCCB6126-C:45]
 Good Name=PGA European Tour (U)
 Internal Name=PGA European Tour
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -4856,7 +4856,7 @@ RDRAM Size=4
 [7BB18D40-83138559-C:55]
 Good Name=Pokemon Snap (A)
 Internal Name=POKEMON SNAP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -4864,7 +4864,7 @@ RDRAM Size=4
 [4FF5976F-ACF559D8-C:50]
 Good Name=Pokemon Snap (E)
 Internal Name=POKEMON SNAP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -4872,7 +4872,7 @@ RDRAM Size=4
 [BA6C293A-9FAFA338-C:46]
 Good Name=Pokemon Snap (F)
 Internal Name=POKEMON SNAP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -4880,7 +4880,7 @@ RDRAM Size=4
 [5753720D-2A8A884D-C:44]
 Good Name=Pokemon Snap (G)
 Internal Name=POKEMON SNAP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -4888,7 +4888,7 @@ RDRAM Size=4
 [C0C85046-61051B05-C:49]
 Good Name=Pokemon Snap (I)
 Internal Name=POKEMON SNAP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -4896,7 +4896,7 @@ RDRAM Size=4
 [EC0F690D-32A7438C-C:4A]
 Good Name=Pokemon Snap (J) (V1.0)
 Internal Name=POKEMON SNAP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -4904,7 +4904,7 @@ RDRAM Size=4
 [E0044E9E-CD659D0D-C:4A]
 Good Name=Pokemon Snap (J) (V1.1)
 Internal Name=POKEMON SNAP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -4912,7 +4912,7 @@ RDRAM Size=4
 [817D286A-EF417416-C:53]
 Good Name=Pokemon Snap (S)
 Internal Name=POKEMON SNAP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -4920,7 +4920,7 @@ RDRAM Size=4
 [CA12B547-71FA4EE4-C:45]
 Good Name=Pokemon Snap (U)
 Internal Name=POKEMON SNAP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -4928,7 +4928,7 @@ RDRAM Size=4
 [39119872-07722E9F-C:45]
 Good Name=Pokemon Snap Station (U)
 Internal Name=POKEMON SNAP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 RDRAM Size=4
@@ -5330,7 +5330,7 @@ RDRAM Size=4
 [20FD0BF1-F5CF1D87-C:50]
 Good Name=Rat Attack (E) (M6)
 Internal Name=RAT ATTACK
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 SMM-FUNC=0
@@ -5338,7 +5338,7 @@ SMM-FUNC=0
 [0304C48E-AC4001B8-C:45]
 Good Name=Rat Attack (U) (M6)
 Internal Name=RAT ATTACK
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 SMM-FUNC=0
@@ -5859,13 +5859,13 @@ AudioResetOnLoad=Yes
 [C00CA948-8E60D34B-C:50]
 Good Name=South Park - Chef's Luv Shack (E)
 Internal Name=South Park Chef's Lu
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 
 [C00CA948-8E60D34B-C:45]
 Good Name=South Park - Chef's Luv Shack (U)
 Internal Name=South Park: Chef's L
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 
 [4F8AFC3A-F7912DF2-C:50]
@@ -5886,7 +5886,7 @@ RDRAM Size=4
 [37463412-EAC5388D-C:4A]
 Good Name=Space Dynamites (J)
 Internal Name=SPACE DYNAMITES
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Culling=1
 
@@ -6065,7 +6065,7 @@ Clear Frame=1
 [827E4890-958468DC-C:4A]
 Good Name=Star Wars - Shutsugeki! Rogue Chuutai (J)
 Internal Name=rogue squadron
-Status=Issues (plugin)
+Status=Compatible
 RSP-JumpTableSize=3584
 
 [FE24AC63-1B41AA17-C:4A]
@@ -6178,7 +6178,7 @@ RDRAM Size=4
 [9510D8D7-35100DD2-C:45]
 Good Name=Stunt Racer 64 (U)
 Internal Name=Stunt Racer 64
-Status=Issues (plugin)
+Status=Compatible
 AudioResetOnLoad=Yes
 HLE GFX=No
 RSP-Mfc0Count=10
@@ -6186,21 +6186,21 @@ RSP-Mfc0Count=10
 [F4646B69-C5751095-C:4A]
 Good Name=Super B-Daman - Battle Phoenix 64 (J)
 Internal Name=BattlePhoenix64
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [F3F2F385-6E490C7F-C:4A]
 Good Name=Super Bowling (J)
 Internal Name=SUPER BOWLING
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [AA1D215A-91CBBE9A-C:45]
 Good Name=Super Bowling 64 (U)
 Internal Name=SUPER BOWLING
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -6247,7 +6247,7 @@ RDRAM Size=4
 [1649D810-F73AD6D2-C:4A]
 Good Name=Super Robot Taisen 64 (J)
 Internal Name=½°Êß°ÛÎÞ¯ÄÀ²¾Ý64
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -6778,25 +6778,25 @@ RDRAM Size=4
 [5F3F49C6-0DC714B0-C:50]
 Good Name=Top Gear Hyper Bike (E)
 Internal Name=Top Gear Hyper Bike
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 
 [845B0269-57DE9502-C:4A]
 Good Name=Top Gear Hyper Bike (J)
 Internal Name=Top Gear Hyper Bike
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [8ECC02F0-7F8BDE81-C:45]
 Good Name=Top Gear Hyper Bike (U)
 Internal Name=Top Gear Hyper Bike
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 
 [75FBDE20-A3189B31-C:0]
 Good Name=Top Gear Hyper Bike (Beta)
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -6827,19 +6827,19 @@ Direct3D8-Direct3DPipe=1
 [7F43E701-536328D1-C:50]
 Good Name=Top Gear Rally (E)
 Internal Name=TOP GEAR RALLY
-Status=Issues (mixed)
+Status=Compatible
 RDRAM Size=4
 
 [0E596247-753D4B8B-C:4A]
 Good Name=Top Gear Rally (J)
 Internal Name=TOP GEAR RALLY
-Status=Issues (mixed)
+Status=Compatible
 RDRAM Size=4
 
 [62269B3D-FE11B1E8-C:45]
 Good Name=Top Gear Rally (U)
 Internal Name=TOP GEAR RALLY
-Status=Issues (mixed)
+Status=Compatible
 RDRAM Size=4
 
 [BEBAB677-51B0B5E4-C:50]
@@ -7125,13 +7125,13 @@ RDRAM Size=4
 [E688A5B8-B14B3F18-C:50]
 Good Name=Twisted Edge Extreme Snowboarding (E)
 Internal Name=TWISTED EDGE
-Status=Issues (mixed)
+Status=Compatible
 Culling=1
 
 [BBC99D32-117DAA80-C:45]
 Good Name=Twisted Edge Extreme Snowboarding (U)
 Internal Name=TWISTED EDGE
-Status=Issues (mixed)
+Status=Compatible
 Culling=1
 
 //================  U  ================
@@ -7171,7 +7171,7 @@ RDRAM Size=4
 [151F79F4-8EEDC8E5-C:50]
 Good Name=Vigilante 8 (E)
 Internal Name=VIGILANTE 8
-Status=Issues (plugin)
+Status=Issues (core)
 32bit=Yes
 Counter Factor=1
 Linking=Off
@@ -7179,7 +7179,7 @@ Linking=Off
 [E2BC82A2-591CD694-C:46]
 Good Name=Vigilante 8 (F)
 Internal Name=VIGILANTE 8
-Status=Issues (plugin)
+Status=Issues (core)
 32bit=Yes
 Counter Factor=1
 Linking=Off
@@ -7187,7 +7187,7 @@ Linking=Off
 [6EDA5178-D396FEC1-C:44]
 Good Name=Vigilante 8 (G)
 Internal Name=VIGILANTE 8
-Status=Issues (plugin)
+Status=Issues (core)
 32bit=Yes
 Counter Factor=1
 Linking=Off
@@ -7195,7 +7195,7 @@ Linking=Off
 [EA71056A-E4214847-C:45]
 Good Name=Vigilante 8 (U)
 Internal Name=VIGILANTE 8
-Status=Issues (plugin)
+Status=Issues (core)
 32bit=Yes
 Counter Factor=1
 Culling=1
@@ -7204,7 +7204,7 @@ Linking=Off
 [DD10BC7E-F900B351-C:50]
 Good Name=Vigilante 8 - 2nd Offence (E)
 Internal Name=V8: SECOND OFFENSE
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 Linking=Off
@@ -7212,7 +7212,7 @@ Linking=Off
 [F5C5866D-052713D9-C:45]
 Good Name=Vigilante 8 - 2nd Offense (U)
 Internal Name=V8: SECOND OFFENSE
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 Linking=Off
@@ -7263,7 +7263,7 @@ RDRAM Size=4
 [045C08C4-4AFD798B-C:4A]
 Good Name=Virtual Pro Wrestling 64 (J)
 Internal Name=ÊÞ°Á¬Ù ÌßÛÚ½ØÝ¸Þ 64
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 Clear Frame=1
 RDRAM Size=4
@@ -7550,7 +7550,7 @@ RDRAM Size=4
 [54310E7D-6B5430D8-C:50]
 Good Name=Wipeout 64 (E)
 Internal Name=Wipeout 64
-Status=Region issue (core)
+Status=Compatible
 32bit=Yes
 Counter Factor=1
 Direct3D8-Direct3DPipe=1
@@ -7596,7 +7596,7 @@ Reg Cache=No
 [AC062778-DFADFCB8-C:50]
 Good Name=World Driver Championship (E) (M5)
 Internal Name=WORLD DRIVER CHAMP
-Status=Issues (plugin)
+Status=Compatible
 AudioResetOnLoad=Yes
 HLE GFX=No
 RDRAM Size=4
@@ -7605,7 +7605,7 @@ RSP-Mfc0Count=10
 [308DFEC8-CE2EB5F6-C:45]
 Good Name=World Driver Championship (U)
 Internal Name=WORLD DRIVER CHAMP
-Status=Issues (plugin)
+Status=Compatible
 AudioResetOnLoad=Yes
 HLE GFX=No
 RDRAM Size=4
@@ -8020,14 +8020,14 @@ RDRAM Size=4
 [B0667DED-BB39A4B8-C:0]
 Good Name=Absolute Crap Intro 1 by Kid Stardust (PD)
 Internal Name=®
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [2E7E893C-4E68B642-C:0]
 Good Name=Absolute Crap Intro 2 by Lem (PD)
 Internal Name=Ð*E
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8076,21 +8076,21 @@ RDRAM Size=4
 [713FDDD3-72D6A0EF-C:20]
 Good Name=Bike Race '98 V1.0 by NAN (PD)
 Internal Name=Bike Race by NaN
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [F4B64159-46FC16CF-C:20]
 Good Name=Bike Race '98 V1.2 by NAN (PD)
 Internal Name=Bike Race V1.2 NaN
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [C2B35C2F-5CD995A2-C:0]
 Good Name=Birthday Demo for Steve by Nep (PD)
 Internal Name=happy b-day Steve
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8112,14 +8112,14 @@ RDRAM Size=4
 [EDA1A0C7-58EE0464-C:0]
 Good Name=Chaos 89 Demo (PD)
 Internal Name=Ð*E
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [B484EB31-D44B1928-C:0]
 Good Name=Christmas Flame Demo (PD)
 Internal Name=Flame Demo 12/25/01
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
@@ -8160,7 +8160,7 @@ RDRAM Size=4
 [5B9D65DF-A18AB4AE-C:0]
 Good Name=CZN Module Player (PD)
 Internal Name=CZN module player
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
@@ -8174,28 +8174,28 @@ RDRAM Size=4
 [19E0E54C-CB721FD2-C:0]
 Good Name=DKONG Demo (PD)
 Internal Name=DragonKing-CrowTRobo
-Status=Unsupported
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [B323E37C-BBC35EC4-C:0]
 Good Name=DKONG Demo (PD)
 Internal Name=DONKEY KONG (DEMO)
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [1194FFD2-808C6FB1-C:45]
 Good Name=DS1 Manager 1.0 by RBubba (PD)
 Internal Name=DS1 Manager V1.0
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [D7484C2A-56CFF26D-C:45]
 Good Name=DS1 Manager 1.1 by RBubba (PD)
 Internal Name=®
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8237,7 +8237,7 @@ RDRAM Size=4
 [D49DFF90-8DB53A8C-C:0]
 Good Name=Evek - V64jr Save Manager by WT_Riker (PD)
 Internal Name=OBS-Evek
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8251,7 +8251,7 @@ RDRAM Size=4
 [8E248649-2E1CDE52-C:0]
 Good Name=Fire_Demo_by_Lac_(PD)
 Internal Name=Fire Demo by Lac (PD)
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8279,14 +8279,14 @@ RDRAM Size=4
 [30E6FE79-3EEA5386-C:0]
 Good Name=Fractal Zoomer Demo by RedboX (PD)
 Internal Name=Test Program
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [714001E3-2EB04B67-C:0]
 Good Name=Freekworld BBS Intro by Rene (PD)
 Internal Name=h¼
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8345,14 +8345,14 @@ RDRAM Size=4
 [2F67DC59-74AAD9F1-C:0]
 Good Name=Ghemor - CD64 Xfer & Save Util (CommsLink) by CrowTRobo (PD)
 Internal Name=Ghemor CL - OBSIDIAN
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [0D99E899-43E0FCD1-C:0]
 Good Name=Ghemor - CD64 Xfer & Save Util (Parallel) by CrowTRobo (PD)
 Internal Name=Ghemor PP - OBSIDIAN
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8380,21 +8380,21 @@ RDRAM Size=4
 [5D391A40-84D7A637-C:0]
 Good Name=Heavy 64 Demo by Destop (PD)
 Internal Name=Destop production
-Status=Unsupported
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
 [4072572D-A23DB72C-C:45]
 Good Name=HiRes CFB Demo (PD)
 Internal Name=h¼
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [BD1263E5-388C9BE7-C:45]
 Good Name=HSD Quick Intro (PD)
 Internal Name=HSD Quick Intro
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8415,7 +8415,7 @@ RDRAM Size=4
 [64709212-699BCF3B-C:0]
 Good Name=Kid Stardust Intro with Sound by Kid Stardust (PD)
 Internal Name=(E
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8436,42 +8436,42 @@ RDRAM Size=4
 [7D292963-D5277C1F-C:45]
 Good Name=Light Force First N64 Demo by Fractal (PD)
 Internal Name=LFC Intro
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [8A8E474B-6458BF2B-C:0]
 Good Name=Liner V1.00 by Colin Phillipps of Memir (PD)
 Internal Name=h¼
-Status=Issues (mixed)
-32bit=Yes
+Status=Issues (core)
+32bit=No
 RDRAM Size=4
 
 [D5CA46C2-F8555155-C:0]
 Good Name=MAME 64 Emulator Beta 3 (PD)
 Internal Name=MAME-64 beta3
-Status=Only intro/part OK
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [9CCE5B1D-6351E283-C:0]
 Good Name=MAME 64 Emulator V1.0 (PD)
 Internal Name=MAME 64 Emulator V1.0 (PD)
-Status=Needs video plugin
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [A47D4AD4-F5B0C6CB-C:45]
 Good Name=Manic Miner - Hidden Levels by RedboX (PD)
 Internal Name=Manic Miner 64
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [A47D4AD4-8BFA81F9-C:45]
 Good Name=Manic Miner by RedboX (PD)
 Internal Name=Manic Miner 64
-Status=Issues (mixed)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8527,14 +8527,14 @@ RDRAM Size=4
 [21548CA9-9059F32C-C:0]
 Good Name=Mini Racers (Unreleased)
 Internal Name=Mini Racers
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [9E6581AB-57CC8CED-C:0]
 Good Name=MMR by Count0 (PD)
 Internal Name=MMR By Count0
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8555,35 +8555,35 @@ RDRAM Size=4
 [94D3D5CB-E8808606-C:0]
 Good Name=MSFTUG Intro #1 by Lac (PD)
 Internal Name=msftug
-Status=Unsupported
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [9865799F-006F908C-C:45]
 Good Name=My Angel Demo (PD)
 Internal Name=My Angel
-Status=Unsupported
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
 [6D2C07F1-C884F0D0-C:0]
 Good Name=N64 Scene Gallery by CALi (PD)
 Internal Name=The N64 Scene
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
 [71255651-C6AE0EA6-C:0]
 Good Name=N64 Stars Demo (PD)
 Internal Name=N64 Stars Demo (PD)
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [C4855DA2-83BBA182-C:0]
 Good Name=Namp64 - N64 MP3-Player by Obsidian (PD)
 Internal Name=Namp64
-Status=Unsupported
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8596,21 +8596,28 @@ RDRAM Size=4
 [AB9F8D97-95EAA766-C:0]
 Good Name=NBC-LFC Kings of Porn Vol 01 (PD)
 Internal Name=Kings of Porn Vol 01
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
 [DD95F49D-2A9B8893-C:0]
-Good Name=NBC-LFC Kings of Porn Vol 01 [a1} (PD)
+Good Name=NBC-LFC Kings of Porn Vol 01 (PD) [a1]
 Internal Name=The Kings of Porn
-Status=Issues (mixed)
+Status=Issues (core)
+32bit=Yes
+RDRAM Size=4
+
+[61A5FCEE-B59FD8D3-C:0]
+Good Name=NBC-LFC Kings of Porn Vol 01 (PD) [a2]
+Internal Name=The Kings of Porn
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
 [011F98B2-1E1C8263-C:0]
 Good Name=NBCG Special Edition (PD)
 Internal Name=NBCG Special Edition
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
@@ -8624,7 +8631,7 @@ RDRAM Size=4
 [15AA9AF2-FF33D333-C:0]
 Good Name=NBCG's Tag Gallery 01 by CALi (PD)
 Internal Name=NBCG TAG Gallery 01
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
@@ -8649,7 +8656,7 @@ RDRAM Size=4
 [60E528A6-9500D4D3-C:0]
 Good Name=Nintendo Family by CALi (PD)
 Internal Name=The Nintendo Family
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
@@ -8663,14 +8670,14 @@ RDRAM Size=4
 [D1C6C55D-F010EF52-C:0]
 Good Name=Nintendo WideBoy 64 by SonCrap (PD)
 Internal Name=h¼
-Status=Unsupported
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [4E01B4A6-C884D085-C:0]
 Good Name=Nintro64 Demo by Lem (POM '98) (PD)
 Internal Name=  Nintro64 by SPLiT
-Status=Unsupported
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
@@ -8691,21 +8698,21 @@ RDRAM Size=4
 [26AD85C5-F908A36B-C:0]
 Good Name=Pamela Demo (padded) (PD)
 Internal Name=Pamela Demo Nr.1
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [7D1727F1-6C6B83EB-C:0]
 Good Name=Pause Demo by RedboX (PD)
 Internal Name=Test Program
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [9118F1B8-987DAC8C-C:0]
 Good Name=PC-Engine 64 Emulator (POM '99) (PD)
 Internal Name=PC-Engine 64
-Status=Issues (core)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8817,7 +8824,7 @@ RDRAM Size=4
 [45627CED-28005F9C-C:0]
 Good Name=Pipendo by Mr. Pips (PD)
 Internal Name=h¼
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
@@ -8885,28 +8892,28 @@ RDRAM Size=4
 [DAA76993-D8ACF77C-C:0]
 Good Name=Pong by Oman (PD)
 Internal Name=h¼
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [C252F9B1-AD70338C-C:0]
 Good Name=Pong V0.01 by Omsk (PD)
 Internal Name=omsk - pong v0.01
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [C5C4F0D5-4EEF2573-C:0]
 Good Name=Psychodelic Demo by Ste (POM '98) (PD)
 Internal Name=ste - pyscodelic
-Status=Unsupported
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [32A92961-DB34982C-C:0]
 Good Name=R.I.P. Jay Demo by Ste (PD)
 Internal Name=R.I.P JAY
-Status=Unsupported
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
@@ -8934,7 +8941,7 @@ RDRAM Size=4
 [79E318E1-86861726-C:0]
 Good Name=RPA Site Intro by Lem (PD)
 Internal Name=h¼
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8948,7 +8955,7 @@ RDRAM Size=4
 [9D9C362D-5BE66B08-C:0]
 Good Name=Shag'a'Delic Demo by Steve and NEP (PD)
 Internal Name=Shag-a-delic/CAMELOT
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8962,14 +8969,14 @@ RDRAM Size=4
 [18531B7D-074AF73E-C:0]
 Good Name=Simon for N64 V0.1a by Jean-Luc Picard (POM '99) (PD)
 Internal Name=h¼
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [C603175E-ACADF5EC-C:45]
 Good Name=Sinus (PD)
 Internal Name=h¼
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -8983,7 +8990,7 @@ RDRAM Size=4
 [5BBE6E34-088B6D0E-C:0]
 Good Name=SLiDeS (PD)
 Internal Name=LaMeRS PiC PRoGGie
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 Culling=1
 Emulate Clear=1
@@ -8999,14 +9006,14 @@ RDRAM Size=4
 [9303DD17-0813B398-C:0]
 Good Name=Soncrap Golden Eye Intro (PD) aka Rad's Bird
 Internal Name=Test Program
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [AAA66229-98CA5CAA-C:0]
 Good Name=Soncrap Intro by RedboX (PD) aka Rad's Bird
 Internal Name=SonCrap Intro
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -9018,7 +9025,7 @@ Status=Compatible
 Counter Factor=1
 
 [8F5179C4-803526DC-C:0]
-Good Name=Spice Girls Rotator Demo by RedboX (PD) [a1]
+Good Name=Spice Girls Rotator Demo by RedboX (PD)
 Internal Name=Space Rotator
 Status=Issues (plugin)
 32bit=Yes
@@ -9047,42 +9054,42 @@ RDRAM Size=4
 [029CAE05-2B8F9DF1-C:0]
 Good Name=SRAM Manager V1.0 Beta (32Mbit) (PD)
 Internal Name=SRAM BACKUP
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [4DEC9986-A8904450-C:0]
 Good Name=SRAM Manager V1.0 PAL Beta (PD)
 Internal Name=SRAM Manager
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [52BA5D2A-9BE3AB78-C:0]
 Good Name=SRAM to DS1 Tool by WT_Riker (PD)
 Internal Name=OBSIDIAN - SRAM2DS1
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [98A2BB11-EE4D4A86-C:0]
 Good Name=SRAM Upload Tool (PD)
 Internal Name=SRAM Upload Tool
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [3C524346-E4ABE776-C:0]
 Good Name=SRAM Upload Tool + Star Fox 64 SRAM (PD)
 Internal Name=STARFOX SRAM
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [EC9BECFF-CAB83632-C:0]
 Good Name=SRAM Uploader-Editor by BlackBag (PD)
 Internal Name=h¼
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -9102,14 +9109,14 @@ RDRAM Size=4
 [1AD61BB9-F1E2BE1A-C:45]
 Good Name=Super Fighter Demo (PD)
 Internal Name=Super Fighter Demo
-Status=Issues (plugin)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
 [1AA71519-51360D55-C:0]
 Good Name=T-Shirt Demo by Neptune and Steve (POM '98) (PD)
 Internal Name=T-Shirt/CML+Antihero
-Status=Needs video plugin
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -9121,9 +9128,9 @@ Status=Compatible
 RDRAM Size=4
 
 [41B1BF58-A1EB9BB7-C:0]
-Good Name=Textlight Demo (PD) [a1]
+Good Name=Textlight Demo (PD)
 Internal Name=GONZOiD AMPHETAMiNE
-Status=Unsupported
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -9176,14 +9183,14 @@ RDRAM Size=4
 [2DD07E20-24D40CD6-C:0]
 Good Name=TRSI Intro by Ayatollah (POM '99) (PD)
 Internal Name=Live suxx!
-Status=Issues (plugin)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
 [37B8F920-A58BB3EF-C:45]
 Good Name=Twintris by Twinsen (POM '98) (PD)
 Internal Name=Twintris
-Status=Unsupported
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -9197,21 +9204,21 @@ RDRAM Size=4
 [4E7DE4EF-0DEC3712-C:0]
 Good Name=UltraMSX2 V1.0 (PD)
 Internal Name=ultraMSX2
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
 [504ABA0A-269AA7F4-C:0]
 Good Name=UltraMSX2 V1.0 (ROMS Inserted) (PD)
 Internal Name=ultraMSX2
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
 [F291B959-A24CBCAF-C:0]
 Good Name=UltraSMS V1.0 (PD)
 Internal Name=ultraSMS
-Status=Issues (mixed)
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
@@ -9230,49 +9237,49 @@ Status=Compatible
 [5F44492A-18552A0A-C:0]
 Good Name=Unix SRAM-Upload Utility 1.0 by Madman (PD)
 Internal Name=h¼
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [3B8E7E01-6AE876A8-C:0]
-Good Name=UPload SRAM V1 by LaC (PD)
+Good Name=Upload SRAM V1 by LaC (PD)
 Internal Name=p&E
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [760EF304-AD6D6A7C-C:45]
 Good Name=V64Jr 512M Backup Program by HKPhooey (PD)
 Internal Name=h¼
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [4BD245D4-4202B322-C:0]
 Good Name=V64Jr Backup Tool by WT_Riker (PD)
 Internal Name=OBSIDIAN - JR Backup
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [F11B663A-698824C0-C:45]
 Good Name=V64Jr Backup Tool V0.2b_Beta by RedboX (PD)
 Internal Name=v64jr Backup v0.2b
-Status=Unsupported
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
 [1CEACBA0-42BC06D6-C:0]
 Good Name=Vector Demo by Destop (POM '99) (PD)
 Internal Name=VECTOR DEMO
-Status=Unsupported
+Status=Issues (core)
 32bit=Yes
 RDRAM Size=4
 
 [34B493C9-07654185-C:0]
 Good Name=View N64 Test Program (PD)
 Internal Name= R3 VIEWER
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -9340,7 +9347,7 @@ RDRAM Size=4
 [1EDA4DE0-22BF698D-C:0]
 Good Name=XtraLife Dextrose Demo by RedboX (PD)
 Internal Name=Test Program
-Status=Issues (plugin)
+Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
@@ -9348,8 +9355,9 @@ RDRAM Size=4
 Good Name=Y2K Demo by WT_Riker (PD)
 Internal Name=OBS-Y2KD
 Status=Issues (core)
-32bit=Yes
+32bit=No
 RDRAM Size=4
+Delay DP=0
 
 [83D8A30C-8552C117-C:0]
 Good Name=Yoshi's Story BootEmu (PD)


### PR DESCRIPTION
### Proposed changes

This updates the current RDB with some small label fixes. A majority of the games marked as having issues or not supported actually work, but were never changed.

I am also redefining what "compatible" means.  This will just mean "can it work in Project64" as opposed to "can it work with default settings, default plugins, and/or with specific settings?" I'm doing this in preparation for larger additions to the RDB, which will for the most part be similar versions of already working games or alternate builds.

Some games actually did have issues, but if you eliminate the plugins causing issues or other factors, many have core issues (such as virtual memory issues, CPU bugs, etc).

I also added another dump of NBC-LFC Kings of Porn Vol 1, specifically the alpha 2 dump. This dump works on real hardware, just needed to be added to the RDB for it to work in Project64.

I removed several bad 'Good Name' titles and replaced them with their proper titles as well.

I also fixed the Y2K Demo by WT_Riker by forcing 32-bit engine off and Delay DP off. This makes it run like it should.

Besides the games I specifically mentioned, the only other things that were changed were the status.

TL;DR updated RDB with more accurate titles, fixed some incorrect status names, and fixed a couple of games while I was at it.

### Does this make breaking changes?
No, the opposite in fact. ;)

### Does this version of Project64 compile and run without issue?
Yes.