### PR TITLE
Audio: Do not block emulation forever when no playback device is available

### DIFF
--- a/Source/Project64-audio/Driver/SoundBase.cpp
+++ b/Source/Project64-audio/Driver/SoundBase.cpp
@@ -19,7 +19,8 @@ SoundDriverBase::SoundDriverBase() :
     m_AI_DMASecondaryBytes(0),
     m_CurrentReadLoc(0),
     m_CurrentWriteLoc(0),
-    m_BufferRemaining(0)
+    m_BufferRemaining(0),
+    m_DeviceActive(false)
 {
     memset(&m_Buffer, 0, sizeof(m_Buffer));
 }
@@ -49,6 +50,13 @@ void SoundDriverBase::AI_LenChanged(uint8_t *start, uint32_t length)
     {
         while ((m_BufferRemaining) == m_MaxBufferSize)
         {
+            if (!m_DeviceActive)
+            {
+                // No playback device: nothing will ever drain the buffer, so
+                // consume it silently rather than block emulation forever
+                LoadAiBuffer(nullptr, m_BufferRemaining);
+                break;
+            }
             pjutil::Sleep(1);
         }
     }
@@ -86,9 +94,14 @@ void SoundDriverBase::AI_Startup()
     m_AI_DMAPrimaryBuffer = m_AI_DMASecondaryBuffer = nullptr;
     m_MaxBufferSize = MAX_SIZE;
     m_CurrentReadLoc = m_CurrentWriteLoc = m_BufferRemaining = 0;
-    if (Initialize())
+    m_DeviceActive = Initialize();
+    if (m_DeviceActive)
     {
         StartAudio();
+    }
+    else
+    {
+        WriteTrace(TraceAudioDriver, TraceWarning, "No audio device available, running silent");
     }
     WriteTrace(TraceAudioDriver, TraceDebug, "Start");
 }

--- a/Source/Project64-audio/Driver/SoundBase.h
+++ b/Source/Project64-audio/Driver/SoundBase.h
@@ -51,5 +51,6 @@ private:
     uint32_t m_BufferRemaining; // Buffer remaining
     uint32_t m_CurrentReadLoc;  // Currently playing buffer
     uint32_t m_CurrentWriteLoc; // Currently writing buffer
+    bool m_DeviceActive;        // False when no playback device could be opened
     uint8_t m_Buffer[MAX_SIZE]; // Emulated buffers
 };


### PR DESCRIPTION
On a PC with no active default audio endpoint (nothing plugged into the headphone jack, no HDMI/DisplayPort audio device present, Windows Audio service stopped, etc.), starting a ROM with the Project64 audio plugin hangs the emulation thread. The window shows "Emulation started", the screen stays black, and the process sits at 0% CPU forever.

Root cause:

1. `DirectSoundDriver::Initialize()` calls `DirectSoundCreate8`, which fails when there is no playback device, so `Initialize()` returns `false` and leaves `m_lpds == nullptr`.
2. `SoundDriverBase::AI_Startup()` therefore never calls `StartAudio()`, so no audio thread is created. (Even when `SetFrequency()` later calls `StartAudio()` unconditionally, `AudioThreadProc()` just waits for `m_lpdsbuf` to become non-null, which never happens because `SetSegmentSize()` skips `CreateSoundBuffer` when `m_lpds` is null.)
3. Nothing ever calls `LoadAiBuffer()`, so `m_BufferRemaining` only grows. Once it reaches `m_MaxBufferSize`, `SoundDriverBase::AI_LenChanged()` enters

   ```cpp
   while ((m_BufferRemaining) == m_MaxBufferSize)
   {
       pjutil::Sleep(1);
   }
   ```

   with nothing able to drain the buffer, and the emulation thread never returns from the AI DMA write.

Fixes #2296

Related but **not** addressed here: #2240 and #2425 (device removed *while* emulation is running). That goes through a different path (the DirectSound thread exits on `GetCurrentPosition` failure) and would need a separate change.

### Proposed changes
  - Add a `m_DeviceActive` flag to `SoundDriverBase`, set from the result of `Initialize()` in `AI_Startup()`.
  - In `AI_LenChanged()`, when no device is active and the buffer is full, consume the buffer via `LoadAiBuffer(nullptr, m_BufferRemaining)` (the existing "return silence" path, which already accepts a null destination) instead of waiting. This keeps the AI DMA state machine and `MI_INTR_AI` interrupts advancing, so the game runs normally with no sound instead of hanging.
  - Log a `TraceWarning` when running with no device so the condition is visible in the audio trace.

The change is confined to `SoundDriverBase`, so it covers both the DirectSound and OpenSL ES drivers. Behaviour when a device *is* present is unchanged.

### Does this make breaking changes?

No. When a playback device is available the code path is identical to before.

### Does this version of Project64 compile and run without issue?

Yes.

- Built Release|Win32 with the VS 2019 Build Tools (`Project64-audio`, `/W4`, no new warnings) and the full solution with VS 2026 (v18) Community.
- Windows 11, headphones unplugged so Windows enumerates no active playback endpoint, GoldenEye 007 (U):
  - Unfixed `Project64-Audio.dll` built from `develop`: "Emulation started", black screen, 0% CPU indefinitely (the bug).
  - With this change: boots through the intro to the mission-select menu and runs normally with no sound.
- With an audio device present, playback is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)