### PR TITLE
Add TOC to the README and other improvements

### DIFF
--- a/Docs/BUILDING.md
+++ b/Docs/BUILDING.md
@@ -7,9 +7,10 @@ If you just want to run Project64 or its development builds, use the [Readme](ht
 
 ## Required software
 
-* Git
+* [Git](https://git-scm.com/downloads)
     * This is a hard requirement. It is used for the build step and requires the solution be a part of the Project64 git repository on disk.
-* Visual Studio 2015, 2017, or 2019 Community Edition
+* [Visual Studio 2015, 2017, or 2019 Community Edition](https://learn.microsoft.com/en-us/visualstudio/releases/2019/release-notes)
+    * Click on the Visual Studio year you want to use from the left dropdown, and follow the download process.
 * During installation, select the `Programming Languages/Visual C++` option in the Visual Studio 2015 installer, or
 * During installation, select the `Desktop development with C++` workload in Visual Studio 2017 and 2019 or newer
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ If you would like to see a changelog that is available [here](./Docs/CHANGELOG.m
 
 Contributions are always welcome!
 
+If you want to contribute to this project, please click [here](https://github.com/project64/project64/blob/develop/Docs/BUILDING.md) to get more information on how to set up a local build environment.
+
 See the [contributing](./.github/CONTRIBUTING.md) file for ways to get started.
 
 ## Maintainers and contributors

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 Project64 is a free and open-source emulator for the Nintendo 64 and Nintendo 64 Disk Drive written in C++ currently only for Windows (planned support for other platforms in the future).
 
+  * [Features](#features)
+  * [Screenshot](#screenshot)
+  * [Installation](#installation)
+  * [Supported requirements](#supported-requirements)
+  * [Support](#support)
+  * [Changelog](#changelog)
+  * [Dependencies](#dependencies)
+  * [Contributing](#contributing)
+  * [Maintainers and contributors](#maintainers-and-contributors)
+  * [🔗 Links](#---links)
+  * [License](#license)
+
 ## Features
 
 - Development and debugging tools


### PR DESCRIPTION
Adds a table of contents for the README.

Fixes #2423 and some cherry-picked improvements from #2388

### Proposed changes
  - Add table of contents to README
  - Add some build and contributor doc improvements

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Yes, no functional changes to the software.