### PR TITLE
Fixed DPI scaling issue on some debugger windows

### DIFF
--- a/Source/Project64/UserInterface/Debugger/Debugger-Commands.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Commands.cpp
@@ -16,20 +16,23 @@ void CCommandList::Attach(HWND hWndNew)
     ModifyStyle(LVS_OWNERDRAWFIXED, 0, 0);
     SetExtendedListViewStyle(LVS_EX_FULLROWSELECT | LVS_EX_DOUBLEBUFFER | LVS_EX_LABELTIP);
 
+    CDC hDC = GetDC();
+    float DPIScale = hDC.GetDeviceCaps(LOGPIXELSX) / 96.0f;
+
     AddColumn(L"", COL_ARROWS);
-    SetColumnWidth(COL_ARROWS, 30);
+    SetColumnWidth(COL_ARROWS, (int)(30 * DPIScale));
 
     AddColumn(L"Address", COL_ADDRESS);
-    SetColumnWidth(COL_ADDRESS, 70);
+    SetColumnWidth(COL_ADDRESS, (int)(70 * DPIScale));
 
     AddColumn(L"Command", COL_COMMAND);
-    SetColumnWidth(COL_COMMAND, 65);
+    SetColumnWidth(COL_COMMAND, (int)(65 * DPIScale));
 
     AddColumn(L"Parameters", COL_PARAMETERS);
-    SetColumnWidth(COL_PARAMETERS, 130);
+    SetColumnWidth(COL_PARAMETERS, (int)(130 * DPIScale));
 
     AddColumn(L"Symbol", COL_SYMBOL);
-    SetColumnWidth(COL_SYMBOL, 180);
+    SetColumnWidth(COL_SYMBOL, (int)(180 * DPIScale));
 }
 
 CDebugCommandsView * CDebugCommandsView::_this = nullptr;

--- a/Source/Project64/UserInterface/Debugger/Debugger-Scripts.cpp
+++ b/Source/Project64/UserInterface/Debugger/Debugger-Scripts.cpp
@@ -28,12 +28,15 @@ LRESULT CDebugScripts::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*l
     DlgSavePos_Init(DebuggerUI_ScriptsPos);
     DlgToolTip_Init();
 
-    m_MonoFont = CreateFont(-12, 0, 0, 0,
+    CDC hDC = GetDC();
+    float DPIScale = hDC.GetDeviceCaps(LOGPIXELSX) / 96.0f;
+
+    m_MonoFont = CreateFont((int)(-12 * DPIScale), 0, 0, 0,
                             FW_DONTCARE, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
                             OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
                             CLEARTYPE_QUALITY, FF_DONTCARE, L"Consolas");
 
-    m_MonoBoldFont = CreateFont(-13, 0, 0, 0,
+    m_MonoBoldFont = CreateFont((int)(-13 * DPIScale), 0, 0, 0,
                                 FW_BOLD, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
                                 OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
                                 CLEARTYPE_QUALITY, FF_DONTCARE, L"Consolas");
@@ -41,7 +44,7 @@ LRESULT CDebugScripts::OnInitDialog(UINT /*uMsg*/, WPARAM /*wParam*/, LPARAM /*l
     m_ScriptList.Attach(GetDlgItem(IDC_SCRIPT_LIST));
     m_ScriptList.AddColumn(L"Status", 0);
     m_ScriptList.AddColumn(L"Script", 1);
-    m_ScriptList.SetColumnWidth(0, 16);
+    m_ScriptList.SetColumnWidth(0, (int)(16 * DPIScale));
     m_ScriptList.SetColumnWidth(1, LVSCW_AUTOSIZE_USEHEADER);
     m_ScriptList.SetExtendedListViewStyle(LVS_EX_FULLROWSELECT | LVS_EX_DOUBLEBUFFER);
     m_ScriptList.ModifyStyle(LVS_OWNERDRAWFIXED, 0, 0);


### PR DESCRIPTION
This fixes a simple UI issue with the text of the script window's output being too small on high-resolution screens. Also fixes the width of the columns in the "Commands" window. I used the `DPIScale` variable calculation from the about page window.

### Proposed changes
  - Simply factors the DPI scale into the size of the font & widths of some columns. Which fixes the text being too small on my high-resolution screen.

### Does this make breaking changes?
 No.

### Does this version of Project64 compile and run without issue?
Yes.
