### PR TITLE
[SortRDB] Use auto for _Pairib starting MSVC 14.2

### DIFF
--- a/Source/SortRdb/main.cpp
+++ b/Source/SortRdb/main.cpp
@@ -245,13 +245,21 @@ int main (int argc, char *argv[])
 		items.push_back(Section);
 		if (PDNames.find(GoodName) == PDNames.end())
 		{
+		#if _MSC_VER >= 1920 // Visual Studio 2019 deprecates _Pairib
+			auto res = GoodNameSections.insert(strmap::value_type(GoodName,items));
+		#else
 			strmap::_Pairib res = GoodNameSections.insert(strmap::value_type(GoodName,items));
+		#endif
 			if (!res.second)
 			{
 				res.first->second.push_back(Section);
 			}
 		} else {
+		#if _MSC_VER >= 1920 // Visual Studio 2019 deprecates _Pairib
+			auto res = PDNameSections.insert(strmap::value_type(GoodName,items));
+		#else
 			strmap::_Pairib res = PDNameSections.insert(strmap::value_type(GoodName,items));
+		#endif
 			if (!res.second)
 			{
 				res.first->second.push_back(Section);


### PR DESCRIPTION
Use `auto` declaration to avoid accessing internal member `_Pairib` on MSVC 14.2 and later.

See https://github.com/project64/project64/commit/05c2b59c3a5f130cf5eccc37a18cdd0a2cb4c105

### Proposed changes
  - Avoid directly declaring internal member `_Pairib` on MSVC 14.2 and later.

### Does this make breaking changes?
No.
