### PR TITLE
CIC improvements

### DIFF
--- a/Source/Project64-core/N64System/MemoryHandler/PeripheralInterfaceHandler.cpp
+++ b/Source/Project64-core/N64System/MemoryHandler/PeripheralInterfaceHandler.cpp
@@ -189,7 +189,7 @@ void PeripheralInterfaceHandler::OnFirstDMA()
     case CIC_NUS_6101:
     case CIC_NUS_5167:
     case CIC_NUS_8303:
-    case CIC_NUS_DDUS:
+    case CIC_NUS_8501:
     case CIC_NUS_8401:
     case CIC_UNKNOWN:
     case CIC_NUS_6102:

--- a/Source/Project64-core/N64System/Mips/Register.cpp
+++ b/Source/Project64-core/N64System/Mips/Register.cpp
@@ -448,7 +448,7 @@ void CRegisters::Reset(bool bPostPif, CMipsMemoryVM & MMU)
             case CIC_NUS_6104:
             case CIC_NUS_5167:
             case CIC_NUS_8303:
-            case CIC_NUS_DDUS:
+            case CIC_NUS_8501:
             case CIC_NUS_8401:
             case CIC_NUS_5101:
             default:
@@ -471,7 +471,7 @@ void CRegisters::Reset(bool bPostPif, CMipsMemoryVM & MMU)
         case CIC_NUS_5167: // 64DD conversion CIC
             m_GPR[22].DW = 0x00000000000000DD;
             break;
-        case CIC_NUS_DDUS: // 64DD US IPL CIC
+        case CIC_NUS_8501: // 64DD US IPL CIC
             m_GPR[22].DW = 0x00000000000000DE;
             break;
         case CIC_NUS_5101: // Aleck64 CIC

