### PR TITLE
Fix bug portuguese brazilian language

### DIFF
--- a/Lang/Brazilian Portuguese.pj.Lang
+++ b/Lang/Brazilian Portuguese.pj.Lang
@@ -1,12 +1,12 @@
 // Meta information
 #1  #  "Português (Brasil)"		// Language ID
-#2  #  "Marcos Spíndula, Felipe e Darkaiser"   // Author
-#3  #  "3.01"			            // Version
+#2  #  "Marcos Spíndula, Felipe e Darkaiser"			// Author
+#3  #  "3.01"			// Version
 #4  #  "08 de julho de 2023"		// Date
 
 /*** Menu ***/
 
-//File menu
+// File menu
 #100#  "&Arquivo"
 #101#  "&Abrir ROM"
 #102#  "Informação &da ROM...."
@@ -19,7 +19,7 @@
 #109#  "S&air"
 #110#  "Abrir &combinação"
 
-//System menu
+// System menu
 #120#  "&Sistema"
 #121#  "&Reiniciar"
 #122#  "&Pausar"


### PR DESCRIPTION
This fixes the bug that prevents this language from being displayed for selection in the emulator.

This fixes this issue #2461

Before
![bug](https://github.com/user-attachments/assets/a0a21aea-33e7-457f-a0e3-f8fe8389ea03)

With this fix
![fix](https://github.com/user-attachments/assets/2e6b6fdb-d3d6-4b7d-8058-1823158459bd)

Working
![working](https://github.com/user-attachments/assets/949996df-8c63-4912-b3c6-136f7e4c579d)


