### PR TITLE
Project64: Improve flexibility of advanced mode settings toggle

### DIFF
--- a/Source/Project64/UserInterface/Settings/SettingsPage-AdvancedOptions.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-AdvancedOptions.h
@@ -39,6 +39,10 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return AdvancedMode;
+    }
 
 private:
     void UpdatePageSettings(void);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Defaults.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Defaults.h
@@ -38,6 +38,10 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return AdvancedMode;
+    }
 
 private:
     void UpdatePageSettings(void);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Directories.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Directories.cpp
@@ -5,8 +5,7 @@
 COptionsDirectoriesPage::COptionsDirectoriesPage(HWND hParent, const RECT & rcDispay) :
     m_InUpdateSettings(false)
 {
-    Create(hParent);
-    if (m_hWnd == nullptr)
+    if (!Create(hParent, rcDispay))
     {
         return;
     }

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Directories.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Directories.h
@@ -1,7 +1,7 @@
 #pragma once
 
 class COptionsDirectoriesPage :
-    public CDialogImpl<COptionsDirectoriesPage>,
+    public CSettingsPageImpl<COptionsDirectoriesPage>,
     public CSettingsPage
 {
     BEGIN_MSG_MAP_EX(COptionsDirectoriesPage)
@@ -47,6 +47,11 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<COptionsDirectoriesPage>::PageAccessible(AdvancedMode);
+    }
 
 private:
     void SelectPluginDir(UINT Code, int id, HWND ctl);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-DiskDrive.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-DiskDrive.h
@@ -34,6 +34,10 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<CDiskDrivePage>::PageAccessible(AdvancedMode);
+    }
 
 private:
     void SelectIplDirJp(UINT Code, int id, HWND ctl);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Game-DiskDrive.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Game-DiskDrive.h
@@ -31,4 +31,8 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<CGameDiskDrivePage>::PageAccessible(AdvancedMode);
+    }
 };

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Game-General.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Game-General.h
@@ -43,4 +43,8 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<CGameGeneralPage>::PageAccessible(AdvancedMode);
+    }
 };

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Game-Plugin.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Game-Plugin.h
@@ -40,6 +40,10 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<CGamePluginPage>::PageAccessible(AdvancedMode);
+    }
 
 private:
     void GfxPluginAbout(UINT /*Code*/, int /*id*/, HWND /*ctl*/)

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Game-Recompiler.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Game-Recompiler.h
@@ -39,6 +39,10 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<CGameRecompilePage>::PageAccessible(AdvancedMode);
+    }
 
 private:
     CPartialGroupBox m_SelfModGroup;

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Game-Status.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Game-Status.h
@@ -31,4 +31,8 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<CGameStatusPage>::PageAccessible(AdvancedMode);
+    }
 };

--- a/Source/Project64/UserInterface/Settings/SettingsPage-GameBrowser.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-GameBrowser.h
@@ -33,6 +33,10 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<COptionsGameBrowserPage>::PageAccessible(AdvancedMode);
+    }
 
 private:
     void UpdatePageSettings(void);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-KeyboardShortcuts.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-KeyboardShortcuts.h
@@ -38,6 +38,10 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<COptionsShortCutsPage>::PageAccessible(AdvancedMode);
+    }
 
 private:
     void OnCpuStateChanged(UINT Code, int id, HWND ctl);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Options.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Options.h
@@ -35,6 +35,10 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<CGeneralOptionsPage>::PageAccessible(AdvancedMode);
+    }
 
 private:
     void OnBasicMode(UINT Code, int id, HWND ctl);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Plugin.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Plugin.h
@@ -39,6 +39,10 @@ public:
     void ApplySettings(bool UpdateScreen);
     bool EnableReset(void);
     void ResetPage(void);
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return CSettingsPageImpl<COptionPluginPage>::PageAccessible(AdvancedMode);
+    }
 
 private:
     void GfxPluginAbout(UINT /*Code*/, int /*id*/, HWND /*ctl*/)

--- a/Source/Project64/UserInterface/Settings/SettingsPage.h
+++ b/Source/Project64/UserInterface/Settings/SettingsPage.h
@@ -13,6 +13,7 @@ public:
     virtual void ApplySettings(bool UpdateScreen) = 0;
     virtual bool EnableReset(void) = 0;
     virtual void ResetPage(void) = 0;
+    virtual bool PageAccessible(bool AdvancedMode) = 0;
 };
 
 template <class T>
@@ -532,6 +533,14 @@ public:
             SendMessage(GetParent(), PSM_CHANGED, (WPARAM)m_hWnd, 0);
         }
     }
+
+#pragma warning(push)
+#pragma warning(disable : 4100) // warning C4100: 'AdvancedMode': unreferenced formal parameter
+    bool PageAccessible(bool AdvancedMode)
+    {
+        return true;
+    }
+#pragma warning(pop)
 
 protected:
     TextBoxList m_TxtBoxList;

--- a/Source/Project64/UserInterface/SettingsConfig.h
+++ b/Source/Project64/UserInterface/SettingsConfig.h
@@ -40,6 +40,7 @@ public:
 
 private:
     void UpdateAdvanced(bool AdvancedMode, HTREEITEM hItem);
+    void DisplayAccessibleSections(bool AdvancedMode, bool UpdateSections);
     void ApplySettings(bool UpdateScreen);
     void BoldChangedPages(HTREEITEM hItem);
 
@@ -47,7 +48,7 @@ private:
 
     CTreeViewCtrl m_PagesTreeList;
     SETTING_SECTIONS m_Sections;
-    CSettingsPage *m_CurrentPage, *m_GeneralOptionsPage, *m_AdvancedPage, *m_DefaultsPage, *m_DiskDrivePage;
+    CSettingsPage *m_CurrentPage, *m_GeneralOptionsPage;
     bool m_GameConfig;
     bool m_bTVNSelChangedSupported;
 };


### PR DESCRIPTION
Extends the flexibility of advanced mode by allowing `CSettingsPage` to define it's own visibility/accessibility. This removes explicit handling of `CAdvancedOptionsPage` and `CDefaultsOptionsPage` in `CSettingConfig`.

This also opens the door for other conditional logic in displaying setting pages, if desired.

Fixes #2369

### Does this make breaking changes?

No, but `COptionsDirectoriesPage` was not implementing `CSettingsPageImpl` and I couldn't see a reason why not, so I also changed that.

### Does this version of Project64 compile and run without issue?

Yes