### PR TITLE
Fix: NRage plugin gets stuck in initialization in certain cases

### DIFF
--- a/Source/nragev20/XInputController.cpp
+++ b/Source/nragev20/XInputController.cpp
@@ -105,10 +105,10 @@ BOOL IsXInputDevice( const GUID* pGuidProductFromDirectInput )
                         // If it does, then get the VID/PID from var.bstrVal
                         DWORD dwPid = 0, dwVid = 0;
                         WCHAR* strVid = wcsstr( var.bstrVal, L"VID_" );
-                        if (strVid && wscanf(strVid, L"VID_%4X", &dwVid) != 1)
+                        if (strVid && swscanf(strVid, L"VID_%4X", &dwVid) != 1)
                             dwVid = 0;
                         WCHAR* strPid = wcsstr( var.bstrVal, L"PID_" );
-                        if (strPid && wscanf(strPid, L"PID_%4X", &dwPid) != 1)
+                        if (strPid && swscanf(strPid, L"PID_%4X", &dwPid) != 1)
                             dwPid = 0;
 
                         // Compare the VID/PID to the DInput device

--- a/Source/nragev20/XInputController.cpp
+++ b/Source/nragev20/XInputController.cpp
@@ -388,8 +388,7 @@ TCHAR * GetN64ButtonNameFromButtonCode( int Button )
 {
     using namespace N64_BUTTONS;
 
-    TCHAR *btnName;
-    btnName = new TCHAR[10];
+    static TCHAR btnName[10];
 
     switch( Button )
     {
@@ -444,10 +443,9 @@ TCHAR * GetN64ButtonArrayFromXAnalog( LPXCONTROLLER gController, int XThStickOrX
     using namespace N64_BUTTONS;
 
     if( !gController || !gController->bConfigured )
-        return NULL;
+        return _T("");
 
-    TCHAR *name;
-    name = new TCHAR[15];
+    static TCHAR name[15];
 
     switch( XThStickOrXDpad )
     {


### PR DESCRIPTION
The function wscanf was incorrectly used to parse VID_ and PID_ values from a string, causing failures in device detection. wscanf expects input from stdin, whereas in this case, the device ID string is stored in memory.

Using swscanf ensures correct parsing from memory instead of waiting for stdin

This fixes the issue where XInput devices not being detected properly at plugin init.

### Proposed changes
Replace wscanf with swscanf to correctly extract the vendor and product IDs from the device ID string.

### Does this make breaking changes?
No

### Does this version of Project64 compile and run without issue?
Yes
