### PR TITLE
correct minimum requirement for PJ64 Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Project64 is a free and open-source emulator for the Nintendo 64 and Nintendo 64
   * 512MB or more
 * Graphics card
   * DirectX 8 capable (Jabo's Direct3D8)
-  * OpenGL 1.1 capable (Project64 Video)
+  * OpenGL 2.0 capable (3.0+ recommended) (Project64 Video)
   * OpenGL 3.3 capable (GLideN64)
+  
+<sub>Intel Integrated Graphics can have issues that are not present with Nvidia and AMD GPU's even when the requirements are met.</sub>
   
 ### Stable Builds
 


### PR DESCRIPTION
The minimum requirement for PJ64 Video is actually closer to 2.0 than it is 1.1, FBE and FBO's weren't available until 1.4 and 1.5 respectively, NPOT wasn't available until 2.0.

### Does this make breaking changes?

This breaks the heart of anyone believing an opengl 1.1 card can run PJ64 Video.

