### PR TITLE
Fix wrong setting names in Project64.cfg for LogRomHeader and LogUnknown

### DIFF
--- a/Source/Project64-core/Settings.cpp
+++ b/Source/Project64-core/Settings.cpp
@@ -422,8 +422,8 @@ void CSettings::AddHowToHandleSetting(const char * BaseDirectory)
     AddHandler(Logging_LogExceptions, new CSettingTypeApplication("Logging", "Log Exceptions", false));
     AddHandler(Logging_NoInterrupts, new CSettingTypeApplication("Logging", "No Interrupts", false));
     AddHandler(Logging_LogCache, new CSettingTypeApplication("Logging", "Log Cache", false));
-    AddHandler(Logging_LogRomHeader, new CSettingTypeApplication("Logging", "Generate Log Files", false));
-    AddHandler(Logging_LogUnknown, new CSettingTypeApplication("Logging", "Log Rom Header", false));
+    AddHandler(Logging_LogRomHeader, new CSettingTypeApplication("Logging", "Log Rom Header", false));
+    AddHandler(Logging_LogUnknown, new CSettingTypeApplication("Logging", "Log Unknown", false));
 
     WriteTrace(TraceAppInit, TraceDebug, "Done");
 }


### PR DESCRIPTION
Fixes a bug where enabling/disabling "Include Read from Rom Header" in Log Options would instead enable/disable all logging, and makes the option "Include unkown Memory accesses" use the correct name in Project64.cfg.

### Proposed changes
  -Fix wrong setting names in Project64.cfg for LogRomHeader and LogUnknown

### Does this make breaking changes?
Small breaking change with existing Project64.cfg files: If the logging option "Include unkown Memory accesses" was enabled, after this change "Include Read from Rom Header" will be enabled instead, and "Include unkown Memory accesses" will be disabled.

### Does this version of Project64 compile and run without issue?
Yes.