### PR TITLE
Mario 64 Shindou and Improvement hack support

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -2997,7 +2997,7 @@ SMM-Protect=1
 SMM-TLB=0
 
 [8A6009B6-94ACE150-C:45]
-              Good Name=Jet Force Gemini (U)
+Good Name=Jet Force Gemini (U)
 Internal Name=JET FORCE GEMINI
 Status=Compatible
 Counter Factor=1

--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -6216,8 +6216,8 @@ RDRAM Size=8
 Good Name=Super Mario 64 - Shindou Edition (J)
 Internal Name=SUPERMARIO64
 Status=Compatible
-32bit=1
 Culling=1
+RDRAM Size=8
 
 [66572080-28E348E1-C:4A]
 Good Name=Super Robot Spirits (J)
@@ -11771,3 +11771,10 @@ SMM-FUNC=0
 SMM-PI DMA=0
 SMM-Protect=1
 SMM-TLB=0
+
+[3114B9B3-05DCE9CA-C:4A]
+Good Name=Super Mario 64 - Shindou Improvement (v1.0) (English)
+Internal Name=SUPERMARIO64
+Status=Compatible
+Culling=1
+RDRAM Size=8


### PR DESCRIPTION
Fixes 
Adds working configuration for [Super Mario 64 - Shindou Improvement](https://www.romhacking.net/hacks/5755/)

Fixed a weirdly indented JFG goodname.

### Does this make breaking changes?
Not a source change

### Does this version of Project64 compile and run without issue?
Not a source change