### PR TITLE
Fix TLB map bug involving 0 sentinel value

### DIFF
--- a/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
+++ b/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
@@ -83,8 +83,8 @@ void CMipsMemoryVM::Reset(bool /*EraseMemory*/)
     {
         size_t address;
 
-        memset(m_TLB_ReadMap, 0, 0xFFFFF * sizeof(size_t));
-        memset(m_TLB_WriteMap, 0, 0xFFFFF * sizeof(size_t));
+        memset(m_TLB_ReadMap, -1, 0xFFFFF * sizeof(size_t));
+        memset(m_TLB_WriteMap, -1, 0xFFFFF * sizeof(size_t));
         for (address = 0x80000000; address < 0xC0000000; address += 0x1000)
         {
             m_TLB_ReadMap[address >> 12] = ((size_t)m_RDRAM + (address & 0x1FFFFFFF)) - address;
@@ -318,7 +318,7 @@ CFlashram* CMipsMemoryVM::GetFlashram()
 
 bool CMipsMemoryVM::LB_VAddr(uint32_t VAddr, uint8_t& Value)
 {
-    if (m_TLB_ReadMap[VAddr >> 12] == 0)
+    if (m_TLB_ReadMap[VAddr >> 12] == -1)
     {
         return false;
     }
@@ -329,7 +329,7 @@ bool CMipsMemoryVM::LB_VAddr(uint32_t VAddr, uint8_t& Value)
 
 bool CMipsMemoryVM::LH_VAddr(uint32_t VAddr, uint16_t& Value)
 {
-    if (m_TLB_ReadMap[VAddr >> 12] == 0)
+    if (m_TLB_ReadMap[VAddr >> 12] == -1)
     {
         return false;
     }
@@ -351,7 +351,7 @@ bool CMipsMemoryVM::LW_VAddr(uint32_t VAddr, uint32_t& Value)
     }
 
     uint8_t* BaseAddress = (uint8_t*)m_TLB_ReadMap[VAddr >> 12];
-    if (BaseAddress == nullptr)
+    if (BaseAddress == (uint8_t*)-1)
     {
         return false;
     }
@@ -371,7 +371,7 @@ bool CMipsMemoryVM::LW_VAddr(uint32_t VAddr, uint32_t& Value)
 
 bool CMipsMemoryVM::LD_VAddr(uint32_t VAddr, uint64_t& Value)
 {
-    if (m_TLB_ReadMap[VAddr >> 12] == 0)
+    if (m_TLB_ReadMap[VAddr >> 12] == -1)
     {
         return false;
     }
@@ -452,7 +452,7 @@ bool CMipsMemoryVM::LD_PAddr(uint32_t PAddr, uint64_t& Value)
 
 bool CMipsMemoryVM::SB_VAddr(uint32_t VAddr, uint8_t Value)
 {
-    if (m_TLB_WriteMap[VAddr >> 12] == 0)
+    if (m_TLB_WriteMap[VAddr >> 12] == -1)
     {
         return false;
     }
@@ -463,7 +463,7 @@ bool CMipsMemoryVM::SB_VAddr(uint32_t VAddr, uint8_t Value)
 
 bool CMipsMemoryVM::SH_VAddr(uint32_t VAddr, uint16_t Value)
 {
-    if (m_TLB_WriteMap[VAddr >> 12] == 0)
+    if (m_TLB_WriteMap[VAddr >> 12] == -1)
     {
         return false;
     }
@@ -484,7 +484,7 @@ bool CMipsMemoryVM::SW_VAddr(uint32_t VAddr, uint32_t Value)
         }
     }
 
-    if (m_TLB_WriteMap[VAddr >> 12] == 0)
+    if (m_TLB_WriteMap[VAddr >> 12] == -1)
     {
         return false;
     }
@@ -495,7 +495,7 @@ bool CMipsMemoryVM::SW_VAddr(uint32_t VAddr, uint32_t Value)
 
 bool CMipsMemoryVM::SD_VAddr(uint32_t VAddr, uint64_t Value)
 {
-    if (m_TLB_WriteMap[VAddr >> 12] == 0)
+    if (m_TLB_WriteMap[VAddr >> 12] == -1)
     {
         return false;
     }
@@ -576,12 +576,12 @@ bool CMipsMemoryVM::SD_PAddr(uint32_t PAddr, uint64_t Value)
 
 bool CMipsMemoryVM::ValidVaddr(uint32_t VAddr) const
 {
-    return m_TLB_ReadMap[VAddr >> 12] != 0;
+    return m_TLB_ReadMap[VAddr >> 12] != -1;
 }
 
 bool CMipsMemoryVM::VAddrToRealAddr(uint32_t VAddr, void * &RealAddress) const
 {
-    if (m_TLB_ReadMap[VAddr >> 12] == 0)
+    if (m_TLB_ReadMap[VAddr >> 12] == -1)
     {
         return false;
     }
@@ -592,7 +592,7 @@ bool CMipsMemoryVM::VAddrToRealAddr(uint32_t VAddr, void * &RealAddress) const
 bool CMipsMemoryVM::TranslateVaddr(uint32_t VAddr, uint32_t &PAddr) const
 {
     // Change the virtual address to a physical address
-    if (m_TLB_ReadMap[VAddr >> 12] == 0)
+    if (m_TLB_ReadMap[VAddr >> 12] == -1)
     {
         return false;
     }
@@ -874,8 +874,8 @@ void CMipsMemoryVM::TLB_Unmaped(uint32_t Vaddr, uint32_t Len)
     for (count = Vaddr; count < End; count += 0x1000)
     {
         size_t Index = count >> 12;
-        m_TLB_ReadMap[Index] = 0;
-        m_TLB_WriteMap[Index] = 0;
+        m_TLB_ReadMap[Index] = -1;
+        m_TLB_WriteMap[Index] = -1;
     }
 }
 

--- a/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
+++ b/Source/Project64-core/N64System/Mips/MemoryVirtualMem.cpp
@@ -83,8 +83,8 @@ void CMipsMemoryVM::Reset(bool /*EraseMemory*/)
     {
         size_t address;
 
-        memset(m_TLB_ReadMap, -1, 0xFFFFF * sizeof(size_t));
-        memset(m_TLB_WriteMap, -1, 0xFFFFF * sizeof(size_t));
+        memset(m_TLB_ReadMap, -1, 0x100000 * sizeof(size_t));
+        memset(m_TLB_WriteMap, -1, 0x100000 * sizeof(size_t));
         for (address = 0x80000000; address < 0xC0000000; address += 0x1000)
         {
             m_TLB_ReadMap[address >> 12] = ((size_t)m_RDRAM + (address & 0x1FFFFFFF)) - address;
@@ -233,7 +233,7 @@ bool CMipsMemoryVM::Initialize(bool SyncSystem)
     m_TLB_WriteMap = new size_t[0x100000];
     if (m_TLB_WriteMap == nullptr)
     {
-        WriteTrace(TraceN64System, TraceError, "Failed to allocate m_TLB_WriteMap (Size: 0x%X)", 0xFFFFF * sizeof(size_t));
+        WriteTrace(TraceN64System, TraceError, "Failed to allocate m_TLB_WriteMap (Size: 0x%X)", 0x100000 * sizeof(size_t));
         FreeMemory();
         return false;
     }


### PR DESCRIPTION
Fixes #2218

### Proposed changes
  - Makes -1 the indicator value for invalid tlb mapping, rather than 0

### Does this make breaking changes?
Not as far as I'm aware

### Does this version of Project64 compile and run without issue?
Yes