### PR TITLE
make plugin manager fall through to globals properly

### DIFF
--- a/Source/Common/IniFile.cpp
+++ b/Source/Common/IniFile.cpp
@@ -400,7 +400,7 @@ bool CIniFileBase::MoveToSectionNameData(const char * lpSectionName, bool Change
             m_CurrentSection = lpSectionName;
             m_CurrentSectionFilePos = 0;
         }
-        m_File.Seek(m_lastSectionSearch, CFileBase::begin);
+        m_File.Seek(0, CFileBase::begin);
         bFoundSection = true;
     }
 


### PR DESCRIPTION
The old code would propogate the plugins defined by the last profile in the user rdb as currently loaded,

if that profile had a plugin that had no settings, it means the user could not open the corresponding settings interface for the globally selected plugins, as it would be greyed out based on the behaviors of that plugin bound to the profile.

[Add description of the PR here]

Fixes #
Plugin settings were unavailable for specific plugin groups if the last profile in the user rdb had selected a plugin that had no settings

### Does this version of Project64 compile and run without issue?

Untested, but the code flows correctly