### PR TITLE
[RDB]Set SGB Emulator to 8MB

### DIFF
--- a/Config/Project64.rdb
+++ b/Config/Project64.rdb
@@ -5610,6 +5610,7 @@ Status=Compatible
 Counter Factor=1
 Linking=Off
 ViRefresh=3000
+RDRAM Size=8
 Core Note=Requires Parallel-RSP.
 
 [93A625B9-2D6022E6-C:42]


### PR DESCRIPTION
since the defaults for rdram changed between 6058 and 6059, i had not accounted for this emulator rom actually needing 8MB

### Fixes ### 
SGB Emulator

### Proposed changes
adds RDRAM Size=8 to the RDB entry

### Does this make breaking changes?
No

### Does this version of Project64 compile and run without issue?
Yes