### PR TITLE
quick dirty possible fix for MBC5 roms of 4MB and 8MB size.

### DIFF
--- a/Source/nragev20/GBCart.cpp
+++ b/Source/nragev20/GBCart.cpp
@@ -346,6 +346,12 @@ bool LoadCart(LPGBCART Cart, LPCTSTR RomFileName, LPCTSTR RamFileName, LPCTSTR T
     case 0x06:
         Cart->iNumRomBanks = 128;
         break;
+    case 0x07:
+        Cart->iNumRomBanks = 256;
+        break;
+    case 0x08:
+        Cart->iNumRomBanks = 512;
+        break;        
     case 0x52:
         Cart->iNumRomBanks = 72;
         break;


### PR DESCRIPTION
only up to 2MB was implemented previously

Fixes #
Should fix mickey speedway USA gb rom error

### Proposed changes
Adds case 7 and 8 from https://gbdev.gg8.se/wiki/articles/The_Cartridge_Header#0148_-_ROM_Size

### Does this make breaking changes?
Potentially, needs testing on transferpak enabled carts.

### Does this version of Project64 compile and run without issue?
Yes