### PR TITLE
Rsp vadd vsub clamp range fix

### DIFF
--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -882,27 +882,22 @@ void RSP_Vector_VADD(void)
 
 void RSP_Vector_VSUB (void) {
 	int el, del;
-	UWORD32 temp;
+    int32_t temp;
 	VECTOR result = {0};
 
 	for ( el = 0; el < 8; el++ ) {
 		del = EleSpec[RSPOpC.rs].B[el];
-        
-		temp.W = (int)RSP_Vect[RSPOpC.rd].HW[el] - (int)RSP_Vect[RSPOpC.rt].HW[del] -
+
+		temp = (int)RSP_Vect[RSPOpC.rd].HW[el] - (int)RSP_Vect[RSPOpC.rt].HW[del] -
 			 ((RSP_Flags[0].UW >> (7 - el)) & 0x1);
-		RSP_ACCUM[el].HW[1] = temp.HW[0];
-		if ((temp.HW[0] & 0x8000) == 0) {
-			if (temp.HW[1] != 0) {
-				result.HW[el] = 0x8000;
-			} else {
-				result.HW[el] = temp.HW[0];
-			}
+		RSP_ACCUM[el].HW[1] = ((int16_t)temp);
+		// Clamp signed
+		if (temp < ((int16_t)-32768)) {
+			result.HW[el] = ((int16_t)-32768);
+		} else if (temp > ((int16_t)32767)) {
+			result.HW[el] = ((int16_t)32767); 
 		} else {
-			if (temp.HW[1] != -1 ) {
-				result.HW[el] = 0x7FFF;
-			} else {
-				result.HW[el] = temp.HW[0];
-			}
+			result.HW[el] = ((int16_t)temp);
 		}
 	}
 	RSP_Flags[0].UW = 0;

--- a/Source/RSP/Interpreter Ops.c
+++ b/Source/RSP/Interpreter Ops.c
@@ -855,29 +855,25 @@ void RSP_Vector_VMADH (void) {
 	RSP_Vect[RSPOpC.sa] = result;
 }
 
-void RSP_Vector_VADD (void) {
+void RSP_Vector_VADD(void)
+{
 	int el, del;
-	UWORD32 temp;
+	int32_t temp;
 	VECTOR result = {0};
 
-	for ( el = 0; el < 8; el++ ) {
+	for (el = 0; el < 8; el++) {
 		del = EleSpec[RSPOpC.rs].B[el];
-        
-		temp.W = (int)RSP_Vect[RSPOpC.rd].HW[el] + (int)RSP_Vect[RSPOpC.rt].HW[del] +
+
+		temp = (int)RSP_Vect[RSPOpC.rd].HW[el] + (int)RSP_Vect[RSPOpC.rt].HW[del] +
 			 ((RSP_Flags[0].UW >> (7 - el)) & 0x1);
-		RSP_ACCUM[el].HW[1] = temp.HW[0];
-		if ((temp.HW[0] & 0x8000) == 0) {
-			if (temp.HW[1] != 0) {
-				result.HW[el] = 0x8000;
-			} else {
-				result.HW[el] = temp.HW[0];
-			}
+		RSP_ACCUM[el].HW[1] = ((int16_t)temp);
+		// Clamp signed
+		if (temp < ((int16_t)-32768)) {
+			result.HW[el] = ((int16_t)-32768);
+		} else if (temp > ((int16_t)32767)) {
+			result.HW[el] = ((int16_t)32767); 
 		} else {
-			if (temp.HW[1] != -1 ) {
-				result.HW[el] = 0x7FFF;
-			} else {
-				result.HW[el] = temp.HW[0];
-			}
+			result.HW[el] = ((int16_t)temp);
 		}
 	}
 	RSP_Vect[RSPOpC.sa] = result;


### PR DESCRIPTION
### The problem
The RSP vadd and vsub do a clamp signed when doing the corresonding operation, the result is set to a int32_t but the clamping currently is not setting the expected value

Lets take the current implementation of RSP_Vector_VADD

```
void RSP_Vector_VADD (void) {
	int el, del;
	UWORD32 temp;
	VECTOR result = {0};

	for ( el = 0; el < 8; el++ ) {
		del = EleSpec[RSPOpC.rs].B[el];
        
		temp.W = (int)RSP_Vect[RSPOpC.rd].HW[el] + (int)RSP_Vect[RSPOpC.rt].HW[del] +
			 ((RSP_Flags[0].UW >> (7 - el)) & 0x1);
		RSP_ACCUM[el].HW[1] = temp.HW[0];
		if ((temp.HW[0] & 0x8000) == 0) {
			if (temp.HW[1] != 0) {
				result.HW[el] = 0x8000;
			} else {
				result.HW[el] = temp.HW[0];
			}
		} else {
			if (temp.HW[1] != -1 ) {
				result.HW[el] = 0x7FFF;
			} else {
				result.HW[el] = temp.HW[0];
			}
		}
	}
	RSP_Vect[RSPOpC.sa] = result;
	RSP_Flags[0].UW = 0;
}
```

The clamp signed operation is done by the following implementation

```
		if ((temp.HW[0] & 0x8000) == 0) {
			if (temp.HW[1] != 0) {
				result.HW[el] = 0x8000;
			} else {
				result.HW[el] = temp.HW[0];
			}
		} else {
			if (temp.HW[1] != -1 ) {
				result.HW[el] = 0x7FFF;
			} else {
				result.HW[el] = temp.HW[0];
			}
		}
```

### Test case

If the addition  value is  set to ```temp.W ``` with value ```-98304 ```

![image](https://github.com/project64/project64/assets/36634775/2e7d3fd9-e12b-490b-8c71-278e6f90330e)

Then ```temp.HW[1] value is -2``` and ```temp.HW[0] value is -32768```, since has the 16th bit set check by ```temp.HW[0] & 0x8000``` ie ```0b1000000000000000``` it will fall to 

```
			if (temp.HW[1] != -1 ) {
				result.HW[el] = 0x7FFF;
			} else {
				result.HW[el] = temp.HW[0];
			}
```
And since ```temp.HW[1] is -2``` it will go to ```result.HW[el] = 0x7FFF;``` setting the value to ```32767``` when the expected value is ```-32768```

### Proposed changes
Implement the clamp signed for vadd and vsub in the following way as described in https://emudev.org/2020/03/28/RSP.html#clamping

```
function clamp_signed(accum)
    if accum < -32768  => return -32768
    if accum > 32767   => return 32767
    return accum
```
    
### Does this make breaking changes?
No

### Does this version of Project64 compile and run without issue?
It does compile and run