### PR TITLE
Add second checkbox for users to confirm they are using latest nightly before reporting bug.

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -139,8 +139,7 @@ body:
     id: RecompilerorInterpreter
     attributes: 
       label: Does the issue manifest with the Interpreter core?
-      description: You can change this setting in the Rom Configuration 
-      (Requires "hide advanced settings" unchechecked)
+      description: You can change this setting in the Rom Configuration (Requires "hide advanced settings" unchechecked)
       value: |
         Recompiler: Y/N
         Interpreter Y/N

--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -34,10 +34,6 @@ body:
 
         Please avoid opening issues if you do not meet the minimum requirements
         for Project64. These are outlined in the README for this repository.
-        
-        **Issues must be reproduced on the current nightly to be accepted, 
-        users indicating an old version in use will have their bug marked 
-        Out of Date and closed.**
   - type: textarea
     id: what-should-happen
     attributes: 

--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -127,7 +127,7 @@ body:
     id: PluginsUsed
     attributes: 
       label: Plugins used while the issue occurred
-      description: What plugins is the issue occuring with?
+      description: What plugins are the issues occuring with?
       value: |
         Graphics plugin (and HLE or LLE):
         Audio plugin:
@@ -135,6 +135,17 @@ body:
         RSP plugin:
     validations: 
       required: true
+  - type: textarea
+    id: RecompilerorInterpreter
+    attributes: 
+      label: Does the issue manifest with the Interpreter core?
+      description: You can change this setting in the Rom Configuration 
+      (Requires "hide advanced settings" unchechecked)
+      value: |
+        Recompiler: Y/N
+        Interpreter Y/N
+    validations: 
+      required: true      
   - type: checkboxes
     id: Copyright_Compliance
     attributes: 

--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -141,8 +141,7 @@ body:
       label: Does the issue manifest with the Interpreter core?
       description: You can change this setting in the Rom Configuration (Requires "hide advanced settings" unchechecked)
       value: |
-        Recompiler: Y/N
-        Interpreter Y/N
+        You can also specify here if certain Recompiler setting combinations allows the game to boot.
     validations: 
       required: true      
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -34,6 +34,10 @@ body:
 
         Please avoid opening issues if you do not meet the minimum requirements
         for Project64. These are outlined in the README for this repository.
+        
+        **Issues must be reproduced on the current nightly to be accepted, 
+        users indicating an old version in use will have their bug marked 
+        Out of Date and closed.**
   - type: textarea
     id: what-should-happen
     attributes: 
@@ -144,4 +148,13 @@ body:
         party.
       options:
         - label: There are no infringing files attached to this bug report.
+          required: true
+  - type: checkboxes
+    id: Latest_Nightly
+    attributes: 
+      label: Using Latest Nightly
+      description: >-
+        Are you using the [latest nightly build](https://www.pj64-emu.com/nightly-builds)?
+      options:
+        - label: I am using the latest nightly build.
           required: true

--- a/.github/ISSUE_TEMPLATE/BUG.yml
+++ b/.github/ISSUE_TEMPLATE/BUG.yml
@@ -141,7 +141,7 @@ body:
       label: Does the issue manifest with the Interpreter core?
       description: You can change this setting in the Rom Configuration (Requires "hide advanced settings" unchechecked)
       value: |
-        You can also specify here if certain Recompiler setting combinations allows the game to boot.
+        You can also specify here if certain Recompiler setting combinations allows the game to work as intended.
     validations: 
       required: true      
   - type: checkboxes


### PR DESCRIPTION
Wording might be up for changing, it occurred to me after that some users might still want to report bugs for 3.0, despite it no longer being the active focus for dev (perhaps 3.0 should be grandfathered at this point and issues for it no longer accepted?)