### PR TITLE
Remove hack and RDRAM limit from Earthworm Jim, fix game running too fast

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1884,17 +1884,13 @@ RDRAM Size=4
 Good Name=Earthworm Jim 3D (E) (M6)
 Internal Name=EARTHWORM JIM 3D
 Status=Compatible
-32bit=Yes
 Culling=1
-RDRAM Size=4
 
 [DF574191-9EB5123D-C:45]
 Good Name=Earthworm Jim 3D (U)
 Internal Name=EARTHWORM JIM 3D
 Status=Compatible
-32bit=Yes
 Culling=1
-RDRAM Size=4
 
 [8C38E5DB-B37C27D7-C:50]
 Good Name=ECW Hardcore Revolution (E)

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -1884,12 +1884,14 @@ RDRAM Size=4
 Good Name=Earthworm Jim 3D (E) (M6)
 Internal Name=EARTHWORM JIM 3D
 Status=Compatible
+ViRefresh=500
 Culling=1
 
 [DF574191-9EB5123D-C:45]
 Good Name=Earthworm Jim 3D (U)
 Internal Name=EARTHWORM JIM 3D
 Status=Compatible
+ViRefresh=500
 Culling=1
 
 [8C38E5DB-B37C27D7-C:50]


### PR DESCRIPTION
The title 😄 

Fixes Earthworm Jim 3D.

### Proposed changes
  - Remove 32-bit engine hack
  - Remove RDRAM limit
  - Fix the game running too fast by setting ViRefresh to 500 instead of 1500

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Yes.