### PR TITLE
Various Widescreen Enhancement Codes

### DIFF
--- a/Config/Enhancements/Banjo-Kazooie (U) (V1.0).enh
+++ b/Config/Enhancements/Banjo-Kazooie (U) (V1.0).enh
@@ -464,6 +464,12 @@ D3371E60 0000
 81375658 3FC6
 8137565C 40B3
 
+$Ultra Widescreen
+Note=For 21:9 aspect ratios. Do not use with other widescreen enhancements.
+81277A0C 4334
+81277A10 4334
+81275D24 4019
+
 $Widescreen
 81277A0C 4334
 81277A10 4334

--- a/Config/Enhancements/Banjo-Kazooie (U) (V1.0).enh
+++ b/Config/Enhancements/Banjo-Kazooie (U) (V1.0).enh
@@ -1,6 +1,18 @@
 [A4BF9306-BF0CDFD1-C:45]
 Name=Banjo-Kazooie (U) (V1.0)
 
+$16:9 Widescreen
+Note=For 16:9 aspect ratios. Do not use with other widescreen enhancements or hacks.
+81277A0C 4334
+81277A10 4334
+81275D24 3FE6
+
+$21:9 Widescreen
+Note=For 21:9 aspect ratios. Do not use with other widescreen enhancements or hacks.
+81277A0C 4334
+81277A10 4334
+81275D24 4019
+
 $Better Special Fix pt1
 D3371E60 0000
 81326930 0811
@@ -463,14 +475,3 @@ D3371E60 0000
 81375654 4049
 81375658 3FC6
 8137565C 40B3
-
-$Ultra Widescreen
-Note=For 21:9 aspect ratios. Do not use with other widescreen enhancements.
-81277A0C 4334
-81277A10 4334
-81275D24 4019
-
-$Widescreen
-81277A0C 4334
-81277A10 4334
-81275D24 3FE6

--- a/Config/Enhancements/Banjo-Kazooie (U) (V1.1).enh
+++ b/Config/Enhancements/Banjo-Kazooie (U) (V1.1).enh
@@ -1,13 +1,14 @@
 [CD7559AC-B26CF5AE-C:45]
 Name=Banjo-Kazooie (U) (V1.1)
 
-$Ultra Widescreen
-Note=For 21:9 aspect ratios. Do not use with other widescreen enhancements.
-8127683C 4334
-81276840 4334
-81274B74 4019
-
-$Widescreen
+$16:9 Widescreen
+Note=For 16:9 aspect ratios. Do not use with other widescreen enhancements or hacks.
 8127683C 4334
 81276840 4334
 81274B74 3FE6
+
+$21:9 Widescreen
+Note=For 21:9 aspect ratios. Do not use with other widescreen enhancements or hacks.
+8127683C 4334
+81276840 4334
+81274B74 4019

--- a/Config/Enhancements/Banjo-Kazooie (U) (V1.1).enh
+++ b/Config/Enhancements/Banjo-Kazooie (U) (V1.1).enh
@@ -1,6 +1,12 @@
 [CD7559AC-B26CF5AE-C:45]
 Name=Banjo-Kazooie (U) (V1.1)
 
+$Ultra Widescreen
+Note=For 21:9 aspect ratios. Do not use with other widescreen enhancements.
+8127683C 4334
+81276840 4334
+81274B74 4019
+
 $Widescreen
 8127683C 4334
 81276840 4334

--- a/Config/Enhancements/Diddy Kong Racing (U) (M2) (V1.1).enh
+++ b/Config/Enhancements/Diddy Kong Racing (U) (M2) (V1.1).enh
@@ -1,6 +1,22 @@
 [E402430D-D2FCFC9D-C:45]
 Name=Diddy Kong Racing (U) (M2) (V1.1)
 
+$16:9 Widescreen
+Note=For 16:9 aspect ratios. Do not use with other widescreen enhancements or hacks.
+81066246 3FE3
+81066396 3FE3
+810663FE 3FE3
+8107037A 3740
+81126714 3FE3
+
+$21:9 Widescreen
+Note=For 21:9 aspect ratios. Do not use with other widescreen enhancements or hacks.
+81066246 4018
+81066396 4018
+810663FE 4018
+8107037A 370F
+81126714 4018
+
 $Alt Sixty Frames
 Note=A friend informed me this didn't freeze
 80079E7A 0003
@@ -8,10 +24,3 @@ Note=A friend informed me this didn't freeze
 $Sixty Frames
 Note=May freeze at some points,physics can get wonky with slopes on both codes.
 80079E7B 0003
-
-$Widescreen
-81066246 3FE3
-81066396 3FE3
-810663FE 3FE3
-8107037A 3740
-81126714 3FE3

--- a/Config/Enhancements/Mario Kart 64 (U).enh
+++ b/Config/Enhancements/Mario Kart 64 (U).enh
@@ -1,6 +1,28 @@
 [3E5055B6-2E92DA52-C:45]
 Name=Mario Kart 64 (U)
 
+$16:9 Widescreen
+Note=For 16:9 aspect ratios. Do not use with other widescreen enhancements or hacks.
+81150146 8E39
+81150148 3FE3
+D10DC532 0001
+81150148 4063
+D10DC532 0002
+81150148 3F63
+810946BA 3FE3
+810947EE 3FE3
+
+$21:9 Widescreen
+Note=For 21:9 aspect ratios. Do not use with other widescreen enhancements or hacks.
+81150146 E38E
+81150148 4018
+D10DC532 0001
+81150148 4098
+D10DC532 0002
+81150148 3F98
+810946BA 4018
+810947EE 4018
+
 $Multiplayer timing fix
 OnByDefault=1
 81001A38 2409

--- a/Config/Enhancements/Super Mario 64 (U).enh
+++ b/Config/Enhancements/Super Mario 64 (U).enh
@@ -1,9 +1,16 @@
 [635A2BFF-8B022326-C:45]
 Good Name=Super Mario 64 (U)
 
-$Widescreen
-Note=Menu Misalignments
+$16:9 Widescreen
+Note=Menu Misalignments. For 16:9 aspect ratios. Do not use with other widescreen enhancements or hacks.
 81325034 3C07
 81325036 3FE3
+8127D6A0 1000
+8127D6D4 1000
+
+$21:9 Widescreen
+Note=Menu Misalignments. For 21:9 aspect ratios. Do not use with other widescreen enhancements or hacks.
+81325034 3C07
+81325036 4018
 8127D6A0 1000
 8127D6D4 1000


### PR DESCRIPTION
Simple modification of the existing 16:9 code to work for 21:9 aspect ratios.

Screenshots for comparison. It's very hard to capture the exact same angle but this should be good enough.
![GLideN64_Banjo-Kazooie_004](https://github.com/user-attachments/assets/0e5591ff-2025-4b74-b55e-f7b7dcbd0466)
![GLideN64_Banjo-Kazooie_001](https://github.com/user-attachments/assets/d8818bcc-d669-41b0-81c8-30d57fbe869b)

Fixes #
None

### Proposed changes
  - Adding this GameShark code.

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
N/A
