### PR TITLE
Fix implementation of quad3d for f3dex 0.95 on pj64 video plugin

### DIFF
--- a/Source/Project64-video/Settings.cpp
+++ b/Source/Project64-video/Settings.cpp
@@ -64,7 +64,6 @@ CSettings::CSettings() :
     m_stipple_mode(GFX_STIPPLE_DISABLE), //used for dithered alpha emulation
     m_stipple_pattern(0), //used for dithered alpha emulation
     m_force_microcheck(false), //check microcode each frame, for mixed F3DEX-S2DEX games
-    m_force_quad3d(false), //force 0xb5 command to be quad, not line 3d
     m_clip_zmin(false), //enable near z clipping
     m_clip_zmax(false), //enable far plane clipping;
     m_adjust_aspect(false), //adjust screen aspect for wide screen mode
@@ -748,7 +747,6 @@ void CSettings::ReadGameSettings(const char * name)
     int stipple_pattern = GetSetting(Set_stipple_pattern);
     m_stipple_pattern = stipple_pattern > 0 ? (uint32_t)stipple_pattern : 0x3E0F83E0;
     m_force_microcheck = GetSetting(Set_force_microcheck) != 0;
-    m_force_quad3d = GetSetting(Set_force_quad3d) != 0;
     m_clip_zmin = GetSetting(Set_clip_zmin) != 0;
     m_clip_zmax = GetSetting(Set_clip_zmax) != 0;
     m_fast_crc = GetSetting(Set_fast_crc) != 0;

--- a/Source/Project64-video/Settings.h
+++ b/Source/Project64-video/Settings.h
@@ -237,7 +237,6 @@ public:
     inline gfxStippleMode_t stipple_mode(void) const { return m_stipple_mode; } //used for dithered alpha emulation
     inline uint32_t stipple_pattern(void) const { return m_stipple_pattern; } //used for dithered alpha emulation
     inline bool force_microcheck(void) const { return m_force_microcheck; } //check microcode each frame, for mixed F3DEX-S2DEX games
-    inline bool force_quad3d(void) const { return m_force_quad3d; } //force 0xb5 command to be quad, not line 3d
     inline bool clip_zmin(void) const { return m_clip_zmin; } //enable near z clipping
     inline bool clip_zmax(void) const { return m_clip_zmax; } //enable far plane clipping
     inline bool adjust_aspect(void) const { return m_adjust_aspect; } //adjust screen aspect for wide screen mode
@@ -383,7 +382,6 @@ private:
     gfxStippleMode_t m_stipple_mode;
     uint32_t m_stipple_pattern;
     bool m_force_microcheck;
-    bool m_force_quad3d;
     bool m_clip_zmin;
     bool m_clip_zmax;
     bool m_adjust_aspect;

--- a/Source/Project64-video/ucode.cpp
+++ b/Source/Project64-video/ucode.cpp
@@ -96,7 +96,7 @@ rdp_instr gfx_instruction[11][256] =
         rdp_setcombine, rdp_settextureimage, rdp_setdepthimage, rdp_setcolorimage
     },
 
-    // uCode 1 - F3DEX 1.XX
+    // uCode 1 - F3DEX 0.95 & 1.XX
     // 00-3f
     // games: Mario Kart, Star Fox
     {
@@ -147,7 +147,7 @@ rdp_instr gfx_instruction[11][256] =
         undef, undef, undef, undef,
         undef, undef, undef, uc6_loaducode,
         uc1_branch_z, uc1_tri2, uc2_modifyvtx, rdphalf_2,
-        uc1_rdphalf_1, uc1_line3d, uc0_cleargeometrymode, uc0_setgeometrymode,
+        uc1_rdphalf_1, uc1_quad3d, uc0_cleargeometrymode, uc0_setgeometrymode,
         uc0_enddl, uc0_setothermode_l, uc0_setothermode_h, uc0_texture,
         uc0_moveword, uc0_popmatrix, uc2_culldl, uc1_tri1,
         // c0-ff: RDP commands

--- a/Source/Project64-video/ucode01.cpp
+++ b/Source/Project64-video/ucode01.cpp
@@ -76,6 +76,31 @@ void uc1_tri2()
     rsp_tri2(vtx);
 }
 
