### PR TITLE
Add note about "hide advanced settings"

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -81,9 +81,7 @@ body:
 
         Nintendo 64 game or Nintendo 64 Disk Drive:
 
-        ROM information: (File > ROM info, or context menu > ROM information in the ROM
-        list)
-
+        ROM information (First you must uncheck "hide advanced settings" in the settings menu, then File > ROM info should show up, post the information contained there in this field): 
         Save type: (Attach game save or save state here)
 
         Original or modified ROM?:(attach patch here)


### PR DESCRIPTION
This pull request only adds a note to users about how to make "ROM information" show up so that they can report said information to the Project64 team.

Mitigates some of #2247 

### Proposed changes
  - Add a note about making ROM information appear

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Yes.