### PR TITLE
Clean up Windows Start Menu entry

### DIFF
--- a/Source/Installer/Installer.iss
+++ b/Source/Installer/Installer.iss
@@ -54,9 +54,7 @@ Name: "{app}\Plugin\GFX\GLideN64"; Permissions: everyone-full
 
 [Icons]
 Name: "{commondesktop}\Project64"; Filename: "{app}\Project64.exe"; Tasks: desktopicon
-Name: "{commonprograms}\Project64 4.0\Project64"; Filename: "{app}\Project64.exe"
-Name: "{commonprograms}\Project64 4.0\Uninstall Project64 4.0"; Filename: "{uninstallexe}"; Parameters: "/LOG"; Flags: createonlyiffileexists
-Name: "{commonprograms}\Project64 4.0\Support"; Filename: "https://discord.gg/Cg3zquF"
+Name: "{commonprograms}\Project64"; Filename: "{app}\Project64.exe"
 
 [Tasks]
 Name: desktopicon; Description: "Create a &desktop icon"


### PR DESCRIPTION
Cleans up the Windows Start Menu entry for the Windows installer.

[Add description of the PR here]

Having an uninstall shortcut is obsolete and an unclean practice in Windows 10+, as one simply can right-click and uninstall. Mostly the same for support, Start Menu is not the right place for it and it can still be added under Apps and Features if needed. This change makes Project64 directly appear on the Start Menu, not requiring further clicks to expand a folder and making the appearance clean.


### Proposed changes
  - Removes uninstall and support shortcut
  - Creates Project64.lnk directly in the Start Menu, without any folders

### Does this make breaking changes?
None, other than leaving the old shortcuts behind when installing over the old version.

### Does this version of Project64 compile and run without issue?
Not compiled at this point, will be done if requested.

Thanks!