### PR TITLE
Core: Fixed recompiler memory overrun for m_TestTimer

### DIFF
--- a/Source/Project64-core/N64System/Recompiler/x86/x86RecompilerOps.cpp
+++ b/Source/Project64-core/N64System/Recompiler/x86/x86RecompilerOps.cpp
@@ -9609,7 +9609,7 @@ void CX86RecompilerOps::OverflowDelaySlot(bool TestTimer)
 
     if (TestTimer)
     {
-        m_Assembler.MoveConstToVariable(&g_System->m_TestTimer, "R4300iOp::m_TestTimer", TestTimer);
+        m_Assembler.MoveConstByteToVariable(&g_System->m_TestTimer, "R4300iOp::m_TestTimer", TestTimer);
     }
 
     m_Assembler.PushImm32("g_System->CountPerOp()", g_System->CountPerOp());


### PR DESCRIPTION
This PR fixes memory overrun for m_TestTimer which is "bool" writing over 3 bytes past the variable. It is not a big issue in 4.x because of alignment but in 3.0.1 it causes random crashes due to it being global.

### Proposed changes
Fixes overrun for m_TestTimer in recompiler

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Yes, tested on my repro, no issues found.