### PR TITLE
Core: Fixed recompiler memory overrun for m_TestTimer

### DIFF
--- a/Source/Project64-core/N64System/Recompiler/x86/x86RecompilerOps.cpp
+++ b/Source/Project64-core/N64System/Recompiler/x86/x86RecompilerOps.cpp
@@ -10202,7 +10202,7 @@ void CX86RecompilerOps::OverflowDelaySlot(bool TestTimer)
 
     if (TestTimer)
     {
-        MoveConstToVariable(TestTimer, &R4300iOp::m_TestTimer, "R4300iOp::m_TestTimer");
+        MoveConstByteToVariable(TestTimer, &R4300iOp::m_TestTimer, "R4300iOp::m_TestTimer");
     }
 
     PushImm32("g_System->CountPerOp()", g_System->CountPerOp());


### PR DESCRIPTION
This PR fixes memory overrun for m_TestTimer which is "bool" writing over 3 bytes past the variable. This overrun causes 3 bytes past the global variable to be scrambled leading to random crashes if compiler decides to place anything important after m_TestTimer

### Proposed changes
Fixes overrun for m_TestTimer in recompiler

### Does this make breaking changes?
No

### Does this version of Project64 compile and run without issue?
Yes