### PR TITLE
Fix x64 build error in RSP-Core

### DIFF
--- a/Source/Project64-rsp-core/Recompiler/RspAssembler.cpp
+++ b/Source/Project64-rsp-core/Recompiler/RspAssembler.cpp
@@ -1,7 +1,6 @@
 #if defined(__amd64__) || defined(_M_X64)
 
 #include "RspAssembler.h"
-#include <Common/StdString.h>
 #include <Project64-rsp-core/Settings/RspSettings.h>
 #include <Settings/Settings.h>
 

--- a/Source/Project64-rsp-core/Recompiler/RspAssembler.h
+++ b/Source/Project64-rsp-core/Recompiler/RspAssembler.h
@@ -1,6 +1,7 @@
 #pragma once
 #if defined(__amd64__) || defined(_M_X64)
 
+#include <Common/StdString.h>
 #include <Project64-rsp-core/Recompiler/asmjit.h>
 #include <map>
 


### PR DESCRIPTION
StdString.h needs to be included inside of RspAssembler.h

### Proposed changes
  - Fixed x64 build error in RSP-Core

### Does this make breaking changes? No


### Does this version of Project64 compile and run without issue? Yes
