### PR TITLE
Core: Fixed race condition deadlock in Enhancements

### DIFF
--- a/Source/Common/CriticalSection.h
+++ b/Source/Common/CriticalSection.h
@@ -34,3 +34,42 @@ private:
     CGuard(const CGuard & copy);
     CGuard & operator=(const CGuard & rhs);
 };
+
+class CUniqueLock
+{
+public:
+    CUniqueLock(CriticalSection & sectionName) :
+        m_cs(sectionName), m_locked(true)
+    {
+        m_cs.enter();
+    }
+    ~CUniqueLock()
+    {
+        if (m_locked)
+            m_cs.leave();
+    }
+
+    inline void lock()
+    {
+        if (!m_locked)
+        {
+            m_cs.enter();
+            m_locked = true;
+        }
+    }
+
+    inline void unlock()
+    {
+        if (m_locked)
+        {
+            m_cs.leave();
+            m_locked = false;
+        }
+    }
+
+private:
+    CriticalSection & m_cs;
+    bool m_locked;
+    CUniqueLock(const CUniqueLock & copy);
+    CUniqueLock & operator=(const CUniqueLock & rhs);
+};

--- a/Source/Project64-core/N64System/Enhancement/Enhancements.h
+++ b/Source/Project64-core/N64System/Enhancement/Enhancements.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Common/CriticalSection.h>
+#include <Common/SyncEvent.h>
 #include <Common/Thread.h>
 #include <Project64-core/N64System/Enhancement/EnhancementFile.h>
 #include <Project64-core/N64System/Enhancement/EnhancementList.h>
@@ -33,6 +34,9 @@ public:
     CEnhancementList Enhancements(void);
 
 private:
+    void LoadImpl(CUniqueLock &);
+    void LoadActiveImpl(CUniqueLock &, CMipsMemoryVM * MMU, CPlugins * Plugins);
+
     class GAMESHARK_CODE
     {
     public:
@@ -115,7 +119,7 @@ private:
     ORIGINAL_VALUES8 m_OriginalValues8;
     CThread m_ScanFileThread;
     bool m_Scan;
-    bool m_Scanned;
+    SyncEvent m_Scanned;
     bool m_UpdateCheats;
     bool m_OverClock;
     uint32_t m_OverClockModifier;


### PR DESCRIPTION
Fixed race condition deadlock in Enhancements.

This race condition is easy to reproduce if you add a `Sleep(1000)` right before `m_CS` is taken for `m_Scanned` [setting](https://github.com/project64/project64/blob/develop/Source/Project64-core/N64System/Enhancement/Enhancements.cpp#L701) + ROM is passed in cmdline arguments. Race condition will cause `WaitScanDone` to wait for 50s before ROM is opened in emulator thread.

### Proposed changes
  - Rework Enhancement waits to remove sleep,
  - Fixed "deadlock" due to `WaitScanDone` method being called under `m_CS` guard.

### Does this make breaking changes?

No

### Does this version of Project64 compile and run without issue?

Yes