### PR TITLE
Changed Elmo's Letter Journey back to status "Issues (core)"

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1909,8 +1909,8 @@ RDRAM Size=4
 [02B1538F-C94B88D0-C:45]
 Good Name=Elmo's Number Journey (U)
 Internal Name=Elmo's Number Journey
-Status=Compatible
-32bit=Yes
+Status=Issues (core)
+32bit=No
 RDRAM Size=4
 
 [E13AE2DC-4FB65CE8-C:4A]


### PR DESCRIPTION
This makes the "Elmo's Letter Journey" status back to "Issues (core)" since it has an issue with TLB emulation.

### Proposed changes
  - Switch the RDB back to "Issues (core)" for "Elmo's Letter Journey"

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Yes.