+void uc1_line3d()
+{
+    if (((rdp.cmd1 & 0xFF000000) == 0) && ((rdp.cmd0 & 0x00FFFFFF) == 0))
+    {
+        uint16_t width = (uint16_t)(rdp.cmd1 & 0xFF) + 3;
+
+        WriteTrace(TraceRDP, TraceDebug, "uc1:line3d width: %d #%d, #%d - %d, %d", width, rdp.tri_n, rdp.tri_n + 1,
+            (rdp.cmd1 >> 17) & 0x7F,
+            (rdp.cmd1 >> 9) & 0x7F);
+
+        gfxVERTEX *vtx[3] = {
+            &rdp.vtx((rdp.cmd1 >> 17) & 0x7F),
+            &rdp.vtx((rdp.cmd1 >> 9) & 0x7F),
+            &rdp.vtx((rdp.cmd1 >> 9) & 0x7F)
+        };
+        uint32_t cull_mode = (rdp.flags & CULLMASK) >> CULLSHIFT;
+        rdp.flags |= CULLMASK;
+        rdp.update |= UPDATE_CULL_MODE;
+        rsp_tri1(vtx, width);
+        rdp.flags ^= CULLMASK;
+        rdp.flags |= cull_mode << CULLSHIFT;
+        rdp.update |= UPDATE_CULL_MODE;
+    }
+}
+
 void uc1_quad3d()
 {
         WriteTrace(TraceRDP, TraceDebug, "uc1:quad3d #%d, #%d", rdp.tri_n, rdp.tri_n + 1);

--- a/Source/Project64-video/ucode01.cpp
+++ b/Source/Project64-video/ucode01.cpp
@@ -78,29 +78,6 @@ void uc1_tri2()
 
 void uc1_line3d()
 {
-    if (!g_settings->force_quad3d() && ((rdp.cmd1 & 0xFF000000) == 0) && ((rdp.cmd0 & 0x00FFFFFF) == 0))
-    {
-        uint16_t width = (uint16_t)(rdp.cmd1 & 0xFF) + 3;
-
-        WriteTrace(TraceRDP, TraceDebug, "uc1:line3d width: %d #%d, #%d - %d, %d", width, rdp.tri_n, rdp.tri_n + 1,
-            (rdp.cmd1 >> 17) & 0x7F,
-            (rdp.cmd1 >> 9) & 0x7F);
-
-        gfxVERTEX *vtx[3] = {
-            &rdp.vtx((rdp.cmd1 >> 17) & 0x7F),
-            &rdp.vtx((rdp.cmd1 >> 9) & 0x7F),
-            &rdp.vtx((rdp.cmd1 >> 9) & 0x7F)
-        };
-        uint32_t cull_mode = (rdp.flags & CULLMASK) >> CULLSHIFT;
-        rdp.flags |= CULLMASK;
-        rdp.update |= UPDATE_CULL_MODE;
-        rsp_tri1(vtx, width);
-        rdp.flags ^= CULLMASK;
-        rdp.flags |= cull_mode << CULLSHIFT;
-        rdp.update |= UPDATE_CULL_MODE;
-    }
-    else
-    {
         WriteTrace(TraceRDP, TraceDebug, "uc1:quad3d #%d, #%d", rdp.tri_n, rdp.tri_n + 1);
 
         gfxVERTEX *vtx[6] = {
@@ -113,7 +90,6 @@ void uc1_line3d()
         };
 
         rsp_tri2(vtx);
-    }
 }
 
 uint32_t branch_dl = 0;

--- a/Source/Project64-video/ucode01.cpp
+++ b/Source/Project64-video/ucode01.cpp
@@ -76,7 +76,7 @@ void uc1_tri2()
     rsp_tri2(vtx);
 }
 
-void uc1_line3d()
+void uc1_quad3d()
 {
         WriteTrace(TraceRDP, TraceDebug, "uc1:quad3d #%d, #%d", rdp.tri_n, rdp.tri_n + 1);
 

--- a/Source/Project64-video/ucode01.h
+++ b/Source/Project64-video/ucode01.h
@@ -8,7 +8,7 @@
 
 void uc1_branch_z();
 void uc1_rdphalf_1();
-void uc1_line3d();
+void uc1_quad3d();
 void uc1_tri1();
 void uc1_tri2();
 void uc1_vertex();

--- a/Source/Project64-video/ucode01.h
+++ b/Source/Project64-video/ucode01.h
@@ -8,6 +8,7 @@
 
 void uc1_branch_z();
 void uc1_rdphalf_1();
+void uc1_line3d();
 void uc1_quad3d();
 void uc1_tri1();
 void uc1_tri2();


### PR DESCRIPTION
This change shouldn't break starfox because I believe only mk64 uses the quadrangle command.

mk64 does actually have a debug wire frame mode for some courses. But as far as I can tell, it's not using line3d (Now that I'm thinking about it, this wire frame might actually be another renderer bug).

Fixes #
 - Rendering of startup logo for mk64
 - Fixes bug with `m_force_quad3d` where the value changed inconsistently.


### Proposed changes
  - Removes `m_force_quad3d` bool
  - Removes line3D implementation for f3dex because that command requires the line3d micro-code to work.
  - Rename line3D to quad3D