--- a/Source/Project64-core/N64System/N64Rom.cpp
+++ b/Source/Project64-core/N64System/N64Rom.cpp
@@ -292,6 +292,9 @@ CICChip CN64Rom::GetCicChipID(uint8_t * RomData, uint64_t * CRC)
     {
     case 0x000000D0027FDF31: return CIC_NUS_6101;
     case 0x000000CFFB631223: return CIC_NUS_6101;
+    case 0x000000C34B2826B8: return CIC_NUS_6101; // iQue
+    case 0x0000002F35CF0DE9: return CIC_NUS_6101; // iQue (Paper Mario)
+    case 0x000000C92ADFE50A: return CIC_NUS_6101; // iQue (Sin and Punishment)
     case 0x000000D057C85244: return CIC_NUS_6102;
     case 0x000000D6497E414B: return CIC_NUS_6103;
     case 0x0000011A49F60E96: return CIC_NUS_6105;

--- a/Source/Project64-core/N64System/N64Rom.cpp
+++ b/Source/Project64-core/N64System/N64Rom.cpp
@@ -302,7 +302,7 @@ CICChip CN64Rom::GetCicChipID(uint8_t * RomData, uint64_t * CRC)
     case 0x000001053BC19870: return CIC_NUS_5167; // 64DD conversion CIC
     case 0x000000D2E53EF008: return CIC_NUS_8303; // 64DD IPL
     case 0x000000D2E53EF39F: return CIC_NUS_8401; // 64DD IPL tool
-    case 0x000000D2E53E5DDA: return CIC_NUS_DDUS; // 64DD IPL US (different CIC)
+    case 0x000000D2E53E5DDA: return CIC_NUS_8501; // 64DD IPL US (different CIC)
     case 0x0000000AF3A34BC8: return CIC_MINI_IPL3;
     case 0x0000007c56242373: return CIC_NUS_6102; // LibDragon IPL3
     default:
@@ -366,7 +366,7 @@ void CN64Rom::CalculateRomCrc()
     case CIC_NUS_6103: v0 = 0xA3886759; break;
     case CIC_NUS_6105: v0 = 0xDF26F436; break;
     case CIC_NUS_6106: v0 = 0x1FEA617A; break;
-    case CIC_NUS_DDUS:
+    case CIC_NUS_8501:
         length = 0x000A0000;
         v0 = 0x861AE3A7;
         break;
@@ -408,7 +408,7 @@ void CN64Rom::CalculateRomCrc()
 
         if (v1 < a3)
         {
-            if (m_CicChip == CIC_NUS_DDUS || m_CicChip == CIC_NUS_8303)
+            if (m_CicChip == CIC_NUS_8501 || m_CicChip == CIC_NUS_8303)
             {
                 t2 = t2 ^ t3;
             }
@@ -502,7 +502,7 @@ bool CN64Rom::IsLoadedRomDDIPL()
     switch (CicChipID())
     {
     case CIC_NUS_8303:
-    case CIC_NUS_DDUS:
+    case CIC_NUS_8501:
     case CIC_NUS_8401:
         return true;
     default:

--- a/Source/Project64-core/N64System/N64System.cpp
+++ b/Source/Project64-core/N64System/N64System.cpp
@@ -385,7 +385,7 @@ bool CN64System::LoadFileImage(const char * FileLoc)
             {
                 g_Settings->SaveString(File_DiskIPLPath, FileLoc);
             }
-            else if (g_DDRom->CicChipID() == CIC_NUS_DDUS)
+            else if (g_DDRom->CicChipID() == CIC_NUS_8501)
             {
                 g_Settings->SaveString(File_DiskIPLUSAPath, FileLoc);
             }
@@ -460,7 +460,7 @@ bool CN64System::LoadFileImageIPL(const char * FileLoc)
 
         if (g_DDRom->CicChipID() == CIC_NUS_8303)
             g_Settings->SaveString(File_DiskIPLPath, FileLoc);
-        else if (g_DDRom->CicChipID() == CIC_NUS_DDUS)
+        else if (g_DDRom->CicChipID() == CIC_NUS_8501)
             g_Settings->SaveString(File_DiskIPLUSAPath, FileLoc);
         else if (g_DDRom->CicChipID() == CIC_NUS_8401)
             g_Settings->SaveString(File_DiskIPLTOOLPath, FileLoc);
@@ -553,7 +553,7 @@ bool CN64System::RunFileImage(const char * FileLoc)
         {
             g_Settings->SaveString(File_DiskIPLPath, FileLoc);
         }
-        else if (g_Rom->CicChipID() == CIC_NUS_DDUS)
+        else if (g_Rom->CicChipID() == CIC_NUS_8501)
         {
             g_Settings->SaveString(File_DiskIPLUSAPath, FileLoc);
         }

--- a/Source/Project64-core/N64System/N64Types.h
+++ b/Source/Project64-core/N64System/N64Types.h
@@ -92,7 +92,7 @@ enum CICChip
     CIC_NUS_6106 = 6,
     CIC_NUS_5167 = 7,
     CIC_NUS_8303 = 8,
-    CIC_NUS_DDUS = 9,
+    CIC_NUS_8501 = 9,
     CIC_NUS_8401 = 10,
     CIC_NUS_5101 = 11,
     CIC_MINI_IPL3 = 12,

--- a/Source/Project64-core/RomList/RomList.cpp
+++ b/Source/Project64-core/RomList/RomList.cpp
@@ -544,7 +544,7 @@ bool CRomList::FillRomInfo(ROM_INFO * pRomInfo)
             pRomInfo->CRC1 = *(uint32_t *)(RomData + 0x10);
             pRomInfo->CRC2 = *(uint32_t *)(RomData + 0x14);
             pRomInfo->CicChip = CN64Rom::GetCicChipID(RomData);
-            if (pRomInfo->CicChip == CIC_NUS_8303 || pRomInfo->CicChip == CIC_NUS_DDUS || pRomInfo->CicChip == CIC_NUS_8401)
+            if (pRomInfo->CicChip == CIC_NUS_8303 || pRomInfo->CicChip == CIC_NUS_8501 || pRomInfo->CicChip == CIC_NUS_8401)
             {
                 pRomInfo->CRC1 = (*(uint16_t *)(RomData + 0x608) << 16) | *(uint16_t *)(RomData + 0x60C);
                 pRomInfo->CRC2 = (*(uint16_t *)(RomData + 0x638) << 16) | *(uint16_t *)(RomData + 0x63C);

--- a/Source/Project64/UserInterface/RomBrowser.cpp
+++ b/Source/Project64/UserInterface/RomBrowser.cpp
@@ -807,9 +807,9 @@ void CRomBrowser::RomList_GetDispInfo(LPARAM pnmh)
         {
             swprintf(lpdi->item.pszText, lpdi->item.cchTextMax / sizeof(wchar_t), L"CIC-NUS-5167");
         }
-        else if (pRomInfo->CicChip == CIC_NUS_DDUS)
+        else if (pRomInfo->CicChip == CIC_NUS_8501)
         {
-            swprintf(lpdi->item.pszText, lpdi->item.cchTextMax / sizeof(wchar_t), L"CIC-NUS-????");
+            swprintf(lpdi->item.pszText, lpdi->item.cchTextMax / sizeof(wchar_t), L"CIC-NUS-8501");
         }
         else if (pRomInfo->CicChip == CIC_NUS_8401)
         {

--- a/Source/Project64/UserInterface/RomInformation.cpp
+++ b/Source/Project64/UserInterface/RomInformation.cpp
@@ -143,7 +143,7 @@ DWORD CALLBACK RomInfoProc(HWND hDlg, DWORD uMsg, WPARAM wParam, LPARAM lParam)
             switch (_this->m_pRomInfo->CicChipID())
             {
             case CIC_NUS_8303:
-            case CIC_NUS_DDUS:
+            case CIC_NUS_8501:
             case CIC_NUS_8401:
                 SetDlgItemText(hDlg, IDC_INFO_CRC1, stdstr_f("0x%08X", (*(uint16_t *)(RomHeader + 0x608) << 16) | *(uint16_t *)(RomHeader + 0x60C)).ToUTF16().c_str());
                 SetDlgItemText(hDlg, IDC_INFO_CRC2, stdstr_f("0x%08X", (*(uint16_t *)(RomHeader + 0x638) << 16) | *(uint16_t *)(RomHeader + 0x63C)).ToUTF16().c_str());
@@ -161,7 +161,7 @@ DWORD CALLBACK RomInfoProc(HWND hDlg, DWORD uMsg, WPARAM wParam, LPARAM lParam)
             case CIC_NUS_8303: CicChip = L"CIC-NUS-8303"; break;
             case CIC_NUS_5167: CicChip = L"CIC-NUS-5167"; break;
             case CIC_NUS_5101: CicChip = L"CIC-NUS-5101"; break;
-            case CIC_NUS_DDUS: CicChip = L"CIC-NUS-????"; break;
+            case CIC_NUS_8501: CicChip = L"CIC-NUS-8501"; break;
             case CIC_NUS_8401: CicChip = L"CIC-NUS-8401"; break;
             default: CicChip = stdstr_f("CIC-NUS-610%d", _this->m_pRomInfo->CicChipID()).ToUTF16(); break;
             }
@@ -230,7 +230,7 @@ DWORD CALLBACK RomInfoProc(HWND hDlg, DWORD uMsg, WPARAM wParam, LPARAM lParam)
             case CIC_UNKNOWN: CicChip = L"Unknown"; break;
             case CIC_NUS_8303: CicChip = L"CIC-NUS-8303"; break;
             case CIC_NUS_5167: CicChip = L"CIC-NUS-5167"; break;
-            case CIC_NUS_DDUS: CicChip = L"CIC-NUS-????"; break;
+            case CIC_NUS_8501: CicChip = L"CIC-NUS-8501"; break;
             default: CicChip = stdstr_f("CIC-NUS-610%d", _this->m_pRomInfo->CicChipID()).ToUTF16(); break;
             }
             SetDlgItemText(hDlg, IDC_INFO_CIC, CicChip.c_str());


### PR DESCRIPTION
This PR adds the CIC CRCs for iQue Player games, allowing them to be properly recognized, and gives CIC-NUS-DDUS its proper name, which is CIC-NUS-8501.

### Proposed changes
  -Add CIC CRCs for iQue Player games
  -Give proper name to 64DD IPL US CIC

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Yes.