### PR TITLE
media id patched dragon sword 64 U added to rdb

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1799,6 +1799,14 @@ Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
+[AE6B1E11-B7CBD69E-C:50]
+Good Name=Dragon Sword (U) (Unreleased Alpha)
+Internal Name=DragonStorm
+Status=Needs video plugin
+Plugin Note=Use GlideN64
+32bit=Yes
+RDRAM Size=4
+
 [B6524461-ED6D04B1-C:50]
 Good Name=Dual Heroes (E)
 Internal Name=Dual heroes PAL
@@ -7016,7 +7024,7 @@ RDRAM Size=4
 Good Name=Turok - Dinosaur Hunter (U) (E3 Alpha) (Fixed)
 Internal Name=TUROKDH_E3_1996ALPHA
 Status=Unsupported
-Core Notes=Hangs on a black screen. Game is playable on real hardware.
+Core Note=Hangs on a black screen. Game is playable on real hardware.
 RDRAM Size=4
 
 [2F70F10D-5C4187FF-C:45]

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1799,8 +1799,16 @@ Status=Compatible
 32bit=Yes
 RDRAM Size=4
 
-[AE6B1E11-B7CBD69E-C:50]
+[AE6B1E11-B7CBD69E-C:0]
 Good Name=Dragon Sword (U) (Unreleased Alpha)
+Internal Name=DragonStorm
+Status=Needs video plugin
+Plugin Note=Use GlideN64
+32bit=Yes
+RDRAM Size=4
+
+[AE6B1E11-B7CBD69E-C:50]
+Good Name=Dragon Sword (U) (Media Header Patch)
 Internal Name=DragonStorm
 Status=Needs video plugin
 Plugin Note=Use GlideN64

--- a/Source/Project64/UserInterface/RomBrowser.cpp
+++ b/Source/Project64/UserInterface/RomBrowser.cpp
@@ -708,6 +708,7 @@ void CRomBrowser::RomList_GetDispInfo(uint32_t pnmh)
         case 'C':wcsncpy(lpdi->item.pszText, L"N64 Cartridge (Disk Compatible)", lpdi->item.cchTextMax / sizeof(wchar_t)); break;
         case 'D':wcsncpy(lpdi->item.pszText, L"64DD Disk", lpdi->item.cchTextMax / sizeof(wchar_t)); break;
         case 'E':wcsncpy(lpdi->item.pszText, L"64DD Disk (Expansion)", lpdi->item.cchTextMax / sizeof(wchar_t)); break;
+        case 'M':wcsncpy(lpdi->item.pszText, L"N64 Development Cartridge", lpdi->item.cchTextMax / sizeof(wchar_t)); break;           
         case 'N':wcsncpy(lpdi->item.pszText, L"N64 Cartridge", lpdi->item.cchTextMax / sizeof(wchar_t)); break;
         case 'Z':wcsncpy(lpdi->item.pszText, L"Aleck64", lpdi->item.cchTextMax / sizeof(wchar_t)); break;
         case 0:  wcsncpy(lpdi->item.pszText, L"None", lpdi->item.cchTextMax / sizeof(wchar_t)); break;


### PR DESCRIPTION
Corrects typo on Turok - Dinosaur Hunter (U) (E3 Alpha) Core Note field

Adds RDB information for a patched version of the dragon sword U rom to the RDB

Patch available: https://cdn.discordapp.com/attachments/280467579095482369/1006839209866305536/Dragon_Sword_64_USA_Proto_1999-08-25.bps

When finished, will also add M media type