### PR TITLE
Remove unused cheat context menu entries

### DIFF
--- a/Source/Project64/UserInterface/CheatUI.cpp
+++ b/Source/Project64/UserInterface/CheatUI.cpp
@@ -346,9 +346,7 @@ LRESULT CCheatList::OnTreeRClicked(NMHDR * lpnmh)
 
     GetCursorPos(&Mouse);
 
-    MenuSetText(hPopupMenu, 0, wGS(CHEAT_ADDNEW).c_str(), nullptr);
-    MenuSetText(hPopupMenu, 1, wGS(CHEAT_EDIT).c_str(), nullptr);
-    MenuSetText(hPopupMenu, 3, wGS(CHEAT_DELETE).c_str(), nullptr);
+    MenuSetText(hPopupMenu, 0, wGS(CHEAT_DELETE).c_str(), nullptr);
 
     if (m_hSelectedItem != nullptr && m_hCheatTree.GetChildItem(m_hSelectedItem) == nullptr)
     {

--- a/Source/Project64/UserInterface/UIResources.rc
+++ b/Source/Project64/UserInterface/UIResources.rc
@@ -1962,9 +1962,6 @@ IDR_CHEAT_MENU MENU
 BEGIN
     POPUP "Popup"
     BEGIN
-        MENUITEM "Add New Cheat...",            ID_POPUP_ADDNEWCHEAT
-        MENUITEM "Edit",                        ID_POPUP_EDIT
-        MENUITEM SEPARATOR
         MENUITEM "Delete",                      ID_POPUP_DELETE
     END
 END


### PR DESCRIPTION
Remove unused entries "Add New Cheat..." and "Edit" from the context menu in the Cheats dialog, which are leftovers from version 1.6 and have been nonfunctional since version 1.7.

### Proposed changes
  -Remove unused cheat context menu entries

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Yes.