### PR TITLE
Fix some UI elements not being highlighted/greyed out when settings are changed

### DIFF
--- a/Source/Project64/UserInterface/Settings/SettingsPage-Defaults.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Defaults.cpp
@@ -26,7 +26,7 @@ CDefaultsOptionsPage::CDefaultsOptionsPage(HWND hParent, const RECT & rcDispay)
     ComboBox = AddModComboBox(GetDlgItem(IDC_RDRAM_SIZE_KNOWN), Default_RDRamSizeUnknown);
     if (ComboBox)
     {
-        ComboBox->SetTextField(GetDlgItem(IDC_MEMORY_SIZE_TEXT));
+        ComboBox->SetTextField(GetDlgItem(IDC_MEMORY_SIZE_KNOWN_TEXT));
         ComboBox->AddItem(wGS(RDRAM_4MB).c_str(), 0x400000);
         ComboBox->AddItem(wGS(RDRAM_8MB).c_str(), 0x800000);
     }
@@ -34,7 +34,7 @@ CDefaultsOptionsPage::CDefaultsOptionsPage(HWND hParent, const RECT & rcDispay)
     ComboBox = AddModComboBox(GetDlgItem(IDC_RDRAM_SIZE_UNKNOWN), Default_RDRamSizeKnown);
     if (ComboBox)
     {
-        ComboBox->SetTextField(GetDlgItem(IDC_MEMORY_SIZE_TEXT));
+        ComboBox->SetTextField(GetDlgItem(IDC_MEMORY_SIZE_UNKOWN_TEXT));
         ComboBox->AddItem(wGS(RDRAM_4MB).c_str(), 0x400000);
         ComboBox->AddItem(wGS(RDRAM_8MB).c_str(), 0x800000);
     }
@@ -67,7 +67,7 @@ CDefaultsOptionsPage::CDefaultsOptionsPage(HWND hParent, const RECT & rcDispay)
     ComboBox = AddModComboBox(GetDlgItem(IDC_DISKSEEKTIMING), Default_DiskSeekTiming);
     if (ComboBox)
     {
-        //ComboBox->SetTextField(GetDlgItem(IDC_COUNTFACT_TEXT));
+        ComboBox->SetTextField(GetDlgItem(IDC_DISKSEEKTIMING_TEXT));
         ComboBox->AddItem(wGS(ROM_DISK_SEEK_TIMING_TURBO).c_str(), DiskSeek_Turbo);
         ComboBox->AddItem(wGS(ROM_DISK_SEEK_TIMING_SLOW).c_str(), DiskSeek_Slow);
     }

--- a/Source/Project64/UserInterface/Settings/SettingsPage-DiskDrive.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-DiskDrive.cpp
@@ -23,6 +23,7 @@ CDiskDrivePage::CDiskDrivePage(HWND hParent, const RECT & rcDispay)
     ComboBox = AddModComboBox(GetDlgItem(IDC_DISKSAVETYPE), Setting_DiskSaveType);
     if (ComboBox)
     {
+        ComboBox->SetTextField(GetDlgItem(IDC_DISKSAVETYPE_TXT));
         ComboBox->AddItem(wGS(DISKSAVE_SHADOW).c_str(), SaveDisk_ShadowFile);
         ComboBox->AddItem(wGS(DISKSAVE_RAM).c_str(), SaveDisk_RAMFile);
     }

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Game-DiskDrive.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Game-DiskDrive.cpp
@@ -17,7 +17,7 @@ CGameDiskDrivePage::CGameDiskDrivePage(HWND hParent, const RECT & rcDispay)
     ComboBox = AddModComboBox(GetDlgItem(IDC_DISKSEEKTIMING2), Game_DiskSeekTiming);
     if (ComboBox)
     {
-        //ComboBox->SetTextField(GetDlgItem(IDC_MEMORY_SIZE_TEXT));
+        ComboBox->SetTextField(GetDlgItem(IDC_DISKSEEKTIMING_TEXT));
         ComboBox->AddItem(wGS(ROM_DISK_SEEK_TIMING_TURBO).c_str(), DiskSeek_Turbo);
         ComboBox->AddItem(wGS(ROM_DISK_SEEK_TIMING_SLOW).c_str(), DiskSeek_Slow);
     }

--- a/Source/Project64/UserInterface/Settings/SettingsPage-Game-Recompiler.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-Game-Recompiler.cpp
@@ -43,6 +43,7 @@ CGameRecompilePage::CGameRecompilePage(HWND hParent, const RECT & rcDispay)
     ComboBox = AddModComboBox(GetDlgItem(IDC_CPU_TYPE), Game_CpuType);
     if (ComboBox)
     {
+        ComboBox->SetTextField(GetDlgItem(IDC_CPU_TYPE_TEXT));
         ComboBox->AddItem(wGS(CORE_RECOMPILER).c_str(), CPU_Recompiler);
         ComboBox->AddItem(wGS(CORE_INTERPTER).c_str(), CPU_Interpreter);
         if (g_Settings->LoadBool(Debugger_Enabled))
@@ -54,6 +55,7 @@ CGameRecompilePage::CGameRecompilePage(HWND hParent, const RECT & rcDispay)
     ComboBox = AddModComboBox(GetDlgItem(IDC_FUNCFIND), Game_FuncLookupMode);
     if (ComboBox)
     {
+        ComboBox->SetTextField(GetDlgItem(IDC_FUNCFIND_TEXT));
         ComboBox->AddItem(wGS(FLM_PLOOKUP).c_str(), FuncFind_PhysicalLookup);
         ComboBox->AddItem(wGS(FLM_VLOOKUP).c_str(), FuncFind_VirtualLookup);
         //ComboBox->AddItem(wGS(FLM_CHANGEMEM).c_str(), FuncFind_ChangeMemory);

--- a/Source/Project64/UserInterface/Settings/SettingsPage-GameBrowser.cpp
+++ b/Source/Project64/UserInterface/Settings/SettingsPage-GameBrowser.cpp
@@ -87,6 +87,7 @@ void COptionsGameBrowserPage::FixCtrlState(void)
     ::EnableWindow(GetDlgItem(IDC_UP), bEnabled);
     ::EnableWindow(GetDlgItem(IDC_DOWN), bEnabled);
     ::EnableWindow(GetDlgItem(IDC_RECURSION), bEnabled);
+    ::EnableWindow(GetDlgItem(IDC_SHOW_FILE_EXTENSIONS), bEnabled);
 }
 
 void COptionsGameBrowserPage::AddFieldClicked(UINT /*Code*/, int /*id*/, HWND /*ctl*/)


### PR DESCRIPTION
Fixes some text labels not being highlighted when their respective setting is changed from its default value. Also fixes a checkbox in the ROM Browser tab not being greyed out when "Use ROM browser" is disabled.

### Does this make breaking changes?
No.

### Does this version of Project64 compile and run without issue?
Yes.