### PR TITLE
Fix MBC30 transferpak support in nrage input plugin

### DIFF
--- a/Source/nragev20/GBCart.cpp
+++ b/Source/nragev20/GBCart.cpp
@@ -889,7 +889,7 @@ bool WriteCartMBC3(LPGBCART Cart, WORD dwAddress, BYTE *Data)
     {
         if (Cart->bHasRam)
         {
-            Cart->iCurrentRamBankNo = Data[0] & 0x03;
+            Cart->iCurrentRamBankNo = Data[0] & 0x07;
             DebugWriteA("Set RAM Bank: %02X\n", Cart->iCurrentRamBankNo);
             if (Cart->bHasTimer && (Data[0] >= 0x08 && Data[0] <= 0x0c))
             {


### PR DESCRIPTION
Changes maximum number of possible RAM banks in mbc3 carts to 8 instead of 4 to support the mbc30 variant. This allows for proper handling of the Pokemon Crystal Japanese saves in Pokemon Stadium 2.

Fixes #1771 

### Proposed changes
  - Change maximum number of RAM banks in WriteCartMBC3 from 0x03 to 0x07.

### Does this make breaking changes?
No. I've tested regular mbc3 saves with Pokemon Stadium to ensure they didn't break in the process.


### Does this version of Project64 compile and run without issue?
Yes.
