### PR TITLE
changes these callbacks back to BOOL so it works again.

### DIFF
--- a/Source/Project64-rsp/Main.cpp
+++ b/Source/Project64-rsp/Main.cpp
@@ -30,7 +30,7 @@
 void ClearAllx86Code(void);
 void ProcessMenuItem(int ID);
 #ifdef _WIN32
-bool CALLBACK CompilerDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+BOOL CALLBACK CompilerDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 HMENU hRSPMenu = NULL;
 #endif
 
@@ -617,7 +617,7 @@ static bool GetBooleanCheck(HWND hDlg, DWORD DialogID)
     return (IsDlgButtonChecked(hDlg, DialogID) == BST_CHECKED) ? true : false;
 }
 
-bool CALLBACK CompilerDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM /*lParam*/)
+BOOL CALLBACK CompilerDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM /*lParam*/)
 {
     char Buffer[256];
 


### PR DESCRIPTION
Fixes 
RSP Compiler config screen

### Proposed changes
- revert mismatched cast back to BOOL since the callback is an Int type, when being optimized with /O1+ the value was being truncated leading to a corrupted GUI.

### Does this make breaking changes?
It changes a Win32 callback back to a Win32 BOOL, that was erroneously changed to bool, so i'd assume not.

### Does this version of Project64 compile and run without issue?
Yes.